### PR TITLE
Enable an CI for test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Coverage with docker
-          command: docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin cargo tarpaulin -v --ciserver circle-ci --coveralls ${COVERALLS_TOKEN} --timeout 600
+          name: Run cargo tarpaulin
+          command: |
+            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin \
+              cargo tarpaulin -v \
+                --features future \
+                --ciserver circle-ci \
+                --coveralls ${COVERALLS_TOKEN} \
+                --timeout 600
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+jobs:
+  rust/coverage:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Coverage with docker
+          command: docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin cargo tarpaulin -v --ciserver circle-ci --coveralls ${COVERALLS_TOKEN} --timeout 600
+
+workflows:
+  build:
+    jobs:
+    - rust/coverage
+  version: 2

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![crates.io release][release-badge]][crate]
 [![docs][docs-badge]][docs]
 [![dependency status][deps-rs-badge]][deps-rs]
+[![coverage status][coveralls-badge]][coveralls]
 [![license][license-badge]](#license)
 
 Moka is a fast, concurrent cache library for Rust. Moka is inspired by
@@ -18,12 +19,14 @@ to evict when the capacity is exceeded.
 [release-badge]: https://img.shields.io/crates/v/moka.svg
 [docs-badge]: https://docs.rs/moka/badge.svg
 [deps-rs-badge]: https://deps.rs/repo/github/moka-rs/moka/status.svg
+[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=master
 [license-badge]: https://img.shields.io/crates/l/moka.svg
 
 [gh-actions]: https://github.com/moka-rs/moka/actions?query=workflow%3ACI
 [crate]: https://crates.io/crates/moka
 [docs]: https://docs.rs/moka
 [deps-rs]: https://deps.rs/repo/github/moka-rs/moka
+[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=master
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 [ristretto-git]: https://github.com/dgraph-io/ristretto


### PR DESCRIPTION
- Run `cargo tarpaulin --features future` at CircleCI.
- Publish the coverage report to Coveralls.