### PR TITLE
Change the cache API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ categories = ["concurrency", "caching"]
 readme = "README.md"
 exclude = [".devcontainer", ".github", ".vscode"]
 
+build = "build.rs"
+
 [dependencies]
 cht = "0.4"
 crossbeam-channel = "0.5"
@@ -28,3 +30,8 @@ scheduled-thread-pool = "0.2"
 
 [dev-dependencies]
 getrandom = "0.2"
+skeptic = "0.13"
+tokio = { version = "1.1", features = ["rt-multi-thread", "macros" ] }
+
+[build-dependencies]
+skeptic = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,7 @@ Moka currently does not provide `async` optimized caches. The sync (blocking) ca
 Here's an example that reads and updates the cache by using multiple threads:
 
 ```rust
-use moka::sync::{
-    // One of the cache implementations.
-    Cache,
-    // The trait for the basic cache API.
-    ConcurrentCache,
-};
+use moka::sync::Cache;
 
 use std::thread;
 
@@ -108,13 +103,14 @@ fn main() {
 ```
 
 
-### NOTE: `get()` returns a clone of the stored value
+### NOTE: `get()` and `remove()` return a clone of the stored value
 
 Note that the return type of `get()` is `Option<V>` instead of `Option<&V>`, where `V` is the value type (`String` in the above example). Every time `get()` is called for an existing key, it creates a clone of the stored value `V` and returns it.
 
-Because of the nature of concurrent cache, `get()` cannot return `Option<&V>`. A value stored in a cache can be dropped or replaced at any time by any other thread including cache's eviction thread. So it is impossible to create a `&V`, a reference to a value and guarantee the value outlives the reference.
+Because of the nature of concurrent cache, `get()` cannot return `Option<&V>`. A value stored in a cache can be dropped or replaced at any time by any other thread including cache's eviction thread. So it is impossible to create a `&V`, a reference to a value, and guarantee the value outlives the reference.
 
-If you want to store values that will be expensive to clone, wrap them by [`std::sync::Arc`][rustdoc-std-arc], a thread-safe reference counting pointer, before storing to a cache.
+If you want to store values that will be expensive to clone, wrap them by `std::sync::Arc` before storing to a cache.
+The [`Arc`][rustdoc-std-arc] is a thread-safe reference counted pointer.
 
 [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
 
@@ -153,12 +149,7 @@ Here is the same example, but using Tokio runtime with `spawn-blocking()`:
 // [dependencies]
 // tokio = { version = "1.1", features = ["rt-multi-thread", "macros" ] }
 
-use moka::sync::{
-    // One of the cache implementations.
-    Cache,
-    // A trait that provides the basic cache API.
-    ConcurrentCache,
-};
+use moka::sync::Cache;
 
 use tokio::task;
 
@@ -241,10 +232,7 @@ Moka supports the following expiration policies:
 To set them, use the cache `Builder`.
 
 ```rust
-use moka::sync::{
-    Builder,
-    ConcurrentCache,
-};
+use moka::sync::Builder;
 
 use std::time::Duration;
 
@@ -268,7 +256,7 @@ fn main() {
 }
 ```
 
-## Usage: Segmented Cache
+## Segmented Cache
 
 Moka caches maintain internal data structures for entry replacement algorithms.
 These structures are guarded by a lock and operations are applied in batches to avoid lock contention using a dedicated worker thread.

--- a/README.md
+++ b/README.md
@@ -18,30 +18,219 @@
 [deps-rs]: https://deps.rs/repo/github/moka-rs/moka
 
 
-**Work in Progress**
-
-Moka is a fast, concurrent cache library for Rust. Moka is inspired by
-[Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
+Moka is a fast, concurrent cache library for Rust.
+It is inspired by [Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
+Moka provides a cache that supports full concurrency of retrievals and a high expected concurrency for updates. It also provides a segmented cache for increased concurrent update performance.
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 [ristretto-git]: https://github.com/dgraph-io/ristretto
 
-<!--
+
 ## Features
 
-**TODO**
--->
+- Thread-safe, highly concurrent in-memory cache implementations.
+- Caches are bounded by the maximum number of elements.
+- Maintains good hit rate by the caching strategies inspired by [Caffeine][caffeine-git]:
+    - Admission to a cache is controlled by the Least Frequently Used (LFU) policy.
+    - Eviction from a cache is controlled by the Least Recently Used (LRU) policy.
+- Support optional expiration policies:
+    - Time to live
+    - Time to idle
 
-## Status
+Moka currently does not provide `async` optimized caches. The sync (blocking) caches in the current version can be safely used under async runtime such as Tokio or async-std, but will not produce optimal performance under heavy updates. See [this example][async-example] for more details. A near future version of Moka will provide `async` optimized caches.
 
-Moka is currently in a very early stage of development (design and PoC). Many
-features are not implemented and the API will change very often.
+[async-example]: #using-cache-with-an-async-runtime-tokio-async-std-etc
 
-<!--
-## Table of Contents
 
-**TODO**
--->
+## Usage
+
+Here's an example that reads and updates the cache by using multiple threads:
+
+```rust
+use moka::sync::{
+    // One of the cache implementations.
+    Cache,
+    // The trait that provides the basic cache API.
+    ConcurrentCache,
+};
+
+use std::thread;
+
+fn value(n: usize) -> String {
+    format!("value {}", n)
+}
+
+fn main() {
+    const NUM_THREADS: usize = 16;
+    const NUM_KEYS_PER_THREAD: usize = 64;
+
+    // Create a cache that can store up to 10,000 elements.
+    let cache = Cache::new(10_000);
+
+    // Spawn threads and read and update the cache simultaneously.
+    let threads: Vec<_> = (0..NUM_THREADS)
+        .map(|i| {
+            // To share the same cache across the threads, clone it.
+            // This is a cheap operation.
+            let my_cache = cache.clone();
+
+            thread::spawn(move || {
+                let start = i * NUM_KEYS_PER_THREAD;
+                let end = (i + 1) * NUM_KEYS_PER_THREAD;
+
+                // Insert 64 elements. (NUM_KEYS_PER_THREAD = 64)
+                for key in start..end {
+                    my_cache.insert(key, value(key));
+                    // get() returns Option<String>, a clone of the stored value.
+                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                }
+
+                for key in (start..end).step_by(4) {
+                    assert_eq!(my_cache.remove(&key), Some(value(key)));
+                }
+            })
+        })
+        .collect();
+
+    // Wait for all threads to complete.
+    threads.into_iter().for_each(|t| t.join().expect("Failed"));
+
+    // Verify the result.
+    for key in 0..(NUM_THREADS * NUM_KEYS_PER_THREAD) {
+        if key % 4 == 0 {
+            assert_eq!(cache.get(&key), None);
+        } else {
+            assert_eq!(cache.get(&key), Some(value(key)));
+        }
+    }
+}
+```
+
+
+### NOTE: `get()` returns a clone of the stored value
+
+Note that the return type of `get()` is `Option<V>` instead of `Option<&V>`, where `V` is the value type (`String` in the above example). Every time `get()` is called for an existing key, it creates a clone of the stored value `V` and returns it.
+
+Because of the nature of concurrent cache, `get()` cannot return `Option<&V>`. A value stored in a cache can be dropped or replaced at any time by any other thread including cache's eviction thread. So it is impossible to create a `&V`, a reference to a value and guarantee the value outlives the reference.
+
+If you want to store values that will be expensive to clone, wrap them by [`std::sync::Arc`][rustdoc-std-arc], a thread-safe reference counting pointer, before storing to a cache.
+
+[rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+
+```rust,ignore
+use std::sync::Arc;
+
+let key = ...
+let large_value = vec![0u8; 2 * 1024 * 1024]; // 2 MiB
+cache.insert(key.clone(), Arc::new(large_value));
+
+// get() will call Arc::clone() on the store value, which is cheap.
+cache.get(&key);
+```
+
+
+## Using Cache with an Async Runtime (Tokio, async-std, etc.)
+
+Currently, Moka does not provide `async` optimized caches. An update operation (`insert()` or `remove()`) can be blocked for a short period of time under heavy updates. They employ locks, mpsc channels and thread sleeps that are not aware of the [Future trait][std-future] in std. While `insert()` or `remove()` can be safely called in an `async fn` or `async` block, they will not produce optimal performance as they may prevent async tasks from switching while acquiring a lock.
+
+Some of the async runtime libraries such as Tokio and async-std provide APIs to off-load a blocking operation to a dedicated thread pool. You may want to use them when calling `insert()` or `remove()` although it is not required.
+
+- Tokio &mdash; [`spawn-blocking()`][tokio-spawn-blocking]
+- async-std &mdash; [`spawn-blocking()`][async-std-spawn-blocking]
+
+[std-future]: https://doc.rust-lang.org/stable/std/future/trait.Future.html
+[tokio-spawn-blocking]: https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html
+[async-std-spawn-blocking]: https://docs.rs/async-std/latest/async_std/task/fn.spawn_blocking.html
+
+Here is the same example, but using Tokio runtime with `spawn-blocking()`:
+
+```rust
+// Cargo.toml
+//
+// [dependencies]
+// tokio = { version = "1.1", features = ["rt-multi-thread", "macros" ] }
+
+use moka::sync::{
+    // One of the cache implementations.
+    Cache,
+    // A trait that provides the basic cache API.
+    ConcurrentCache,
+};
+
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    const NUM_TASKS: usize = 16;
+    const NUM_KEYS_PER_TASK: usize = 64;
+
+    fn value(n: usize) -> String {
+        format!("value {}", n)
+    }
+
+    // Create a cache that can store up to 10,000 elements.
+    let cache = Cache::new(10_000);
+
+    // Spawn async tasks and write to and read from the cache.
+    let tasks: Vec<_> = (0..NUM_TASKS)
+        .map(|i| {
+            // To share the same cache across the async tasks, clone it.
+            // This is a cheap operation.
+            let my_cache = cache.clone();
+
+            tokio::spawn(async move {
+                let start = i * NUM_KEYS_PER_TASK;
+                let end = (i + 1) * NUM_KEYS_PER_TASK;
+
+                // Insert 64 elements. (NUM_KEYS_PER_TASK = 64)
+                for key in start..end {
+                    // Use spawn_blocking() for insert() as it internally uses locks
+                    // that are not async aware.
+                    let my_cache1 = my_cache.clone();
+                    task::spawn_blocking(move || my_cache1.insert(key, value(key)))
+                        .await
+                        .unwrap();
+                    
+                    // get() returns Option<String>, a clone of the stored value.
+                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                }
+
+                // Remove every 4 element of the inserted elements.
+                for key in (start..end).step_by(4) {
+                    // Use spawn_blocking() for remove() as it internally uses locks
+                    // that are not async aware.
+                    let my_cache1 = my_cache.clone();
+                    let res = task::spawn_blocking(move || my_cache1.remove(&key))
+                        .await
+                        .unwrap();
+                    assert_eq!(res, Some(value(key)));
+                }
+            })
+        })
+        .collect();
+
+    // Wait for all tasks to complete.
+    for task in tasks {
+        task.await.expect("Failed");
+    }
+
+    // Verify the result.
+    for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
+        if key % 4 == 0 {
+            assert_eq!(cache.get(&key), None);
+        } else {
+            assert_eq!(cache.get(&key), Some(value(key)));
+        }
+    }
+}
+```
+
+A near future version of Moka will provide `async` optimized caches.
+
+
+## Usage: Expiration Policies
+
+
 
 ## Requirements
 
@@ -53,17 +242,15 @@ features are not implemented and the API will change very often.
 - cht requires 1.41.
 -->
 
-<!--
-## Usage
 
-### Example
+## Miscellaneous Information
 
-**TODO**
+Moka is named after the [moka pot][moka-pot-wikipedia], a stove-top coffee maker that brews espresso-like coffee using boiling water pressurized by steam.
 
-### Config
+[caffeine-git]: https://github.com/ben-manes/caffeine
+[ristretto-git]: https://github.com/dgraph-io/ristretto
+[moka-pot-wikipedia]: https://en.wikipedia.org/wiki/Moka_pot
 
-**TODO**
--->
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // generates doc tests for `README.md`.
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,7 +64,7 @@ struct DeqNodes<K> {
 }
 
 pub(crate) struct ValueEntry<K, V> {
-    pub(crate) value: Arc<V>,
+    pub(crate) value: V,
     last_accessed: Option<Arc<AtomicU64>>,
     last_modified: Option<Arc<AtomicU64>>,
     nodes: Mutex<DeqNodes<K>>,
@@ -72,7 +72,7 @@ pub(crate) struct ValueEntry<K, V> {
 
 impl<K, V> ValueEntry<K, V> {
     pub(crate) fn new(
-        value: Arc<V>,
+        value: V,
         last_accessed: Option<Instant>,
         last_modified: Option<Instant>,
         access_order_q_node: Option<KeyDeqNodeAO<K>>,
@@ -89,7 +89,7 @@ impl<K, V> ValueEntry<K, V> {
         }
     }
 
-    pub(crate) fn new_with(value: Arc<V>, other: &Self) -> Self {
+    pub(crate) fn new_with(value: V, other: &Self) -> Self {
         let nodes = {
             let other_nodes = other.nodes.lock();
             DeqNodes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,108 +1,108 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
 
-//! Moka is a fast, concurrent cache library for Rust. Moka is
-//! inspired by [Caffeine][caffeine-git] (Java) and
-//! [Ristretto][ristretto-git] (Go).
+//! Moka is a fast, concurrent cache library for Rust. Moka is inspired by
+//! [Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
 //!
 //! Moka provides in-memory concurrent cache implementations
-//! [`Cache`][cache-struct] and [`SegmentedCache`][seg-cache-struct].
-//! They support full concurrency of retrievals and a high expected
-//! concurrency for updates.
-//! <!-- They support full concurrency of retrievals, a high expected
-//! concurrency for updates, and multiple ways to bound the cache. -->
+//! [`sync::Cache`][cache-struct] and [`sync::SegmentedCache`][seg-cache-struct].
+//! They support full concurrency of retrievals and a high expected concurrency for
+//! updates.
+//! <!-- They support full concurrency of retrievals, a high expected concurrency for
+//! updates, and multiple ways to bound the cache. -->
 //!
-//! Both `Cache` and `SegmentedCache` utilize a lock-free concurrent
-//! hash table `cht::SegmentedHashMap` from the [cht][cht-crate] crate
-//! for the central key-value storage. These caches perform a
-//! best-effort bounding of a map using an entry replacement algorithm
-//! to determine which entries to evict when the capacity is exceeded.
+//! Both `Cache` and `SegmentedCache` utilize a lock-free concurrent hash table
+//! `cht::SegmentedHashMap` from the [cht][cht-crate] crate for the central key-value
+//! storage. These caches perform a best-effort bounding of a map using an entry
+//! replacement algorithm to determine which entries to evict when the capacity is
+//! exceeded.
 //!
-//! While `Cache` will be good for general use cases, `SegmentedCache`
-//! may yield better performance under heavy concurrent updates.
-//! However, `SegmentedCache` has little overheads on
-//! retrievals/updates for managing multiple internal segments.
+//! While `Cache` will be good for general use cases, `SegmentedCache` may yield
+//! better performance under heavy concurrent updates. However, `SegmentedCache` has
+//! little overheads on retrievals/updates for managing multiple internal segments.
 //!
 //! [caffeine-git]: https://github.com/ben-manes/caffeine
 //! [ristretto-git]: https://github.com/dgraph-io/ristretto
-//! [cache-struct]: ./struct.Cache.html
-//! [seg-cache-struct]: ./struct.SegmentedCache.html
+//! [cache-struct]: ./sync/struct.Cache.html
+//! [seg-cache-struct]: ./sync/struct.SegmentedCache.html
 //! [cht-crate]: https://crates.io/crates/cht
 //!
-//! ## Status
+//! # Usages
 //!
-//! Moka is currently in a very early stage of development (design and PoC). Many
-//! features are not implemented and the API will change very often.
+//! See the followings:
 //!
-//! ## Example
+//! - The API document for the [`sync::Cache`][cache-struct].
+//! - The [README][readme].
 //!
-//! TODO
+//! [readme]: https://github.com/moka-rs/moka/blob/master/README.md
+//!
+//! # Minimum Supported Rust Version
+//!
+//! This crate's minimum supported Rust version (MSRV) is 1.45.2.
+//!
+//! If no feature is enabled, MSRV will be updated conservatively. When using other
+//! features, like `async` (which is not available yet), MSRV might be updated more
+//! frequently, up to the latest stable. In both cases, increasing MSRV is _not_
+//! considered a semver-breaking change.
+//!
+//! # Implementation Details
 //!
 //! ## Concurrency
 //!
-//! The entry replacement algorithms are kept eventually consistent
-//! with the map. While updates to the cache are immediately applied
-//! to the map, recording of reads and writes may not be immediately
-//! reflected on the cache policy's data structures.
+//! The entry replacement algorithms are kept eventually consistent with the
+//! map. While updates to the cache are immediately applied to the map, recording of
+//! reads and writes may not be immediately reflected on the cache policy's data
+//! structures.
 //!
-//! These structures are guarded by a lock and operations are applied
-//! in batches to avoid lock contention. There are bounded
-//! inter-thread channels to hold these operations. These channels are
-//! drained at the first opportunity when:
+//! These structures are guarded by a lock and operations are applied in batches to
+//! avoid lock contention. There are bounded inter-thread channels to hold these
+//! operations. These channels are drained at the first opportunity when:
 //!
-//! - The numbers of read/write recordings reach to the configured
-//!   amounts.
+//! - The numbers of read/write recordings reach to the configured amounts.
 //! - Or, the certain time past from the last draining.
 //!
-//! In a `Cache`, this draining and batch application is handled by a
-//! single worker thread. So under heavy concurrent operations from
-//! clients, draining may not be able to catch up and the bounded
-//! channels can become full.
+//! In a `Cache`, this draining and batch application is handled by a single worker
+//! thread. So under heavy concurrent operations from clients, draining may not be
+//! able to catch up and the bounded channels can become full.
 //!
-//! When read or write channel becomes full, one of the followings
-//! will occur:
+//! When read or write channel becomes full, one of the followings will occur:
 //!
-//! - For the read channel, recordings of new reads will be discarded,
-//!   so that retrievals will never be blocked. This behavior may have
-//!   some impact to the hit rate of the cache.
-//! - For the write channel, updates from clients to the cache will be
-//!   blocked until the draining task catches up.
+//! - For the read channel, recordings of new reads will be discarded, so that
+//!   retrievals will never be blocked. This behavior may have some impact to the hit
+//!   rate of the cache.
+//! - For the write channel, updates from clients to the cache will be blocked until
+//!   the draining task catches up.
 //!
-//! `Cache` does its best to avoid blocking updates by adjusting the
-//! interval of draining and throttling updates from clients. But
-//! since it has only one worker thread, it cannot always avoid
-//! blocking. If this happens very often in your cache (in the future,
-//! you can check the statistics of the cache), you may want to
-//! switch to `SegmentedCache`. It has multiple internal cache
-//! segments and each segment has dedicated draining thread.
+//! `Cache` does its best to avoid blocking updates by adjusting the interval of
+//! draining and throttling updates from clients. But since it has only one worker
+//! thread, it cannot always avoid blocking. If this happens very often in your cache
+//! (in the future, you can check the statistics of the cache), you may want to
+//! switch to `SegmentedCache`. It has multiple internal cache segments and each
+//! segment has dedicated draining thread.
 //!
 //! ## Admission and Eviction
 //!
-//! Every time a client tries to retrieve an item from the cache, that
-//! activity is retained in a historic popularity estimator. This
-//! estimator has a tiny memory footprint as it uses hashing to
-//! probabilistically estimate an item's frequency.
+//! Every time a client tries to retrieve an item from the cache, that activity is
+//! retained in a historic popularity estimator. This estimator has a tiny memory
+//! footprint as it uses hashing to probabilistically estimate an item's frequency.
 //!
-//! Both `Cache` and `SegmentedCache` employ [TinyLFU] (Least
-//! Frequently Used) as the admission policy. When a new entry is
-//! inserted to the cache, it is temporary admitted to the cache, and
-//! a recording of this insertion is added to the write queue. When
-//! the write queue is drained and the main space of the cache is
-//! already full, then the historic popularity estimator determines to
-//! evict one of the following entries:
+//! Both `Cache` and `SegmentedCache` employ [TinyLFU] (Least Frequently Used) as the
+//! admission policy. When a new entry is inserted to the cache, it is temporary
+//! admitted to the cache, and a recording of this insertion is added to the write
+//! queue. When the write queue is drained and the main space of the cache is already
+//! full, then the historic popularity estimator determines to evict one of the
+//! following entries:
 //!
-//! - The newly admitted entry
-//! - Or, the victim entry that is selected from the main space by LRU
-//!   (Least Recently Used) eviction policy
+//! - The newly admitted entry.
+//! - Or, the victim entry that is selected from the main space by LRU (Least
+//!   Recently Used) eviction policy.
 //!
-//! In a future release of this crate, TinyLFU admission policy will
-//! be replaced by Window TinyLFU (W-TinyLFU) policy. W-TinyLFU has an
-//! admission window in front of the main space. A new entry starts in
-//! the admission window and remains there as long as it has high
-//! temporal locality (recency). Eventually an entry will slip off
-//! from the window, then TinyLFU comes in play to determine whether
-//! or not to admit the entry to the main space based on its
-//! popularity (frequency).
+//! In a future release of this crate, TinyLFU admission policy will be replaced by
+//! Window TinyLFU (W-TinyLFU) policy. W-TinyLFU has an admission window in front of
+//! the main space. A new entry starts in the admission window and remains there as
+//! long as it has high temporal locality (recency). Eventually an entry will slip
+//! off from the window, then TinyLFU comes in play to determine whether or not to
+//! admit the entry to the main space based on its popularity (frequency).
 //!
 //! [TinyLFU]: https://dl.acm.org/citation.cfm?id=3149371
 //!
@@ -117,15 +117,20 @@
 //!
 //! - The variable expiration
 //!
-//! These policies are provided with O(1) time complexity:
+//! These policies are provided with _O(1)_ time complexity:
 //!
 //! - The time-to-live policy uses a write-order queue.
 //! - The time-to-idle policy uses an access-order queue.
-//! - The variable expiration will use a
-//!   [hierarchical timer wheel][timer-wheel].
+//! - The variable expiration will use a [hierarchical timer wheel][timer-wheel].
 //!
 //! [timer-wheel]: http://www.cs.columbia.edu/~nahum/w6998/papers/ton97-timing-wheels.pdf
 //!
+//! # About the Name
+//!
+//! Moka is named after the [moka pot][moka-pot-wikipedia], a stove-top coffee maker that
+//! brews espresso-like coffee using boiling water pressurized by steam.
+//!
+//! [moka-pot-wikipedia]: https://en.wikipedia.org/wiki/Moka_pot
 
 pub mod sync;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! inspired by [Caffeine][caffeine-git] (Java) and
 //! [Ristretto][ristretto-git] (Go).
 //!
-//! This crate provides in-memory concurrent cache implementations
+//! Moka provides in-memory concurrent cache implementations
 //! [`Cache`][cache-struct] and [`SegmentedCache`][seg-cache-struct].
 //! They support full concurrency of retrievals and a high expected
 //! concurrency for updates.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 mod builder;
 pub(crate) mod cache;
 mod segment;
@@ -7,23 +5,6 @@ mod segment;
 pub use builder::Builder;
 pub use cache::Cache;
 pub use segment::SegmentedCache;
-
-// Interior mutability (no need for `&mut self`)
-pub trait ConcurrentCache<K, V> {
-    fn get(&self, key: &K) -> Option<V>;
-
-    fn insert(&self, key: K, value: V);
-
-    fn remove(&self, key: &K) -> Option<V>;
-
-    fn capacity(&self) -> usize;
-
-    fn time_to_live(&self) -> Option<Duration>;
-
-    fn time_to_idle(&self) -> Option<Duration>;
-
-    fn num_segments(&self) -> usize;
-}
 
 pub trait ConcurrentCacheExt<K, V> {
     fn sync(&self);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 mod builder;
 pub(crate) mod cache;
@@ -10,11 +10,11 @@ pub use segment::SegmentedCache;
 
 // Interior mutability (no need for `&mut self`)
 pub trait ConcurrentCache<K, V> {
-    fn get(&self, key: &K) -> Option<Arc<V>>;
+    fn get(&self, key: &K) -> Option<V>;
 
-    fn insert(&self, key: K, value: V) -> Arc<V>;
+    fn insert(&self, key: K, value: V);
 
-    fn remove(&self, key: &K) -> Option<Arc<V>>;
+    fn remove(&self, key: &K) -> Option<V>;
 
     fn capacity(&self) -> usize;
 

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -18,6 +18,7 @@ pub struct Builder<C> {
 impl<K, V> Builder<Cache<K, V, RandomState>>
 where
     K: Eq + Hash,
+    V: Clone,
 {
     pub fn new(capacity: usize) -> Self {
         Self {
@@ -60,6 +61,7 @@ where
 impl<K, V> Builder<SegmentedCache<K, V, RandomState>>
 where
     K: Eq + Hash,
+    V: Clone,
 {
     pub fn build(self) -> SegmentedCache<K, V, RandomState> {
         let build_hasher = RandomState::default();
@@ -107,7 +109,7 @@ mod tests {
     use super::Builder;
     use crate::sync::ConcurrentCache;
 
-    use std::{sync::Arc, time::Duration};
+    use std::time::Duration;
 
     #[test]
     fn build_cache() {
@@ -120,7 +122,7 @@ mod tests {
         assert_eq!(cache.num_segments(), 1);
 
         cache.insert('a', "Alice");
-        assert_eq!(cache.get(&'a'), Some(Arc::new("Alice")));
+        assert_eq!(cache.get(&'a'), Some("Alice"));
 
         let cache = Builder::new(100)
             .time_to_live(Duration::from_secs(45 * 60))
@@ -133,7 +135,7 @@ mod tests {
         assert_eq!(cache.num_segments(), 1);
 
         cache.insert('a', "Alice");
-        assert_eq!(cache.get(&'a'), Some(Arc::new("Alice")));
+        assert_eq!(cache.get(&'a'), Some("Alice"));
     }
 
     #[test]
@@ -147,7 +149,7 @@ mod tests {
         assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
 
         cache.insert('b', "Bob");
-        assert_eq!(cache.get(&'b'), Some(Arc::new("Bob")));
+        assert_eq!(cache.get(&'b'), Some("Bob"));
 
         let cache = Builder::new(100)
             .segments(16)
@@ -161,6 +163,6 @@ mod tests {
         assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
 
         cache.insert('b', "Bob");
-        assert_eq!(cache.get(&'b'), Some(Arc::new("Bob")));
+        assert_eq!(cache.get(&'b'), Some("Bob"));
     }
 }

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -7,8 +7,34 @@ use std::{
     time::Duration,
 };
 
+/// Builds a `Cache` or `SegmentedCache` with various configuration knobs.
+///
+/// ```rust
+/// use moka::sync::Builder;
+///
+/// use std::time::Duration;
+///
+/// let cache = Builder::new(10_000) // Max 10,000 elements
+///     // Time to live (TTL): 30 minutes
+///     .time_to_live(Duration::from_secs(30 * 60))
+///     // Time to idle (TTI):  5 minutes
+///     .time_to_idle(Duration::from_secs( 5 * 60))
+///     // Create the cache.
+///     .build();
+///
+/// // This entry will expire after 5 minutes (TTI) if there is no get().
+/// cache.insert(0, "zero");
+///
+/// // This get() will extend the entry life for another 5 minutes.
+/// cache.get(&0);
+///
+/// // Even though we keep calling get(), the entry will expire
+/// // after 30 minutes (TTL) from the insert().
+/// ```
+///
 pub struct Builder<C> {
-    capacity: usize,
+    max_capacity: usize,
+    initial_capacity: Option<usize>,
     num_segments: Option<usize>,
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
@@ -20,9 +46,10 @@ where
     K: Eq + Hash,
     V: Clone,
 {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(max_capacity: usize) -> Self {
         Self {
-            capacity,
+            max_capacity,
+            initial_capacity: None,
             num_segments: None,
             time_to_live: None,
             time_to_idle: None,
@@ -32,7 +59,8 @@ where
 
     pub fn segments(self, num_segments: usize) -> Builder<SegmentedCache<K, V, RandomState>> {
         Builder {
-            capacity: self.capacity,
+            max_capacity: self.max_capacity,
+            initial_capacity: self.initial_capacity,
             num_segments: Some(num_segments),
             time_to_live: self.time_to_live,
             time_to_idle: self.time_to_idle,
@@ -43,7 +71,8 @@ where
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
         Cache::with_everything(
-            self.capacity,
+            self.max_capacity,
+            self.initial_capacity,
             build_hasher,
             self.time_to_live,
             self.time_to_idle,
@@ -54,7 +83,13 @@ where
     where
         S: BuildHasher + Clone,
     {
-        Cache::with_everything(self.capacity, hasher, self.time_to_live, self.time_to_idle)
+        Cache::with_everything(
+            self.max_capacity,
+            self.initial_capacity,
+            hasher,
+            self.time_to_live,
+            self.time_to_idle,
+        )
     }
 }
 
@@ -66,7 +101,8 @@ where
     pub fn build(self) -> SegmentedCache<K, V, RandomState> {
         let build_hasher = RandomState::default();
         SegmentedCache::with_everything(
-            self.capacity,
+            self.max_capacity,
+            self.initial_capacity,
             self.num_segments.unwrap(),
             build_hasher,
             self.time_to_live,
@@ -79,7 +115,8 @@ where
         S: BuildHasher + Clone,
     {
         SegmentedCache::with_everything(
-            self.capacity,
+            self.max_capacity,
+            self.initial_capacity,
             self.num_segments.unwrap(),
             hasher,
             self.time_to_live,
@@ -89,6 +126,13 @@ where
 }
 
 impl<C> Builder<C> {
+    pub fn initial_capacity(self, capacity: usize) -> Self {
+        Self {
+            initial_capacity: Some(capacity),
+            ..self
+        }
+    }
+
     pub fn time_to_live(self, duration: Duration) -> Self {
         Self {
             time_to_live: Some(duration),
@@ -115,7 +159,7 @@ mod tests {
         // Cache<char, String>
         let cache = Builder::new(100).build();
 
-        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.max_capacity(), 100);
         assert_eq!(cache.time_to_live(), None);
         assert_eq!(cache.time_to_idle(), None);
         assert_eq!(cache.num_segments(), 1);
@@ -128,7 +172,7 @@ mod tests {
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
 
-        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.max_capacity(), 100);
         assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
         assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
         assert_eq!(cache.num_segments(), 1);
@@ -142,7 +186,7 @@ mod tests {
         // SegmentCache<char, String>
         let cache = Builder::new(100).segments(16).build();
 
-        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.max_capacity(), 100);
         assert_eq!(cache.time_to_live(), None);
         assert_eq!(cache.time_to_idle(), None);
         assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
@@ -156,7 +200,7 @@ mod tests {
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
 
-        assert_eq!(cache.capacity(), 100);
+        assert_eq!(cache.max_capacity(), 100);
         assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
         assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
         assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -107,7 +107,6 @@ impl<C> Builder<C> {
 #[cfg(test)]
 mod tests {
     use super::Builder;
-    use crate::sync::ConcurrentCache;
 
     use std::time::Duration;
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -71,7 +71,7 @@ pub(crate) const PERIODICAL_SYNC_FAST_PACE_NANOS: u64 = 500;
 /// This is because the `Cache` allows concurrent updates from threads so a value stored in the cache can be dropped or replaced at any time by any other thread.
 /// It is impossible to create a reference `&V` and guarantee the value outlives its reference.
 ///
-/// If you want to store values that will be expensive to clone, wrap them by the `std::sync::Arc` before storing to a cache.
+/// If you want to store values that will be expensive to clone, you may want to wrap them by the `std::sync::Arc` before storing to a cache.
 /// The [`Arc`][rustdoc-std-arc] is a thread-safe reference-counted pointer and its `clone()` method is cheap.
 ///
 /// [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
- Bumped the version to 0.1.0-beta.2
- Changed the cache API:
    - Removed the `ConcurrentCache` trait.
    - Renamed `remove()` method to `invalidate()`, and changed the return type to `()`.
    - Changed the return type of `insert()` to `()`.
    - Changed the return type of `get()` from `Arc<V>` to `V`. 
    - Updated `get()` and `invalidate()` methods to accept the type for the key that implement the `Borrow` trait for `Arc<K>`.
- Updated the cache `Builder` to support the `initial_capacity`.
- Added doc tests (skeptic) to the README.
- Wrote some rustdoc.