### PR TITLE
Support time-to-idle policy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - stable
           - beta
-          # - 1.43.1  # MSRV
+          - 1.45.2  # MSRV
 
     steps:
       - name: Checkout Moka

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.43.1  # MSRV
+          # - 1.43.1  # MSRV
 
     steps:
       - name: Checkout Moka

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ exclude = [".devcontainer", ".github", ".vscode"]
 cht = "0.4"
 crossbeam-channel = "0.5"
 # hierarchical_hash_wheel_timer = "1.0"
-lazy_static = "1.4"
 num_cpus = "1.13"
+once_cell = "1.5"
 parking_lot = "0.11"
 scheduled-thread-pool = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crossbeam-channel = "0.5"
 num_cpus = "1.13"
 once_cell = "1.5"
 parking_lot = "0.11"
+quanta = { version = "0.7", path = "../moka-related/quanta" }
 scheduled-thread-pool = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ crossbeam-channel = "0.5"
 num_cpus = "1.13"
 once_cell = "1.5"
 parking_lot = "0.11"
-quanta = { version = "0.7", path = "../moka-related/quanta" }
+# quanta = { version = "0.7", path = "../moka-related/quanta" }
+quanta = "0.7"
 scheduled-thread-pool = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [".devcontainer", ".github", ".vscode"]
 
 [dependencies]
 cht = "0.4"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 # hierarchical_hash_wheel_timer = "1.0"
 lazy_static = "1.4"
 num_cpus = "1.13"
-parking_lot = "0.10"
+parking_lot = "0.11"
 scheduled-thread-pool = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # Moka
 
-[![GitHub Actions](https://github.com/moka-rs/moka/workflows/CI/badge.svg)][gh-actions]
+[![GitHub Actions][gh-actions-badge]][gh-actions]
+[![crates.io release][release-badge]][crate]
+[![docs][docs-badge]][docs]
+[![dependency status][deps-rs-badge]][deps-rs]
+[![license][license-badge]](#license)
+
+[gh-actions-badge]: https://github.com/moka-rs/moka/workflows/CI/badge.svg
+[release-badge]: https://img.shields.io/crates/v/moka.svg
+[docs-badge]: https://docs.rs/moka/badge.svg
+[deps-rs-badge]: https://deps.rs/repo/github/moka-rs/moka/status.svg
+[license-badge]: https://img.shields.io/crates/l/moka.svg
 
 [gh-actions]: https://github.com/moka-rs/moka/actions?query=workflow%3ACI
+[crate]: https://crates.io/crates/moka
+[docs]: https://docs.rs/moka
+[deps-rs]: https://deps.rs/repo/github/moka-rs/moka
+
 
 **Work in Progress**
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ features are not implemented and the API will change very often.
 
 ## Requirements
 
-- Rust 1.43.1 or newer.
+- Rust 1.45.2 or newer.
 
 <!--
+- quanta requires 1.45.
 - aHash 0.5 requires 1.43.
 - cht requires 1.41.
 -->

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -29,7 +29,7 @@ where
         }
     }
 
-    pub fn segment(self, num_segments: usize) -> Builder<SegmentedCache<K, V, RandomState>> {
+    pub fn segments(self, num_segments: usize) -> Builder<SegmentedCache<K, V, RandomState>> {
         Builder {
             capacity: self.capacity,
             num_segments: Some(num_segments),
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn build_segmented_cache() {
         // SegmentCache<char, String>
-        let cache = Builder::new(100).segment(16).build();
+        let cache = Builder::new(100).segments(16).build();
 
         assert_eq!(cache.capacity(), 100);
         assert_eq!(cache.time_to_live(), None);
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(cache.get(&'b'), Some(Arc::new("Bob")));
 
         let cache = Builder::new(100)
-            .segment(16)
+            .segments(16)
             .time_to_live(Duration::from_secs(45 * 60))
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,175 @@
+use crate::{Cache, SegmentedCache};
+
+use std::{
+    collections::hash_map::RandomState,
+    hash::{BuildHasher, Hash},
+    marker::PhantomData,
+    time::Duration,
+};
+
+pub struct Builder<C, S = RandomState> {
+    capacity: usize,
+    num_segments: Option<usize>,
+    time_to_live: Option<Duration>,
+    time_to_idle: Option<Duration>,
+    cache_type: PhantomData<C>,
+    build_hasher_type: PhantomData<S>,
+}
+
+impl<K, V, S> Builder<Cache<K, V, S>>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Clone,
+{
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            num_segments: None,
+            time_to_live: None,
+            time_to_idle: None,
+            cache_type: PhantomData::default(),
+            build_hasher_type: PhantomData::default(),
+        }
+    }
+
+    pub fn segment(self, num_segments: usize) -> Builder<SegmentedCache<K, V, S>> {
+        Builder {
+            capacity: self.capacity,
+            num_segments: Some(num_segments),
+            time_to_live: self.time_to_live,
+            time_to_idle: self.time_to_idle,
+            cache_type: PhantomData::default(),
+            build_hasher_type: PhantomData::default(),
+        }
+    }
+
+    pub fn build_with_hasher(self, hasher: S) -> Cache<K, V, S> {
+        Cache::with_everything(self.capacity, hasher, self.time_to_live, self.time_to_idle)
+    }
+}
+
+impl<K, V> Builder<Cache<K, V, RandomState>>
+where
+    K: Eq + Hash,
+{
+    pub fn build(self) -> Cache<K, V, RandomState> {
+        let build_hasher = RandomState::default();
+        Cache::with_everything(
+            self.capacity,
+            build_hasher,
+            self.time_to_live,
+            self.time_to_idle,
+        )
+    }
+}
+
+impl<K, V, S> Builder<SegmentedCache<K, V, S>>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Clone,
+{
+    pub fn build_with_hasher(self, hasher: S) -> SegmentedCache<K, V, S> {
+        SegmentedCache::with_everything(
+            self.capacity,
+            self.num_segments.unwrap(),
+            hasher,
+            self.time_to_live,
+            self.time_to_idle,
+        )
+    }
+}
+
+impl<K, V> Builder<SegmentedCache<K, V, RandomState>>
+where
+    K: Eq + Hash,
+{
+    pub fn build(self) -> SegmentedCache<K, V, RandomState> {
+        let build_hasher = RandomState::default();
+        SegmentedCache::with_everything(
+            self.capacity,
+            self.num_segments.unwrap(),
+            build_hasher,
+            self.time_to_live,
+            self.time_to_idle,
+        )
+    }
+}
+
+impl<C> Builder<C> {
+    pub fn time_to_live(self, duration: Duration) -> Self {
+        Self {
+            time_to_live: Some(duration),
+            ..self
+        }
+    }
+
+    pub fn time_to_idle(self, duration: Duration) -> Self {
+        Self {
+            time_to_idle: Some(duration),
+            ..self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Builder;
+    use crate::ConcurrentCache;
+
+    use std::{sync::Arc, time::Duration};
+
+    #[test]
+    fn build_cache() {
+        // Cache<char, String>
+        let cache = Builder::new(100).build();
+
+        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.time_to_live(), None);
+        assert_eq!(cache.time_to_idle(), None);
+        assert_eq!(cache.num_segments(), 1);
+
+        cache.insert('a', "Alice");
+        assert_eq!(cache.get(&'a'), Some(Arc::new("Alice")));
+
+        let cache = Builder::new(100)
+            .time_to_live(Duration::from_secs(45 * 60))
+            .time_to_idle(Duration::from_secs(15 * 60))
+            .build();
+
+        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(cache.num_segments(), 1);
+
+        cache.insert('a', "Alice");
+        assert_eq!(cache.get(&'a'), Some(Arc::new("Alice")));
+    }
+
+    #[test]
+    fn build_segmented_cache() {
+        // SegmentCache<char, String>
+        let cache = Builder::new(100).segment(16).build();
+
+        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.time_to_live(), None);
+        assert_eq!(cache.time_to_idle(), None);
+        assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
+
+        cache.insert('b', "Bob");
+        assert_eq!(cache.get(&'b'), Some(Arc::new("Bob")));
+
+        let cache = Builder::new(100)
+            .segment(16)
+            .time_to_live(Duration::from_secs(45 * 60))
+            .time_to_idle(Duration::from_secs(15 * 60))
+            .build();
+
+        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
+
+        cache.insert('b', "Bob");
+        assert_eq!(cache.get(&'b'), Some(Arc::new("Bob")));
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -595,7 +595,12 @@ where
         for _ in 0..count {
             match ch.try_recv() {
                 Ok(Insert(kh, entry)) => self.handle_insert(kh, entry, timestamp, deqs, &freq),
-                Ok(Update(entry)) => deqs.move_to_back(entry),
+                Ok(Update(entry)) => {
+                    if let Some(ts) = timestamp {
+                        unsafe { entry.set_last_accessed(ts) };
+                    }
+                    deqs.move_to_back(entry)
+                }
                 Ok(Remove(entry)) => deqs.unlink(entry),
                 Err(_) => break,
             };

--- a/src/frequency_sketch.rs
+++ b/src/frequency_sketch.rs
@@ -165,15 +165,14 @@ impl FrequencySketch {
 #[cfg(test)]
 mod tests {
     use super::FrequencySketch;
+    use once_cell::sync::Lazy;
     use std::hash::{BuildHasher, Hash, Hasher};
 
-    lazy_static::lazy_static! {
-        static ref ITEM: u32 = {
-            let mut buf = [0; 4];
-            getrandom::getrandom(&mut buf).unwrap();
-            unsafe { std::mem::transmute::<[u8; 4], u32>(buf) }
-        };
-    }
+    static ITEM: Lazy<u32> = Lazy::new(|| {
+        let mut buf = [0; 4];
+        getrandom::getrandom(&mut buf).unwrap();
+        unsafe { std::mem::transmute::<[u8; 4], u32>(buf) }
+    });
 
     // This test was ported from Caffeine.
     #[test]

--- a/src/frequency_sketch.rs
+++ b/src/frequency_sketch.rs
@@ -244,7 +244,7 @@ mod tests {
     // This test was ported from Caffeine.
     #[test]
     fn heavy_hitters() {
-        let mut sketch = FrequencySketch::with_capacity(1024);
+        let mut sketch = FrequencySketch::with_capacity(2048);
         let hasher = hasher();
 
         for i in 100..100_000 {

--- a/src/frequency_sketch.rs
+++ b/src/frequency_sketch.rs
@@ -244,7 +244,7 @@ mod tests {
     // This test was ported from Caffeine.
     #[test]
     fn heavy_hitters() {
-        let mut sketch = FrequencySketch::with_capacity(2048);
+        let mut sketch = FrequencySketch::with_capacity(65_536);
         let hasher = hasher();
 
         for i in 100..100_000 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,16 +122,18 @@
 //! [timer-wheel]: http://www.cs.columbia.edu/~nahum/w6998/papers/ton97-timing-wheels.pdf
 //!
 
+mod builder;
 mod cache;
 mod deque;
 mod frequency_sketch;
 mod segment;
 mod thread_pool;
 
+pub use builder::Builder;
 pub use cache::Cache;
 pub use segment::SegmentedCache;
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 // Interior mutability (no need for `&mut self`)
 pub trait ConcurrentCache<K, V> {
@@ -147,5 +149,15 @@ pub trait ConcurrentCache<K, V> {
 
     fn remove(&self, key: &K) -> Option<Arc<V>>;
 
+    fn capacity(&self) -> usize;
+
+    fn time_to_live(&self) -> Option<Duration>;
+
+    fn time_to_idle(&self) -> Option<Duration>;
+
+    fn num_segments(&self) -> usize;
+}
+
+pub trait ConcurrentCacheExt<K, V> {
     fn sync(&self);
 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,11 +1,13 @@
-use crate::{cache::Cache, ConcurrentCache};
+use crate::{cache::Cache, ConcurrentCache, ConcurrentCacheExt};
 
 use std::{
+    collections::hash_map::RandomState,
     hash::{BuildHasher, Hash, Hasher},
     sync::Arc,
+    time::Duration,
 };
 
-pub struct SegmentedCache<K, V, S> {
+pub struct SegmentedCache<K, V, S = RandomState> {
     inner: Arc<Inner<K, V, S>>,
 }
 
@@ -33,7 +35,7 @@ impl<K, V, S> Clone for SegmentedCache<K, V, S> {
     }
 }
 
-impl<K, V> SegmentedCache<K, V, std::collections::hash_map::RandomState>
+impl<K, V> SegmentedCache<K, V, RandomState>
 where
     K: Eq + Hash,
 {
@@ -46,8 +48,8 @@ where
     ///
     /// Panics if `num_segments` is 0.
     pub fn new(capacity: usize, num_segments: usize) -> Self {
-        let build_hasher = std::collections::hash_map::RandomState::default();
-        Self::with_hasher(capacity, num_segments, build_hasher)
+        let build_hasher = RandomState::default();
+        Self::with_everything(capacity, num_segments, build_hasher, None, None)
     }
 }
 
@@ -56,6 +58,10 @@ where
     K: Eq + Hash,
     S: BuildHasher + Clone,
 {
+    pub fn with_hasher(capacity: usize, num_segments: usize, build_hasher: S) -> Self {
+        Self::with_everything(capacity, num_segments, build_hasher, None, None)
+    }
+
     // TODO: Instead of taking the capacity as an argument, take the followings:
     // - initial_capacity of the cache (hashmap)
     // - max_capacity of the cache (hashmap)
@@ -64,9 +70,21 @@ where
     /// # Panics
     ///
     /// Panics if `num_segments` is 0.
-    pub fn with_hasher(capacity: usize, num_segments: usize, build_hasher: S) -> Self {
+    pub(crate) fn with_everything(
+        capacity: usize,
+        num_segments: usize,
+        build_hasher: S,
+        time_to_live: Option<Duration>,
+        time_to_idle: Option<Duration>,
+    ) -> Self {
         Self {
-            inner: Arc::new(Inner::new(capacity, num_segments, build_hasher)),
+            inner: Arc::new(Inner::new(
+                capacity,
+                num_segments,
+                build_hasher,
+                time_to_live,
+                time_to_idle,
+            )),
         }
     }
 
@@ -100,6 +118,28 @@ where
         self.inner.select(hash).remove(key)
     }
 
+    fn capacity(&self) -> usize {
+        self.inner.desired_capacity
+    }
+
+    fn time_to_live(&self) -> Option<Duration> {
+        self.inner.segments[0].time_to_live()
+    }
+
+    fn time_to_idle(&self) -> Option<Duration> {
+        self.inner.segments[0].time_to_idle()
+    }
+
+    fn num_segments(&self) -> usize {
+        self.inner.segments.len()
+    }
+}
+
+impl<K, V, S> ConcurrentCacheExt<K, V> for SegmentedCache<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Clone,
+{
     fn sync(&self) {
         for segment in self.inner.segments.iter() {
             segment.sync()
@@ -108,6 +148,7 @@ where
 }
 
 struct Inner<K, V, S> {
+    desired_capacity: usize,
     segments: Box<[Cache<K, V, S>]>,
     build_hasher: S,
     segment_shift: u32,
@@ -121,7 +162,13 @@ where
     /// # Panics
     ///
     /// Panics if `num_segments` is 0.
-    fn new(capacity: usize, num_segments: usize, build_hasher: S) -> Self {
+    fn new(
+        capacity: usize,
+        num_segments: usize,
+        build_hasher: S,
+        time_to_live: Option<Duration>,
+        time_to_idle: Option<Duration>,
+    ) -> Self {
         assert!(num_segments > 0);
 
         let actual_num_segments = num_segments.next_power_of_two();
@@ -131,10 +178,18 @@ where
         // NOTE: We cannot initialize the segments as `vec![cache; actual_num_segments]`
         // because Cache::clone() does not clone its inner but shares the same inner.
         let segments = (0..num_segments)
-            .map(|_| Cache::with_hasher(seg_capacity, build_hasher.clone()))
+            .map(|_| {
+                Cache::with_everything(
+                    seg_capacity,
+                    build_hasher.clone(),
+                    time_to_live,
+                    time_to_idle,
+                )
+            })
             .collect::<Vec<_>>();
 
         Self {
+            desired_capacity: capacity,
             segments: segments.into_boxed_slice(),
             build_hasher,
             segment_shift,
@@ -167,7 +222,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{ConcurrentCache, SegmentedCache};
+    use super::{ConcurrentCache, ConcurrentCacheExt, SegmentedCache};
     use std::sync::Arc;
 
     #[test]

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -142,7 +142,7 @@ where
 {
     fn sync(&self) {
         for segment in self.inner.segments.iter() {
-            segment.sync()
+            segment.sync();
         }
     }
 }

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use scheduled_thread_pool::ScheduledThreadPool;
 use std::{collections::HashMap, sync::Arc};
@@ -6,9 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 // TODO: Use enum. e.g. Pool::{Default, Name(String)}.
 const DEFAULT_POOL_NAME: &str = "$$default$$";
 
-lazy_static! {
-    static ref REGISTRY: ThreadPoolRegistry = ThreadPoolRegistry::default();
-}
+static REGISTRY: Lazy<ThreadPoolRegistry> = Lazy::new(ThreadPoolRegistry::default);
 
 pub(crate) struct ThreadPool {
     pub(crate) name: String,


### PR DESCRIPTION
- Implement time-to-idle policy.
- Introduce the cache builder.
- Add more methods to `ConcurrentCache` trait: `capacity()`, `time_to_live()`, `time_to_idle()` and `num_segments()`
- Move `sync()` method to a separate `ConcurrentCacheExt` trait.
- Replace lazy_static with once_cell.
- Bump the version to 0.1.0-alpha.3.
- Raise the minimum supported Rust version (MSRV) to 1.45.2 (because of quanta crate).
- Stabilized a unit test for the frequency sketch by increase the capacity of the sketch.