### PR TITLE
Add the `invalidate_all` method to all caches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "Moka",
         "Ristretto",
         "Tatsuya",
-        "unsync",
+        "Upsert",
         "actix",
         "ahash",
         "benmanes",
@@ -27,6 +27,7 @@
         "semver",
         "structs",
         "toolchain",
+        "unsync",
         "usize"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,47 @@
 
 ## Version 0.3.0
 
-- Add an unsync cache (`moka::unsync::Cache`) and its builder.
+### Added
+
+- Add an unsync cache (`moka::unsync::Cache`) and its builder for single-thread
+  applications. ([#9][gh-pull-0009])
 - Add `invalidate_all` method to `sync`, `future` and `unsync` caches.
+  ([#11][gh-pull-0011])
+
+### Fixed
+
+- Fix problems including segfault caused by race conditions between the sync/eviction
+  thread and client writes. (Addressed as a part of [#11][gh-pull-0011]).
+
 
 ## Version 0.2.0
 
+### Added
+
 - Add an asynchronous, futures aware cache (`moka::future::Cache`) and its builder.
+  ([#7][gh-pull-0007])
+
 
 ## Version 0.1.0
 
-### Features
+### Added
 
-- Thread-safe, highly concurrent in-memory cache implementations.
-- Caches are bounded by the maximum number of elements.
-- Maintains good hit rate by using entry replacement algorithms inspired by
-  [Caffeine][caffeine-git]:
-    - Admission to a cache is controlled by the Least Frequently Used (LFU) policy.
-    - Eviction from a cache is controlled by the Least Recently Used (LRU) policy.
-- Supports expiration policies:
-    - Time to live
-    - Time to idle
+- Add thread-safe, highly concurrent in-memory cache implementations
+  (`moka::sync::{Cache, SegmentedCache}`) with the following features:
+    - Bounded by the maximum number of elements.
+    - Maintains good hit rate by using entry replacement algorithms inspired by
+      [Caffeine][caffeine-git]:
+        - Admission to a cache is controlled by the Least Frequently Used (LFU) policy.
+        - Eviction from a cache is controlled by the Least Recently Used (LRU) policy.
+    - Expiration policies:
+        - Time to live
+        - Time to idle
+
+
+<!-- Links -->
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
+
+[gh-pull-0011]: https://github.com/moka-rs/moka/pull/11/
+[gh-pull-0009]: https://github.com/moka-rs/moka/pull/9/
+[gh-pull-0007]: https://github.com/moka-rs/moka/pull/7/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,14 @@
-# Moka &mdash; Release Notes
+# Moka &mdash; Change Log
 
 ## Unreleased
 
-### Features
-
-- Introduce an unsync cache.
+- Add an unsync cache (`moka::unsync::Cache`) and its builder.
+- Add `invalidate_all` method to `sync`, `future` and `unsync` caches.
 
 
 ## Version 0.2.0
 
-### Features
-
-- Introduce an asynchronous (futures aware) cache.
+- Add an asynchronous, futures aware cache (`moka::future::Cache`) and its builder.
 
 
 ## Version 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
 # Moka &mdash; Change Log
 
-## Unreleased
+## Version 0.3.0
 
 - Add an unsync cache (`moka::unsync::Cache`) and its builder.
 - Add `invalidate_all` method to `sync`, `future` and `unsync` caches.
 
-
 ## Version 0.2.0
 
 - Add an asynchronous, futures aware cache (`moka::future::Cache`) and its builder.
-
 
 ## Version 0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ future = ["async-io"]
 cht = "0.4"
 crossbeam-channel = "0.5"
 num_cpus = "1.13"
-once_cell = "1.5"
+once_cell = "1.7"
 parking_lot = "0.11"
 # v0.7.1 or newer should be used as v0.7.0 will not compile on non-x86_64 platforms.
 # https://github.com/metrics-rs/quanta/pull/38

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-moka = "0.2"
+moka = "0.3"
 ```
 
 To use the asynchronous cache, enable a crate feature called "future".
 
 ```toml
 [dependencies]
-moka = { version = "0.2", features = ["future"] }
+moka = { version = "0.3", features = ["future"] }
 ```
 
 
@@ -161,7 +161,7 @@ Here is a similar program to the previous example, but using asynchronous cache 
 // Cargo.toml
 //
 // [dependencies]
-// moka = { version = "0.2", features = ["future"] }
+// moka = { version = "0.3", features = ["future"] }
 // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 // futures = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Moka is a fast, concurrent cache library for Rust. Moka is inspired by
 
 Moka provides cache implementations that support full concurrency of retrievals and
 a high expected concurrency for updates. Moka also provides a not thread-safe cache
-implementation for single threaded applications.
+implementation for single thread applications.
 
 All caches perform a best-effort bounding of a  hash map using an entry
 replacement algorithm to determine which entries to evict when the capacity is
@@ -41,7 +41,7 @@ exceeded.
     - Blocking caches that can be shared across OS threads.
     - An asynchronous (futures aware) cache that can be accessed inside and outside
       of asynchronous contexts.
-- A not thread-safe, in-memory cache implementation for single threaded applications.
+- A not thread-safe, in-memory cache implementation for single thread applications.
 - Caches are bounded by the maximum number of entries.
 - Maintains good hit rate by using an entry replacement algorithms inspired by
   [Caffeine][caffeine-git]:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ Moka is a fast, concurrent cache library for Rust. Moka is inspired by
 [Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
 
 Moka provides cache implementations that support full concurrency of retrievals and
-a high expected concurrency for updates. They perform a best-effort bounding of a
-concurrent hash map using an entry replacement algorithm to determine which entries
-to evict when the capacity is exceeded.
+a high expected concurrency for updates. Moka also provides a not thread-safe cache
+implementation for single threaded applications.
+
+All caches perform a best-effort bounding of a  hash map using an entry
+replacement algorithm to determine which entries to evict when the capacity is
+exceeded.
 
 [gh-actions-badge]: https://github.com/moka-rs/moka/workflows/CI/badge.svg
 [release-badge]: https://img.shields.io/crates/v/moka.svg
@@ -35,9 +38,10 @@ to evict when the capacity is exceeded.
 ## Features
 
 - Thread-safe, highly concurrent in-memory cache implementations:
-    - Synchronous (blocking) caches that can be shared across OS threads.
+    - Blocking caches that can be shared across OS threads.
     - An asynchronous (futures aware) cache that can be accessed inside and outside
       of asynchronous contexts.
+- A not thread-safe, in-memory cache implementation for single threaded applications.
 - Caches are bounded by the maximum number of entries.
 - Maintains good hit rate by using an entry replacement algorithms inspired by
   [Caffeine][caffeine-git]:
@@ -67,12 +71,12 @@ moka = { version = "0.2", features = ["future"] }
 
 ## Example: Synchronous Cache
 
-The synchronous (blocking) caches are defined in the `sync` module.
+The thread-safe, blocking caches are defined in the `sync` module.
 
 Cache entries are manually added using `insert` method, and are stored in the cache
 until either evicted or manually invalidated.
 
-Here's an example that reads and updates a cache by using multiple threads:
+Here's an example of reading and updating a cache by using multiple threads:
 
 ```rust
 // Use the synchronous cache.
@@ -220,12 +224,13 @@ async fn main() {
 
 ## Avoiding to clone the value at `get`
 
-The return type of `get` method is `Option<V>` instead of `Option<&V>`, where `V` is
-the value type. Every time `get` is called for an existing key, it creates a clone of
-the stored value `V` and returns it. This is because the `Cache` allows concurrent
-updates from threads so a value stored in the cache can be dropped or replaced at any
-time by any other thread. `get` cannot return a reference `&V` as it is impossible to
-guarantee the value outlives the reference.
+For the concurrent caches (`sync` and `future` caches), the return type of `get`
+method is `Option<V>` instead of `Option<&V>`, where `V` is the value type. Every
+time `get` is called for an existing key, it creates a clone of the stored value `V`
+and returns it. This is because the `Cache` allows concurrent updates from threads so
+a value stored in the cache can be dropped or replaced at any time by any other
+thread. `get` cannot return a reference `&V` as it is impossible to guarantee the
+value outlives the reference.
 
 If you want to store values that will be expensive to clone, wrap them by
 `std::sync::Arc` before storing in a cache. [`Arc`][rustdoc-std-arc] is a thread-safe

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,3 +11,11 @@ pub(crate) trait AccessTime {
     fn last_modified(&self) -> Option<Instant>;
     fn set_last_modified(&mut self, timestamp: Instant);
 }
+
+pub(crate) fn u64_to_instant(ts: u64) -> Option<Instant> {
+    if ts == u64::MAX {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute(ts) })
+    }
+}

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -91,6 +91,10 @@ impl<T> Deque<T> {
         }
     }
 
+    pub(crate) fn region(&self) -> &CacheRegion {
+        &self.region
+    }
+
     pub(crate) fn contains(&self, node: &DeqNode<T>) -> bool {
         self.region == node.region && (node.prev.is_some() || self.is_head(node))
     }

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,4 +1,4 @@
-//! Provides thread-safe, asynchronous (futures aware) cache implementations.
+//! Provides a thread-safe, asynchronous (futures aware) cache implementation.
 //!
 //! To use this module, enable a crate feature called "future".
 

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -50,8 +50,8 @@ where
     K: Eq + Hash,
     V: Clone,
 {
-    /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
-    /// `SegmentedCache` holding up to `max_capacity` entries.
+    /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
+    /// up to `max_capacity` entries.
     pub fn new(max_capacity: usize) -> Self {
         Self {
             max_capacity,
@@ -64,9 +64,6 @@ where
     }
 
     /// Builds a `Cache<K, V>`.
-    ///
-    /// If you want to build a `SegmentedCache<K, V>`, call `segments` method before
-    /// calling this method.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
         Cache::with_everything(
@@ -79,9 +76,6 @@ where
     }
 
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
-    ///
-    /// If you want to build a `SegmentedCache<K, V>`, call `segments` method  before
-    /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
         S: BuildHasher + Clone,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -327,6 +327,10 @@ where
         }
     }
 
+    pub fn invalidate_all(&self) {
+        self.base.invalidate_all();
+    }
+
     /// Returns the `max_capacity` of this cache.
     pub fn max_capacity(&self) -> usize {
         self.base.max_capacity()
@@ -575,6 +579,34 @@ mod tests {
 
         assert!(cache.get(&10).is_none());
         assert!(cache.get(&20).is_some());
+    }
+
+    #[tokio::test]
+    async fn invalidate_all() {
+        let mut cache = Cache::new(100);
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice").await;
+        cache.insert("b", "bob").await;
+        cache.insert("c", "cindy").await;
+        assert_eq!(cache.get(&"a"), Some("alice"));
+        assert_eq!(cache.get(&"b"), Some("bob"));
+        assert_eq!(cache.get(&"c"), Some("cindy"));
+        cache.sync();
+
+        cache.invalidate_all();
+        cache.sync();
+
+        cache.insert("d", "david").await;
+        cache.sync();
+
+        assert!(cache.get(&"a").is_none());
+        assert!(cache.get(&"b").is_none());
+        assert!(cache.get(&"c").is_none());
+        assert_eq!(cache.get(&"d"), Some("david"));
     }
 
     #[tokio::test]

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -40,7 +40,7 @@ use std::{
 ///   [`blocking_invalidate`](#method.blocking_invalidate) methods. They will block
 ///   for a short time under heavy updates.
 ///
-/// Here's an example that reads and updates a cache by using multiple asynchronous
+/// Here's an example of reading and updating a cache by using multiple asynchronous
 /// tasks with [Tokio][tokio-crate] runtime:
 ///
 /// [tokio-crate]: https://crates.io/crates/tokio
@@ -327,6 +327,16 @@ where
         }
     }
 
+    /// Discards all cached values.
+    ///
+    /// This method returns immediately and a background thread will evict all the
+    /// cached values inserted before the time when this method was called. It is
+    /// guaranteed that the `get` method must not return these invalidated values
+    /// even if they have not been evicted.
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
     pub fn invalidate_all(&self) {
         self.base.invalidate_all();
     }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -49,7 +49,7 @@ use std::{
 /// // Cargo.toml
 /// //
 /// // [dependencies]
-/// // moka = { version = "0.2", features = ["future"] }
+/// // moka = { version = "0.3", features = ["future"] }
 /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 /// // futures = "0.3"
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! [cht][cht-crate] crate for the central key-value storage.
 //!
 //! Moka also provides an in-memory, not thread-safe cache implementation for single
-//! threaded applications.
+//! thread applications.
 //!
 //! All cache implementations perform a best-effort bounding of the map using an entry
 //! replacement algorithm to determine which entries to evict when the capacity is
@@ -26,7 +26,7 @@
 //!     - Blocking caches that can be shared across OS threads.
 //!     - An asynchronous (futures aware) cache that can be accessed inside and
 //!       outside of asynchronous contexts.
-//! - A not thread-safe, in-memory cache implementation for single threaded applications.
+//! - A not thread-safe, in-memory cache implementation for single thread applications.
 //! - Caches are bounded by the maximum number of entries.
 //! - Maintains good hit rate by using entry replacement algorithms inspired by
 //!   [Caffeine][caffeine-git]:
@@ -131,7 +131,8 @@
 //!
 //! A future release will support the following:
 //!
-//! - The variable expiration
+//! - The variable expiration (which allows to set different expiration on each
+//!   cached entry)
 //!
 //! These policies are provided with _O(1)_ time complexity:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,16 @@
 //! [Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
 //!
 //! Moka provides in-memory concurrent cache implementations that support full
-//! concurrency of retrievals and a high expected concurrency for updates.
-//! <!-- , and multiple ways to bound the cache. -->
+//! concurrency of retrievals and a high expected concurrency for updates. <!-- , and multiple ways to bound the cache. -->
 //! They utilize a lock-free concurrent hash table `cht::SegmentedHashMap` from the
-//! [cht][cht-crate] crate for the central key-value storage. These caches perform a
-//! best-effort bounding of the map using an entry replacement algorithm to determine
-//! which entries to evict when the capacity is exceeded.
+//! [cht][cht-crate] crate for the central key-value storage.
+//!
+//! Moka also provides an in-memory, not thread-safe cache implementation for single
+//! threaded applications.
+//!
+//! All cache implementations perform a best-effort bounding of the map using an entry
+//! replacement algorithm to determine which entries to evict when the capacity is
+//! exceeded.
 //!
 //! [caffeine-git]: https://github.com/ben-manes/caffeine
 //! [ristretto-git]: https://github.com/dgraph-io/ristretto
@@ -19,9 +23,10 @@
 //! # Features
 //!
 //! - Thread-safe, highly concurrent in-memory cache implementations:
-//!     - Synchronous (blocking) caches that can be shared across OS threads.
+//!     - Blocking caches that can be shared across OS threads.
 //!     - An asynchronous (futures aware) cache that can be accessed inside and
 //!       outside of asynchronous contexts.
+//! - A not thread-safe, in-memory cache implementation for single threaded applications.
 //! - Caches are bounded by the maximum number of entries.
 //! - Maintains good hit rate by using entry replacement algorithms inspired by
 //!   [Caffeine][caffeine-git]:
@@ -33,35 +38,38 @@
 //!
 //! # Examples
 //!
-//! See the followings:
+//! See the following document:
 //!
-//! - Synchronous (blocking) caches:
-//!     - The document for the [`sync::Cache`][sync-cache-struct] and
+//! - Thread-safe, blocking caches:
+//!     - [`sync::Cache`][sync-cache-struct] and
 //!       [`sync::SegmentedCache`][sync-seg-cache-struct].
-//! - Asynchronous (futures aware) cache:
-//!     - The document for the [`future::Cache`][future-cache-struct].
+//! - An asynchronous (futures aware) cache:
+//!     - [`future::Cache`][future-cache-struct].
+//! - A not thread-safe, blocking cache for single threaded applications:
+//!     - [`unsync::Cache`][unsync-cache-struct].
 //!
 //! [future-cache-struct]: ./future/struct.Cache.html
 //! [sync-cache-struct]: ./sync/struct.Cache.html
 //! [sync-seg-cache-struct]: ./sync/struct.SegmentedCache.html
+//! [unsync-cache-struct]: ./unsync/struct.Cache.html
 //!
 //! # Minimum Supported Rust Version
 //!
 //! This crate's minimum supported Rust version (MSRV) is 1.45.2.
 //!
-//! If no feature is enabled, MSRV will be updated conservatively. When using other
-//! features, like `async` (which is not available yet), MSRV might be updated more
-//! frequently, up to the latest stable. In both cases, increasing MSRV is _not_
-//! considered a semver-breaking change.
+//! If no crate feature is enabled, MSRV will be updated conservatively. When using
+//! features like `future`, MSRV might be updated more frequently, up to the latest
+//! stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
+//! change.
 //!
 //! # Implementation Details
 //!
 //! ## Concurrency
 //!
-//! The entry replacement algorithms are kept eventually consistent with the
-//! map. While updates to the cache are immediately applied to the map, recording of
-//! reads and writes may not be immediately reflected on the cache policy's data
-//! structures.
+//! In a concurrent cache (`sync` or `future` cache), the entry replacement
+//! algorithms are kept eventually consistent with the map. While updates to the
+//! cache are immediately applied to the map, recording of reads and writes may not
+//! be immediately reflected on the cache policy's data structures.
 //!
 //! These structures are guarded by a lock and operations are applied in batches to
 //! avoid lock contention. There are bounded inter-thread channels to hold these
@@ -95,12 +103,11 @@
 //! retained in a historic popularity estimator. This estimator has a tiny memory
 //! footprint as it uses hashing to probabilistically estimate an item's frequency.
 //!
-//! Both `Cache` and `SegmentedCache` employ [TinyLFU] (Least Frequently Used) as the
-//! admission policy. When a new entry is inserted to the cache, it is temporary
-//! admitted to the cache, and a recording of this insertion is added to the write
-//! queue. When the write queue is drained and the main space of the cache is already
-//! full, then the historic popularity estimator determines to evict one of the
-//! following entries:
+//! All caches employ [TinyLFU] (Least Frequently Used) as the admission policy. When
+//! a new entry is inserted to the cache, it is temporary admitted to the cache, and
+//! a recording of this insertion is added to the write queue. When the write queue
+//! is drained and the main space of the cache is already full, then the historic
+//! popularity estimator determines to evict one of the following entries:
 //!
 //! - The temporary admitted entry.
 //! - Or, an entry that is selected from the main cache space by LRU (Least Recently

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -112,8 +112,8 @@ impl<K, V> ValueEntry<K, V> {
                 write_order_q_node: other_nodes.write_order_q_node,
             }
         };
-        let last_accessed = other.last_accessed.clone();
-        let last_modified = other.last_modified.clone();
+        let last_accessed = Arc::clone(&other.last_accessed);
+        let last_modified = Arc::clone(&other.last_modified);
         // To prevent this updated ValueEntry from being evicted by a expiration policy,
         // set the max value to the timestamps. They will be replaced with the real
         // timestamps when applying writes.
@@ -128,11 +128,11 @@ impl<K, V> ValueEntry<K, V> {
     }
 
     pub(crate) fn raw_last_accessed(&self) -> Arc<AtomicU64> {
-        self.last_accessed.clone()
+        Arc::clone(&self.last_accessed)
     }
 
     pub(crate) fn raw_last_modified(&self) -> Arc<AtomicU64> {
-        self.last_modified.clone()
+        Arc::clone(&self.last_modified)
     }
 
     pub(crate) fn access_order_q_node(&self) -> Option<KeyDeqNodeAo<K>> {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-//! Provides thread-safe, synchronous (blocking) cache implementations.
+//! Provides thread-safe, blocking cache implementations.
 
 use crate::common::{deque::DeqNode, u64_to_instant, AccessTime};
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,6 +1,6 @@
 //! Provides thread-safe, synchronous (blocking) cache implementations.
 
-use crate::common::{deque::DeqNode, AccessTime};
+use crate::common::{deque::DeqNode, u64_to_instant, AccessTime};
 
 use parking_lot::Mutex;
 use quanta::Instant;
@@ -42,11 +42,11 @@ impl<K> KeyHash<K> {
 
 pub(crate) struct KeyDate<K> {
     pub(crate) key: Arc<K>,
-    pub(crate) timestamp: Option<Arc<AtomicU64>>,
+    pub(crate) timestamp: Arc<AtomicU64>,
 }
 
 impl<K> KeyDate<K> {
-    pub(crate) fn new(key: Arc<K>, timestamp: Option<Arc<AtomicU64>>) -> Self {
+    pub(crate) fn new(key: Arc<K>, timestamp: Arc<AtomicU64>) -> Self {
         Self { key, timestamp }
     }
 }
@@ -54,11 +54,11 @@ impl<K> KeyDate<K> {
 pub(crate) struct KeyHashDate<K> {
     pub(crate) key: Arc<K>,
     pub(crate) hash: u64,
-    pub(crate) timestamp: Option<Arc<AtomicU64>>,
+    pub(crate) timestamp: Arc<AtomicU64>,
 }
 
 impl<K> KeyHashDate<K> {
-    pub(crate) fn new(kh: KeyHash<K>, timestamp: Option<Arc<AtomicU64>>) -> Self {
+    pub(crate) fn new(kh: KeyHash<K>, timestamp: Arc<AtomicU64>) -> Self {
         Self {
             key: kh.key,
             hash: kh.hash,
@@ -86,21 +86,17 @@ unsafe impl<K> Send for DeqNodes<K> {}
 
 pub(crate) struct ValueEntry<K, V> {
     pub(crate) value: V,
-    last_accessed: Option<Arc<AtomicU64>>,
-    last_modified: Option<Arc<AtomicU64>>,
+    last_accessed: Arc<AtomicU64>,
+    last_modified: Arc<AtomicU64>,
     nodes: Mutex<DeqNodes<K>>,
 }
 
 impl<K, V> ValueEntry<K, V> {
-    pub(crate) fn new(
-        value: V,
-        last_accessed: Option<Instant>,
-        last_modified: Option<Instant>,
-    ) -> Self {
+    pub(crate) fn new(value: V) -> Self {
         Self {
             value,
-            last_accessed: last_accessed.map(|ts| Arc::new(AtomicU64::new(ts.as_u64()))),
-            last_modified: last_modified.map(|ts| Arc::new(AtomicU64::new(ts.as_u64()))),
+            last_accessed: Arc::new(AtomicU64::new(std::u64::MAX)),
+            last_modified: Arc::new(AtomicU64::new(std::u64::MAX)),
             nodes: Mutex::new(DeqNodes {
                 access_order_q_node: None,
                 write_order_q_node: None,
@@ -124,11 +120,11 @@ impl<K, V> ValueEntry<K, V> {
         }
     }
 
-    pub(crate) fn raw_last_accessed(&self) -> Option<Arc<AtomicU64>> {
+    pub(crate) fn raw_last_accessed(&self) -> Arc<AtomicU64> {
         self.last_accessed.clone()
     }
 
-    pub(crate) fn raw_last_modified(&self) -> Option<Arc<AtomicU64>> {
+    pub(crate) fn raw_last_modified(&self) -> Arc<AtomicU64> {
         self.last_modified.clone()
     }
 
@@ -166,44 +162,24 @@ impl<K, V> ValueEntry<K, V> {
 impl<K, V> AccessTime for Arc<ValueEntry<K, V>> {
     #[inline]
     fn last_accessed(&self) -> Option<Instant> {
-        self.last_accessed
-            .as_ref()
-            .map(|ts| ts.load(Ordering::Relaxed))
-            .and_then(|ts| {
-                if ts == u64::MAX {
-                    None
-                } else {
-                    Some(unsafe { std::mem::transmute(ts) })
-                }
-            })
+        u64_to_instant(self.last_accessed.load(Ordering::Relaxed))
     }
 
     #[inline]
     fn set_last_accessed(&mut self, timestamp: Instant) {
-        if let Some(ts) = &self.last_accessed {
-            ts.store(timestamp.as_u64(), Ordering::Relaxed);
-        }
+        self.last_accessed
+            .store(timestamp.as_u64(), Ordering::Relaxed);
     }
 
     #[inline]
     fn last_modified(&self) -> Option<Instant> {
-        self.last_modified
-            .as_ref()
-            .map(|ts| ts.load(Ordering::Relaxed))
-            .and_then(|ts| {
-                if ts == u64::MAX {
-                    None
-                } else {
-                    Some(unsafe { std::mem::transmute(ts) })
-                }
-            })
+        u64_to_instant(self.last_modified.load(Ordering::Relaxed))
     }
 
     #[inline]
     fn set_last_modified(&mut self, timestamp: Instant) {
-        if let Some(ts) = &self.last_modified {
-            ts.store(timestamp.as_u64(), Ordering::Relaxed);
-        }
+        self.last_modified
+            .store(timestamp.as_u64(), Ordering::Relaxed);
     }
 }
 
@@ -220,48 +196,28 @@ impl<K> AccessTime for DeqNode<KeyDate<K>> {
 
     #[inline]
     fn last_modified(&self) -> Option<Instant> {
-        self.element
-            .timestamp
-            .as_ref()
-            .map(|ts| ts.load(Ordering::Relaxed))
-            .and_then(|ts| {
-                if ts == u64::MAX {
-                    None
-                } else {
-                    Some(unsafe { std::mem::transmute(ts) })
-                }
-            })
+        u64_to_instant(self.element.timestamp.load(Ordering::Relaxed))
     }
 
     #[inline]
     fn set_last_modified(&mut self, timestamp: Instant) {
-        if let Some(ts) = self.element.timestamp.as_ref() {
-            ts.store(timestamp.as_u64(), Ordering::Relaxed);
-        }
+        self.element
+            .timestamp
+            .store(timestamp.as_u64(), Ordering::Relaxed);
     }
 }
 
 impl<K> AccessTime for DeqNode<KeyHashDate<K>> {
     #[inline]
     fn last_accessed(&self) -> Option<Instant> {
-        self.element
-            .timestamp
-            .as_ref()
-            .map(|ts| ts.load(Ordering::Relaxed))
-            .and_then(|ts| {
-                if ts == u64::MAX {
-                    None
-                } else {
-                    Some(unsafe { std::mem::transmute(ts) })
-                }
-            })
+        u64_to_instant(self.element.timestamp.load(Ordering::Relaxed))
     }
 
     #[inline]
     fn set_last_accessed(&mut self, timestamp: Instant) {
-        if let Some(ts) = self.element.timestamp.as_ref() {
-            ts.store(timestamp.as_u64(), Ordering::Relaxed);
-        }
+        self.element
+            .timestamp
+            .store(timestamp.as_u64(), Ordering::Relaxed);
     }
 
     #[inline]
@@ -276,7 +232,7 @@ impl<K> AccessTime for DeqNode<KeyHashDate<K>> {
 }
 
 pub(crate) enum ReadOp<K, V> {
-    Hit(u64, Arc<ValueEntry<K, V>>, Option<Instant>),
+    Hit(u64, Arc<ValueEntry<K, V>>, Instant),
     Miss(u64),
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -116,7 +116,7 @@ impl<K, V> ValueEntry<K, V> {
         let last_modified = other.last_modified.clone();
         // To prevent this updated ValueEntry from being evicted by a expiration policy,
         // set the max value to the timestamps. They will be replaced with the real
-        // timestamps when applying writes. 
+        // timestamps when applying writes.
         last_accessed.store(std::u64::MAX, Ordering::Release);
         last_modified.store(std::u64::MAX, Ordering::Release);
         Self {

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -30,7 +30,7 @@ use std::{
 /// Cache entries are manually added using `insert` method, and are stored in the
 /// cache until either evicted or manually invalidated.
 ///
-/// Here's an example that reads and updates a cache by using multiple threads:
+/// Here's an example of reading and updating a cache by using multiple threads:
 ///
 /// ```rust
 /// use moka::sync::Cache;
@@ -282,6 +282,16 @@ where
         }
     }
 
+    /// Discards all cached values.
+    ///
+    /// This method returns immediately and a background thread will evict all the
+    /// cached values inserted before the time when this method was called. It is
+    /// guaranteed that the `get` method must not return these invalidated values
+    /// even if they have not been evicted.
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
     pub fn invalidate_all(&self) {
         self.base.invalidate_all();
     }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -282,6 +282,10 @@ where
         }
     }
 
+    pub fn invalidate_all(&self) {
+        self.base.invalidate_all();
+    }
+
     /// Returns the `max_capacity` of this cache.
     pub fn max_capacity(&self) -> usize {
         self.base.max_capacity()
@@ -442,6 +446,34 @@ mod tests {
 
         assert!(cache.get(&10).is_none());
         assert!(cache.get(&20).is_some());
+    }
+
+    #[test]
+    fn invalidate_all() {
+        let mut cache = Cache::new(100);
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cindy");
+        assert_eq!(cache.get(&"a"), Some("alice"));
+        assert_eq!(cache.get(&"b"), Some("bob"));
+        assert_eq!(cache.get(&"c"), Some("cindy"));
+        cache.sync();
+
+        cache.invalidate_all();
+        cache.sync();
+
+        cache.insert("d", "david");
+        cache.sync();
+
+        assert!(cache.get(&"a").is_none());
+        assert!(cache.get(&"b").is_none());
+        assert!(cache.get(&"c").is_none());
+        assert_eq!(cache.get(&"d"), Some("david"));
     }
 
     #[test]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -370,7 +370,7 @@ where
     K: Hash + Eq,
     S: BuildHasher + Clone,
 {
-    fn reconfigure_for_testing(&mut self) {
+    pub(crate) fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();
     }
 

--- a/src/sync/deques.rs
+++ b/src/sync/deques.rs
@@ -31,11 +31,11 @@ impl<K> Deques<K> {
     pub(crate) fn push_back_ao<V>(
         &mut self,
         region: CacheRegion,
-        kh: KeyHashDate<K>,
+        khd: KeyHashDate<K>,
         entry: &Arc<ValueEntry<K, V>>,
     ) {
         use CacheRegion::*;
-        let node = Box::new(DeqNode::new(region, kh));
+        let node = Box::new(DeqNode::new(region, khd));
         let node = match node.as_ref().region {
             Window => self.window.push_back(node),
             MainProbation => self.probation.push_back(node),
@@ -45,13 +45,13 @@ impl<K> Deques<K> {
         entry.set_access_order_q_node(Some(node));
     }
 
-    pub(crate) fn push_back_wo<V>(&mut self, kh: KeyDate<K>, entry: &Arc<ValueEntry<K, V>>) {
-        let node = Box::new(DeqNode::new(CacheRegion::WriteOrder, kh));
+    pub(crate) fn push_back_wo<V>(&mut self, kd: KeyDate<K>, entry: &Arc<ValueEntry<K, V>>) {
+        let node = Box::new(DeqNode::new(CacheRegion::WriteOrder, kd));
         let node = self.write_order.push_back(node);
         entry.set_write_order_q_node(Some(node));
     }
 
-    pub(crate) fn move_to_back_ao<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+    pub(crate) fn move_to_back_ao<V>(&mut self, entry: &Arc<ValueEntry<K, V>>) {
         use CacheRegion::*;
         if let Some(node) = entry.access_order_q_node() {
             let p = unsafe { node.as_ref() };
@@ -68,7 +68,25 @@ impl<K> Deques<K> {
         }
     }
 
-    pub(crate) fn move_to_back_wo<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+    pub(crate) fn move_to_back_ao_in_deque<V>(
+        deq_name: &str,
+        deq: &mut Deque<KeyHashDate<K>>,
+        entry: &Arc<ValueEntry<K, V>>,
+    ) {
+        if let Some(node) = entry.access_order_q_node() {
+            let p = unsafe { node.as_ref() };
+            if deq.contains(p) {
+                unsafe { deq.move_to_back(node) };
+            } else {
+                panic!(
+                    "move_to_back_ao_in_deque - node is not a member of {} deque. {:?}",
+                    deq_name, p,
+                )
+            }
+        }
+    }
+
+    pub(crate) fn move_to_back_wo<V>(&mut self, entry: &Arc<ValueEntry<K, V>>) {
         use CacheRegion::*;
         if let Some(node) = entry.write_order_q_node() {
             let p = unsafe { node.as_ref() };
@@ -79,7 +97,24 @@ impl<K> Deques<K> {
         }
     }
 
-    pub(crate) fn unlink_ao<V>(&mut self, entry: Arc<ValueEntry<K, V>>) {
+    pub(crate) fn move_to_back_wo_in_deque<V>(
+        deq: &mut Deque<KeyDate<K>>,
+        entry: &Arc<ValueEntry<K, V>>,
+    ) {
+        if let Some(node) = entry.write_order_q_node() {
+            let p = unsafe { node.as_ref() };
+            if deq.contains(p) {
+                unsafe { deq.move_to_back(node) };
+            } else {
+                panic!(
+                    "move_to_back_wo_in_deque - node is not a member of write_order deque. {:?}",
+                    p,
+                )
+            }
+        }
+    }
+
+    pub(crate) fn unlink_ao<V>(&mut self, entry: &Arc<ValueEntry<K, V>>) {
         if let Some(node) = entry.take_access_order_q_node() {
             self.unlink_node_ao(node);
         }
@@ -88,14 +123,14 @@ impl<K> Deques<K> {
     pub(crate) fn unlink_ao_from_deque<V>(
         deq_name: &str,
         deq: &mut Deque<KeyHashDate<K>>,
-        entry: Arc<ValueEntry<K, V>>,
+        entry: &Arc<ValueEntry<K, V>>,
     ) {
         if let Some(node) = entry.take_access_order_q_node() {
             unsafe { Self::unlink_node_ao_from_deque(deq_name, deq, node) };
         }
     }
 
-    pub(crate) fn unlink_wo<V>(deq: &mut Deque<KeyDate<K>>, entry: Arc<ValueEntry<K, V>>) {
+    pub(crate) fn unlink_wo<V>(deq: &mut Deque<KeyDate<K>>, entry: &Arc<ValueEntry<K, V>>) {
         if let Some(node) = entry.take_write_order_q_node() {
             Self::unlink_node_wo(deq, node);
         }

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -189,6 +189,23 @@ where
     }
 }
 
+// For unit tests.
+#[cfg(test)]
+impl<K, V, S> SegmentedCache<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Clone,
+{
+    fn reconfigure_for_testing(&mut self) {
+        let inner = Arc::get_mut(&mut self.inner)
+            .expect("There are other strong reference to self.inner Arc");
+
+        for segment in inner.segments.iter_mut() {
+            segment.reconfigure_for_testing();
+        }
+    }
+}
+
 struct Inner<K, V, S> {
     desired_capacity: usize,
     segments: Box<[Cache<K, V, S>]>,
@@ -275,11 +292,11 @@ mod tests {
 
     #[test]
     fn basic_single_thread() {
-        let cache = SegmentedCache::new(3, 1);
-        // cache.reconfigure_for_testing();
+        let mut cache = SegmentedCache::new(3, 1);
+        cache.reconfigure_for_testing();
 
         // Make the cache exterior immutable.
-        // let cache = cache;
+        let cache = cache;
 
         cache.insert("a", "alice");
         cache.insert("b", "bob");
@@ -323,11 +340,11 @@ mod tests {
     fn basic_multi_threads() {
         let num_threads = 4;
 
-        let cache = SegmentedCache::new(100, num_threads);
-        // cache.reconfigure_for_testing();
+        let mut cache = SegmentedCache::new(100, num_threads);
+        cache.reconfigure_for_testing();
 
         // Make the cache exterior immutable.
-        // let cache = cache;
+        let cache = cache;
 
         let handles = (0..num_threads)
             .map(|id| {
@@ -350,31 +367,31 @@ mod tests {
         assert!(cache.get(&20).is_some());
     }
 
-    // #[test]
-    // fn invalidate_all() {
-    //     let cache = SegmentedCache::new(3, 4);
-    //     // cache.reconfigure_for_testing();
+    #[test]
+    fn invalidate_all() {
+        let mut cache = SegmentedCache::new(100, 4);
+        cache.reconfigure_for_testing();
 
-    //     // Make the cache exterior immutable.
-    //     // let cache = cache;
+        // Make the cache exterior immutable.
+        let cache = cache;
 
-    //     cache.insert("a", "alice");
-    //     cache.insert("b", "bob");
-    //     cache.insert("c", "cindy");
-    //     assert_eq!(cache.get(&"a"), Some("alice"));
-    //     assert_eq!(cache.get(&"b"), Some("bob"));
-    //     assert_eq!(cache.get(&"c"), Some("cindy"));
-    //     cache.sync();
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cindy");
+        assert_eq!(cache.get(&"a"), Some("alice"));
+        assert_eq!(cache.get(&"b"), Some("bob"));
+        assert_eq!(cache.get(&"c"), Some("cindy"));
+        cache.sync();
 
-    //     cache.invalidate_all();
-    //     cache.sync();
+        cache.invalidate_all();
+        cache.sync();
 
-    //     cache.insert("d", "david");
-    //     cache.sync();
+        cache.insert("d", "david");
+        cache.sync();
 
-    //     assert!(cache.get(&"a").is_none());
-    //     assert!(cache.get(&"b").is_none());
-    //     assert!(cache.get(&"c").is_none());
-    //     assert_eq!(cache.get(&"d"), Some("david"));
-    // }
+        assert!(cache.get(&"a").is_none());
+        assert!(cache.get(&"b").is_none());
+        assert!(cache.get(&"c").is_none());
+        assert_eq!(cache.get(&"d"), Some("david"));
+    }
 }

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -141,6 +141,12 @@ where
         self.inner.select(hash).invalidate(key);
     }
 
+    pub fn invalidate_all(&self) {
+        for segment in self.inner.segments.iter() {
+            segment.invalidate_all();
+        }
+    }
+
     /// Returns the `max_capacity` of this cache.
     pub fn max_capacity(&self) -> usize {
         self.inner.desired_capacity
@@ -273,7 +279,7 @@ mod tests {
         // cache.reconfigure_for_testing();
 
         // Make the cache exterior immutable.
-        let cache = cache;
+        // let cache = cache;
 
         cache.insert("a", "alice");
         cache.insert("b", "bob");
@@ -321,7 +327,7 @@ mod tests {
         // cache.reconfigure_for_testing();
 
         // Make the cache exterior immutable.
-        let cache = cache;
+        // let cache = cache;
 
         let handles = (0..num_threads)
             .map(|id| {
@@ -343,4 +349,32 @@ mod tests {
         assert!(cache.get(&10).is_none());
         assert!(cache.get(&20).is_some());
     }
+
+    // #[test]
+    // fn invalidate_all() {
+    //     let cache = SegmentedCache::new(3, 4);
+    //     // cache.reconfigure_for_testing();
+
+    //     // Make the cache exterior immutable.
+    //     // let cache = cache;
+
+    //     cache.insert("a", "alice");
+    //     cache.insert("b", "bob");
+    //     cache.insert("c", "cindy");
+    //     assert_eq!(cache.get(&"a"), Some("alice"));
+    //     assert_eq!(cache.get(&"b"), Some("bob"));
+    //     assert_eq!(cache.get(&"c"), Some("cindy"));
+    //     cache.sync();
+
+    //     cache.invalidate_all();
+    //     cache.sync();
+
+    //     cache.insert("d", "david");
+    //     cache.sync();
+
+    //     assert!(cache.get(&"a").is_none());
+    //     assert!(cache.get(&"b").is_none());
+    //     assert!(cache.get(&"c").is_none());
+    //     assert_eq!(cache.get(&"d"), Some("david"));
+    // }
 }

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -1,3 +1,5 @@
+//! Provides a *not* thread-safe, blocking cache implementation.
+
 pub(crate) mod builder;
 pub(crate) mod cache;
 mod deques;

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -49,8 +49,8 @@ where
     K: Eq + Hash,
     V: Clone,
 {
-    /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
-    /// `SegmentedCache` holding up to `max_capacity` entries.
+    /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
+    /// up to `max_capacity` entries.
     pub fn new(max_capacity: usize) -> Self {
         Self {
             max_capacity,
@@ -62,9 +62,6 @@ where
     }
 
     /// Builds a `Cache<K, V>`.
-    ///
-    /// If you want to build a `SegmentedCache<K, V>`, call `segments` method before
-    /// calling this method.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
         Cache::with_everything(
@@ -77,9 +74,6 @@ where
     }
 
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
-    ///
-    /// If you want to build a `SegmentedCache<K, V>`, call `segments` method  before
-    /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
         S: BuildHasher + Clone,

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -47,7 +47,6 @@ pub struct CacheBuilder<C> {
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
     K: Eq + Hash,
-    V: Clone,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
     /// up to `max_capacity` entries.

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -26,7 +26,7 @@ type CacheStore<K, V, S> = std::collections::HashMap<Rc<K>, ValueEntry<K, V>, S>
 ///
 /// # Characteristic difference between `unsync` and `sync`/`future` caches
 ///
-/// If you use a cache from a single threaded application, `unsync::Cache` may
+/// If you use a cache from a single thread application, `unsync::Cache` may
 /// outperform other caches for updates and retrievals because other caches have some
 /// overhead on syncing internal data structures between threads.
 ///

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -163,6 +163,11 @@ where
         }
     }
 
+    pub fn invalidate_all(&mut self) {
+        self.cache.clear();
+        self.deques.clear();
+    }
+
     pub fn max_capacity(&self) -> usize {
         self.max_capacity
     }
@@ -218,9 +223,7 @@ where
         now: Instant,
     ) -> bool {
         if let (Some(ts), Some(tti)) = (entry.last_accessed(), time_to_idle) {
-            if ts + *tti <= now {
-                return true;
-            }
+            return ts + *tti <= now;
         }
         false
     }
@@ -232,9 +235,7 @@ where
         now: Instant,
     ) -> bool {
         if let (Some(ts), Some(ttl)) = (entry.last_modified(), time_to_live) {
-            if ts + *ttl <= now {
-                return true;
-            }
+            return ts + *ttl <= now;
         }
         false
     }
@@ -506,6 +507,27 @@ mod tests {
 
         cache.invalidate(&"b");
         assert_eq!(cache.get(&"b"), None);
+    }
+
+    #[test]
+    fn invalidate_all() {
+        let mut cache = Cache::new(100);
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cindy");
+        assert_eq!(cache.get(&"a"), Some(&"alice"));
+        assert_eq!(cache.get(&"b"), Some(&"bob"));
+        assert_eq!(cache.get(&"c"), Some(&"cindy"));
+
+        cache.invalidate_all();
+
+        cache.insert("d", "david");
+
+        assert!(cache.get(&"a").is_none());
+        assert!(cache.get(&"b").is_none());
+        assert!(cache.get(&"c").is_none());
+        assert_eq!(cache.get(&"d"), Some(&"david"));
     }
 
     #[test]

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -123,7 +123,6 @@ pub struct Cache<K, V, S = RandomState> {
 impl<K, V> Cache<K, V, RandomState>
 where
     K: Hash + Eq,
-    V: Clone,
 {
     /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity` entries.
     ///
@@ -143,7 +142,6 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq,
-    V: Clone,
     S: BuildHasher + Clone,
 {
     pub(crate) fn with_everything(
@@ -272,7 +270,6 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq,
-    V: Clone,
     S: BuildHasher + Clone,
 {
     #[inline]

--- a/src/unsync/deques.rs
+++ b/src/unsync/deques.rs
@@ -22,6 +22,13 @@ impl<K> Default for Deques<K> {
 }
 
 impl<K> Deques<K> {
+    pub(crate) fn clear(&mut self) {
+        self.window = Deque::new(CacheRegion::Window);
+        self.probation = Deque::new(CacheRegion::MainProbation);
+        self.protected = Deque::new(CacheRegion::MainProtected);
+        self.write_order = Deque::new(CacheRegion::WriteOrder);
+    }
+
     pub(crate) fn push_back_ao<V>(
         &mut self,
         region: CacheRegion,


### PR DESCRIPTION
This pull request adds the `invalidate_all` method to all `sync`, `future` and `unsync` caches. The `invalidate_all` method was requested in #10.

- Add `invalidate_all` method.
- Update internal `handle_upsert` and `evict` methods to prevent problems including segfault caused by race conditions between the sync/eviction thread and client writes (especially `invalidate`).
- Bump the version to 0.3.0.
- Upgrade a dependency: once_cell 1.5 -> 1.7.