### PR TITLE
Support time-to-live policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.1.0-alpha.3"
+version = "0.1.0-beta.1"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,12 @@
+use parking_lot::Mutex;
 use quanta::Instant;
-use std::{cell::UnsafeCell, ptr::NonNull, sync::Arc};
+use std::{
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 pub(crate) mod deque;
 pub(crate) mod deques;
@@ -23,56 +30,90 @@ impl<K> KeyHash<K> {
 
 pub(crate) struct KeyDate<K> {
     pub(crate) key: Arc<K>,
-    // Optional. Instant(0u64) for None.
-    pub(crate) timestamp: Instant,
+    pub(crate) timestamp: Option<Arc<AtomicU64>>,
 }
 
 impl<K> KeyDate<K> {
-    pub(crate) fn new(key: Arc<K>, timestamp: Option<Instant>) -> Self {
-        Self {
-            key,
-            timestamp: timestamp.unwrap_or_else(|| unsafe { std::mem::transmute(0u64) }),
-        }
+    pub(crate) fn new(key: Arc<K>, timestamp: Option<Arc<AtomicU64>>) -> Self {
+        Self { key, timestamp }
     }
 }
 
 pub(crate) struct KeyHashDate<K> {
     pub(crate) key: Arc<K>,
     pub(crate) hash: u64,
-    // Optional. Instant(0u64) for None.
-    pub(crate) timestamp: Instant,
+    pub(crate) timestamp: Option<Arc<AtomicU64>>,
 }
 
 impl<K> KeyHashDate<K> {
-    pub(crate) fn new(kh: KeyHash<K>, timestamp: Option<Instant>) -> Self {
+    pub(crate) fn new(kh: KeyHash<K>, timestamp: Option<Arc<AtomicU64>>) -> Self {
         Self {
             key: kh.key,
             hash: kh.hash,
-            timestamp: timestamp.unwrap_or_else(|| unsafe { std::mem::transmute(0u64) }),
+            timestamp,
         }
     }
 }
 
-pub(crate) type KeyDeqNodeAO<K> = Option<NonNull<DeqNode<KeyHashDate<K>>>>;
-pub(crate) type KeyDeqNodeWO<K> = Option<NonNull<DeqNode<KeyDate<K>>>>;
+pub(crate) type KeyDeqNodeAO<K> = NonNull<DeqNode<KeyHashDate<K>>>;
+pub(crate) type KeyDeqNodeWO<K> = NonNull<DeqNode<KeyDate<K>>>;
 
 pub(crate) struct ValueEntry<K, V> {
     pub(crate) value: Arc<V>,
-    pub(crate) access_order_q_node: UnsafeCell<KeyDeqNodeAO<K>>,
-    pub(crate) write_order_q_node: UnsafeCell<KeyDeqNodeWO<K>>,
+    last_accessed: Option<Arc<AtomicU64>>,
+    last_modified: Option<Arc<AtomicU64>>,
+    access_order_q_node: Mutex<Option<KeyDeqNodeAO<K>>>,
+    write_order_q_node: Mutex<Option<KeyDeqNodeWO<K>>>,
 }
 
 impl<K, V> ValueEntry<K, V> {
     pub(crate) fn new(
         value: Arc<V>,
-        access_order_q_node: KeyDeqNodeAO<K>,
-        write_order_q_node: KeyDeqNodeWO<K>,
+        last_accessed: Option<Instant>,
+        last_modified: Option<Instant>,
+        access_order_q_node: Option<KeyDeqNodeAO<K>>,
+        write_order_q_node: Option<KeyDeqNodeWO<K>>,
     ) -> Self {
         Self {
             value,
-            access_order_q_node: UnsafeCell::new(access_order_q_node),
-            write_order_q_node: UnsafeCell::new(write_order_q_node),
+            last_accessed: last_accessed.map(|ts| Arc::new(AtomicU64::new(ts.as_u64()))),
+            last_modified: last_modified.map(|ts| Arc::new(AtomicU64::new(ts.as_u64()))),
+            access_order_q_node: Mutex::new(access_order_q_node),
+            write_order_q_node: Mutex::new(write_order_q_node),
         }
+    }
+
+    pub(crate) fn new_with(value: Arc<V>, other: &Self) -> Self {
+        Self {
+            value,
+            last_accessed: other.last_accessed.clone(),
+            last_modified: other.last_modified.clone(),
+            access_order_q_node: Mutex::new(*other.access_order_q_node().lock()),
+            write_order_q_node: Mutex::new(*other.write_order_q_node().lock()),
+        }
+    }
+
+    pub(crate) fn raw_last_accessed(&self) -> Option<Arc<AtomicU64>> {
+        self.last_accessed.clone()
+    }
+
+    pub(crate) fn raw_last_modified(&self) -> Option<Arc<AtomicU64>> {
+        self.last_modified.clone()
+    }
+
+    pub(crate) fn access_order_q_node(&self) -> &Mutex<Option<KeyDeqNodeAO<K>>> {
+        &self.access_order_q_node
+    }
+    pub(crate) fn set_access_order_q_node(&self, node: Option<KeyDeqNodeAO<K>>) {
+        *self.access_order_q_node.lock() = node;
+    }
+
+    pub(crate) fn write_order_q_node(&self) -> &Mutex<Option<KeyDeqNodeWO<K>>> {
+        &self.write_order_q_node
+    }
+
+    pub(crate) fn set_write_order_q_node(&self, node: Option<KeyDeqNodeWO<K>>) {
+        *self.write_order_q_node.lock() = node;
     }
 }
 
@@ -86,28 +127,43 @@ pub(crate) trait AccessTime {
 impl<K, V> AccessTime for Arc<ValueEntry<K, V>> {
     #[inline]
     fn last_accessed(&self) -> Option<Instant> {
-        unsafe { (*self.access_order_q_node.get()).map(|node| node.as_ref().element.timestamp) }
+        self.last_accessed
+            .as_ref()
+            .map(|ts| ts.load(Ordering::Relaxed))
+            .and_then(|ts| {
+                if ts == u64::MAX {
+                    None
+                } else {
+                    Some(unsafe { std::mem::transmute(ts) })
+                }
+            })
     }
 
     #[inline]
     fn set_last_accessed(&mut self, timestamp: Instant) {
-        unsafe {
-            if let Some(mut node) = *self.access_order_q_node.get() {
-                node.as_mut().element.timestamp = timestamp;
-            }
+        if let Some(ts) = &self.last_accessed {
+            ts.store(timestamp.as_u64(), Ordering::Relaxed);
         }
     }
 
     #[inline]
     fn last_modified(&self) -> Option<Instant> {
-        unsafe { (*self.write_order_q_node.get()).map(|node| node.as_ref().element.timestamp) }
+        self.last_modified
+            .as_ref()
+            .map(|ts| ts.load(Ordering::Relaxed))
+            .and_then(|ts| {
+                if ts == u64::MAX {
+                    None
+                } else {
+                    Some(unsafe { std::mem::transmute(ts) })
+                }
+            })
     }
 
+    #[inline]
     fn set_last_modified(&mut self, timestamp: Instant) {
-        unsafe {
-            if let Some(mut node) = *self.write_order_q_node.get() {
-                node.as_mut().element.timestamp = timestamp;
-            }
+        if let Some(ts) = &self.last_modified {
+            ts.store(timestamp.as_u64(), Ordering::Relaxed);
         }
     }
 }
@@ -119,28 +175,54 @@ impl<K> AccessTime for DeqNode<KeyDate<K>> {
     }
 
     #[inline]
-    fn set_last_accessed(&mut self, _timestamp: Instant) { /* do nothing */
+    fn set_last_accessed(&mut self, _timestamp: Instant) {
+        // do nothing
     }
 
     #[inline]
     fn last_modified(&self) -> Option<Instant> {
-        Some(self.element.timestamp)
+        self.element
+            .timestamp
+            .as_ref()
+            .map(|ts| ts.load(Ordering::Relaxed))
+            .and_then(|ts| {
+                if ts == u64::MAX {
+                    None
+                } else {
+                    Some(unsafe { std::mem::transmute(ts) })
+                }
+            })
     }
 
+    #[inline]
     fn set_last_modified(&mut self, timestamp: Instant) {
-        self.element.timestamp = timestamp;
+        if let Some(ts) = self.element.timestamp.as_ref() {
+            ts.store(timestamp.as_u64(), Ordering::Relaxed);
+        }
     }
 }
 
 impl<K> AccessTime for DeqNode<KeyHashDate<K>> {
     #[inline]
     fn last_accessed(&self) -> Option<Instant> {
-        Some(self.element.timestamp)
+        self.element
+            .timestamp
+            .as_ref()
+            .map(|ts| ts.load(Ordering::Relaxed))
+            .and_then(|ts| {
+                if ts == u64::MAX {
+                    None
+                } else {
+                    Some(unsafe { std::mem::transmute(ts) })
+                }
+            })
     }
 
     #[inline]
     fn set_last_accessed(&mut self, timestamp: Instant) {
-        self.element.timestamp = timestamp;
+        if let Some(ts) = self.element.timestamp.as_ref() {
+            ts.store(timestamp.as_u64(), Ordering::Relaxed);
+        }
     }
 
     #[inline]
@@ -149,7 +231,8 @@ impl<K> AccessTime for DeqNode<KeyHashDate<K>> {
     }
 
     #[inline]
-    fn set_last_modified(&mut self, _timestamp: Instant) { /* do nothing */
+    fn set_last_modified(&mut self, _timestamp: Instant) {
+        // do nothing
     }
 }
 

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -19,6 +19,7 @@ pub(crate) enum CacheRegion {
     Window,
     MainProbation,
     MainProtected,
+    WriteOrder,
 }
 
 #[derive(PartialEq, Eq)]
@@ -94,26 +95,6 @@ impl<T> Deque<T> {
         self.region == node.region && (node.prev.is_some() || self.is_head(node))
     }
 
-    /// Adds the given node to the front of the list.
-    // pub(crate) fn push_front(&mut self, mut node: Box<DeqNode<T>>) {
-    //     // This method takes care not to create mutable references to whole nodes,
-    //     // to maintain validity of aliasing pointers into `element`.
-    //     unsafe {
-    //         node.next = self.head;
-    //         node.prev = None;
-    //         let node = Some(NonNull::new(Box::into_raw(node)).expect("Got a null ptr"));
-
-    //         match self.head {
-    //             None => self.tail = node,
-    //             // Not creating new mutable (unique!) references overlapping `element`.
-    //             Some(head) => (*head.as_ptr()).prev = node,
-    //         }
-
-    //         self.head = node;
-    //         self.len += 1;
-    //     }
-    // }
-
     pub(crate) fn peek_front(&self) -> Option<&DeqNode<T>> {
         // This method takes care not to create mutable references to whole nodes,
         // to maintain validity of aliasing pointers into `element`.
@@ -125,7 +106,7 @@ impl<T> Deque<T> {
         // This method takes care not to create mutable references to whole nodes,
         // to maintain validity of aliasing pointers into `element`.
         self.head.map(|node| unsafe {
-            let node = Box::from_raw(node.as_ptr());
+            let mut node = Box::from_raw(node.as_ptr());
             self.head = node.next;
 
             match self.head {
@@ -135,6 +116,9 @@ impl<T> Deque<T> {
             }
 
             self.len -= 1;
+
+            node.prev = None;
+            node.next = None;
             node
         })
     }
@@ -166,25 +150,6 @@ impl<T> Deque<T> {
             node
         }
     }
-
-    /// Removes and returns the node at the back of the list.
-    // pub(crate) fn pop_back(&mut self) -> Option<Box<DeqNode<T>>> {
-    //     // This method takes care not to create mutable references to whole nodes,
-    //     // to maintain validity of aliasing pointers into `element`.
-    //     self.tail.map(|node| unsafe {
-    //         let node = Box::from_raw(node.as_ptr());
-    //         self.tail = node.prev;
-
-    //         match self.tail {
-    //             None => self.head = None,
-    //             // Not creating new mutable (unique!) references overlapping `element`.
-    //             Some(tail) => (*tail.as_ptr()).next = None,
-    //         }
-
-    //         self.len -= 1;
-    //         node
-    //     })
-    // }
 
     /// Panics:
     pub(crate) unsafe fn move_to_back(&mut self, mut node: NonNull<DeqNode<T>>) {

--- a/src/common/deques.rs
+++ b/src/common/deques.rs
@@ -1,14 +1,15 @@
 use super::{
     deque::{CacheRegion, DeqNode, Deque},
-    KeyHashDate, ValueEntry,
+    KeyDate, KeyHashDate, ValueEntry,
 };
 
-use std::{ptr::NonNull, sync::Arc};
+use std::{ptr::NonNull, sync::Arc, unreachable};
 
 pub(crate) struct Deques<K> {
     pub(crate) window: Deque<KeyHashDate<K>>, //    Not used yet.
     pub(crate) probation: Deque<KeyHashDate<K>>,
     pub(crate) protected: Deque<KeyHashDate<K>>, // Not used yet.
+    pub(crate) write_order: Deque<KeyDate<K>>,
 }
 
 impl<K> Default for Deques<K> {
@@ -17,12 +18,13 @@ impl<K> Default for Deques<K> {
             window: Deque::new(CacheRegion::Window),
             probation: Deque::new(CacheRegion::MainProbation),
             protected: Deque::new(CacheRegion::MainProtected),
+            write_order: Deque::new(CacheRegion::WriteOrder),
         }
     }
 }
 
 impl<K> Deques<K> {
-    pub(crate) fn push_back<V>(
+    pub(crate) fn push_back_ao<V>(
         &mut self,
         region: CacheRegion,
         kh: KeyHashDate<K>,
@@ -34,14 +36,21 @@ impl<K> Deques<K> {
             Window => self.window.push_back(node),
             MainProbation => self.probation.push_back(node),
             MainProtected => self.protected.push_back(node),
+            WriteOrder => unreachable!(),
         };
-        unsafe { *(entry.deq_node.get()) = Some(node) };
+        unsafe { *(entry.access_order_q_node.get()) = Some(node) };
     }
 
-    pub(crate) fn move_to_back<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+    pub(crate) fn push_back_wo<V>(&mut self, kh: KeyDate<K>, entry: &Arc<ValueEntry<K, V>>) {
+        let node = Box::new(DeqNode::new(CacheRegion::WriteOrder, kh));
+        let node = self.write_order.push_back(node);
+        unsafe { *(entry.write_order_q_node.get()) = Some(node) };
+    }
+
+    pub(crate) fn move_to_back_ao<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
         use CacheRegion::*;
         unsafe {
-            if let Some(node) = *entry.deq_node.get() {
+            if let Some(node) = *entry.access_order_q_node.get() {
                 let p = node.as_ref();
                 match &p.region {
                     Window if self.window.contains(p) => self.window.move_to_back(node),
@@ -51,7 +60,7 @@ impl<K> Deques<K> {
                     MainProtected if self.protected.contains(p) => {
                         self.protected.move_to_back(node)
                     }
-                    region => eprintln!(
+                    region => panic!(
                         "move_to_back - node is not a member of {:?} deque. {:?}",
                         region, p
                     ),
@@ -60,15 +69,41 @@ impl<K> Deques<K> {
         }
     }
 
-    pub(crate) fn unlink<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+    pub(crate) fn move_to_back_wo<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+        use CacheRegion::*;
         unsafe {
-            if let Some(node) = (*entry.deq_node.get()).take() {
-                self.unlink_node(node);
+            if let Some(node) = *entry.write_order_q_node.get() {
+                let p = node.as_ref();
+                debug_assert_eq!(&p.region, &WriteOrder);
+                if self.write_order.contains(p) {
+                    self.write_order.move_to_back(node);
+                } else {
+                    panic!(
+                        "move_to_back - node is not a member of write_order deque. {:?}",
+                        p
+                    )
+                }
             }
         }
     }
 
-    pub(crate) fn unlink_node(&mut self, node: NonNull<DeqNode<KeyHashDate<K>>>) {
+    pub(crate) fn unlink_ao<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+        unsafe {
+            if let Some(node) = (*entry.access_order_q_node.get()).take() {
+                self.unlink_node_ao(node);
+            }
+        }
+    }
+
+    pub(crate) fn unlink_wo<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+        unsafe {
+            if let Some(node) = (*entry.write_order_q_node.get()).take() {
+                self.unlink_node_wo(node);
+            }
+        }
+    }
+
+    pub(crate) fn unlink_node_ao(&mut self, node: NonNull<DeqNode<KeyHashDate<K>>>) {
         use CacheRegion::*;
         unsafe {
             let p = node.as_ref();
@@ -76,10 +111,26 @@ impl<K> Deques<K> {
                 Window if self.window.contains(p) => self.window.unlink(node),
                 MainProbation if self.probation.contains(p) => self.probation.unlink(node),
                 MainProtected if self.protected.contains(p) => self.protected.unlink(node),
-                region => eprintln!(
+                region => panic!(
                     "unlink_node - node is not a member of {:?} deque. {:?}",
                     region, p
                 ),
+            }
+        }
+    }
+
+    pub(crate) fn unlink_node_wo(&mut self, node: NonNull<DeqNode<KeyDate<K>>>) {
+        use CacheRegion::*;
+        unsafe {
+            let p = node.as_ref();
+            debug_assert_eq!(&p.region, &WriteOrder);
+            if self.write_order.contains(p) {
+                self.write_order.unlink(node);
+            } else {
+                panic!(
+                    "unlink_node - node is not a member of write_order deque. {:?}",
+                    p
+                )
             }
         }
     }

--- a/src/common/deques.rs
+++ b/src/common/deques.rs
@@ -3,7 +3,7 @@ use super::{
     KeyDate, KeyHashDate, ValueEntry,
 };
 
-use std::{ptr::NonNull, sync::Arc, unreachable};
+use std::{ptr::NonNull, sync::Arc};
 
 pub(crate) struct Deques<K> {
     pub(crate) window: Deque<KeyHashDate<K>>, //    Not used yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,14 +108,19 @@
 //!
 //! ## Expiration
 //!
-//! Cache expiration policies such as time-to-live are planned but not
-//! implemented in the current release of this crate.
+//! Current release supports the following cache expiration policies:
 //!
-//! A future release will provide such policies with O(1) time
-//! complexity:
+//! - The time-to-live policy
+//! - The time-to-idle policy
 //!
-//! - The time-to-live policy will use a write-order queue.
-//! - The time-to-idle policy will use an access-order queue.
+//! A future release will support the following:
+//!
+//! - The variable expiration
+//!
+//! These policies are provided with O(1) time complexity:
+//!
+//! - The time-to-live policy uses a write-order queue.
+//! - The time-to-idle policy uses an access-order queue.
 //! - The variable expiration will use a
 //!   [hierarchical timer wheel][timer-wheel].
 //!

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -12,12 +12,6 @@ pub use segment::SegmentedCache;
 pub trait ConcurrentCache<K, V> {
     fn get(&self, key: &K) -> Option<Arc<V>>;
 
-    // fn get_or_insert(&self, key: K, default: V) -> Arc<V>;
-
-    // fn get_or_insert_with<F>(&self, key: K, default: F) -> Arc<V>
-    // where
-    //     F: FnOnce() -> V;
-
     fn insert(&self, key: K, value: V) -> Arc<V>;
 
     fn remove(&self, key: &K) -> Option<Arc<V>>;

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -197,8 +197,8 @@ where
             },
             // on_modify
             |_k, old_entry| {
-                let aoq_node = unsafe { (*old_entry.access_order_q_node.get()).clone() };
-                let woq_node = unsafe { (*old_entry.write_order_q_node.get()).clone() };
+                let aoq_node = unsafe { *old_entry.access_order_q_node.get() };
+                let woq_node = unsafe { *old_entry.write_order_q_node.get() };
                 let entry = Arc::new(ValueEntry::new(Arc::clone(&value), aoq_node, woq_node));
                 let cnt = op_cnt2.fetch_add(1, Ordering::Relaxed);
                 op2 = Some((cnt, WriteOp::Update(entry.clone())));

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -539,6 +539,7 @@ where
                 Ok(Update(mut entry)) => {
                     if let Some(ts) = timestamp {
                         entry.set_last_accessed(ts);
+                        entry.set_last_modified(ts);
                     }
                     deqs.move_to_back_ao(Arc::clone(&entry));
                     deqs.move_to_back_wo(entry)
@@ -661,8 +662,8 @@ where
     #[inline]
     fn is_expired_entry_wo(&self, entry: &impl AccessTime, now: Instant) -> bool {
         debug_assert!(self.has_expiry());
-        if let (Some(ts), Some(tti)) = (entry.last_modified(), self.time_to_live) {
-            if ts + tti <= now {
+        if let (Some(ts), Some(ttl)) = (entry.last_modified(), self.time_to_live) {
+            if ts + ttl <= now {
                 return true;
             }
         }


### PR DESCRIPTION
- Implement time-to-live policy.
- Bump the version to 0.1.0-beta.1
- Fixed bugs causing segmentation fault (use after free) when accessing stale deq node.