### PR TITLE
Add the `invalidate_entries_if` method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,11 +21,13 @@
         "mpsc",
         "nanos",
         "nocapture",
+        "preds",
         "runtimes",
         "rustdoc",
         "rustfmt",
         "semver",
         "structs",
+        "thiserror",
         "toolchain",
         "unsync",
         "usize"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "Kawano",
         "MSRV",
         "Moka",
+        "RUSTFLAGS",
         "Ristretto",
         "Tatsuya",
         "Upsert",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "mpsc",
         "nanos",
         "nocapture",
+        "peekable",
         "preds",
         "runtimes",
         "rustdoc",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka &mdash; Change Log
 
+## Version 0.4.0
+
+### Added
+
+- Add `invalidate_entries_if` method to `sync`, `future` and `unsync` caches.
+  ([#12][gh-pull-0012]) &mdash; **IN-PROGRESS**
+
+
 ## Version 0.3.0
 
 ### Added
@@ -43,6 +51,7 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
+[gh-pull-0012]: https://github.com/moka-rs/moka/pull/12/
 [gh-pull-0011]: https://github.com/moka-rs/moka/pull/11/
 [gh-pull-0009]: https://github.com/moka-rs/moka/pull/9/
 [gh-pull-0007]: https://github.com/moka-rs/moka/pull/7/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - **Breaking change**: Now `sync::{Cache, SegmentedCache}` and `future::Cache`
-  require `Send`, `Sync` and `'static` bounds for the generic parameters `K` (key),
+  require `Send`, `Sync` and `'static` for the generic parameters `K` (key),
   `V` (value) and `S` (hasher state). This is necessary to prevent potential
   undefined behaviors in applications using single-threaded async runtime such as
   Actix-rt. ([#19][gh-pull-0019])
@@ -13,7 +13,7 @@
 ### Added
 
 - Add `invalidate_entries_if` method to `sync`, `future` and `unsync` caches.
-  ([#12][gh-pull-0012]) &mdash; **IN-PROGRESS**
+  ([#12][gh-pull-0012])
 
 ## Version 0.3.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,10 @@ crossbeam-channel = "0.5"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"
-# v0.7.1 or newer should be used as v0.7.0 will not compile on non-x86_64 platforms.
-# https://github.com/metrics-rs/quanta/pull/38
-quanta = "0.7.1"
+quanta = "0.8"
 scheduled-thread-pool = "0.2"
 thiserror = "1.0"
+uuid = { version = "0.8", features = ["v4"] }
 
 # Optional dependencies
 async-io = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT OR Apache-2.0"
 # homepage = "https://"
 documentation = "https://docs.rs/moka/"
 repository = "https://github.com/moka-rs/moka"
-keywords = ["concurrent", "cache"]
-categories = ["concurrency", "caching"]
+keywords = ["cache", "concurrent"]
+categories = ["caching", "concurrency"]
 readme = "README.md"
 exclude = [".devcontainer", ".github", ".vscode"]
 build = "build.rs"
@@ -33,6 +33,7 @@ parking_lot = "0.11"
 # https://github.com/metrics-rs/quanta/pull/38
 quanta = "0.7.1"
 scheduled-thread-pool = "0.2"
+thiserror = "1.0"
 
 # Optional dependencies
 async-io = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossbeam-channel = "0.5"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"
-quanta = "0.8"
+quanta = "0.9"
 scheduled-thread-pool = "0.2"
 thiserror = "1.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ exceeded.
 [deps-rs-badge]: https://deps.rs/repo/github/moka-rs/moka/status.svg
 [coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=master
 [license-badge]: https://img.shields.io/crates/l/moka.svg
+[fossa-badge]: https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield
 
 [gh-actions]: https://github.com/moka-rs/moka/actions?query=workflow%3ACI
 [crate]: https://crates.io/crates/moka
 [docs]: https://docs.rs/moka
 [deps-rs]: https://deps.rs/repo/github/moka-rs/moka
 [coveralls]: https://coveralls.io/github/moka-rs/moka?branch=master
+[fossa]: https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 [ristretto-git]: https://github.com/dgraph-io/ristretto
@@ -333,6 +335,18 @@ change.
 -->
 
 
+## Developing Moka
+
+**Running All Tests**
+
+To run all tests including `futures` feature and doc tests on the README, use the
+following command:
+
+```console
+$ RUSTFLAGS='--cfg skeptic' cargo test --all-features
+```
+
+
 ## Road Map
 
 - [x] `async` optimized caches. (`v0.2.0`)
@@ -360,6 +374,7 @@ at your option.
 
 See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE) for details.
 
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_large)
 
 <!--
 
@@ -367,6 +382,3 @@ MEMO:
 - Column width is 85. (Emacs: C-x f)
 
 -->
-
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-moka = "0.3"
+moka = "0.4"
 ```
 
 To use the asynchronous cache, enable a crate feature called "future".
 
 ```toml
 [dependencies]
-moka = { version = "0.3", features = ["future"] }
+moka = { version = "0.4", features = ["future"] }
 ```
 
 
@@ -161,7 +161,7 @@ Here is a similar program to the previous example, but using asynchronous cache 
 // Cargo.toml
 //
 // [dependencies]
-// moka = { version = "0.3", features = ["future"] }
+// moka = { version = "0.4", features = ["future"] }
 // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 // futures = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ change.
 
 **Running All Tests**
 
-To run all tests including `futures` feature and doc tests on the README, use the
+To run all tests including `future` feature and doc tests on the README, use the
 following command:
 
 ```console

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,7 @@
 use quanta::Instant;
 
 pub(crate) mod deque;
+pub(crate) mod error;
 pub(crate) mod frequency_sketch;
 pub(crate) mod thread_pool;
 pub(crate) mod unsafe_weak_pointer;

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -238,6 +238,7 @@ impl<T> Deque<T> {
         self.len -= 1;
     }
 
+    #[allow(unused)]
     pub(crate) fn reset_cursor(&mut self) {
         self.cursor = None;
     }

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -103,6 +103,10 @@ impl<T> Deque<T> {
         &self.region
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
     pub(crate) fn contains(&self, node: &DeqNode<T>) -> bool {
         self.region == node.region && (node.prev.is_some() || self.is_head(node))
     }
@@ -303,11 +307,6 @@ impl<T> Deque<T> {
                 self.cursor = None;
             }
         }
-    }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.len
     }
 }
 

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -121,7 +121,7 @@ impl<T> Deque<T> {
             if self.is_at_cursor(node.as_ref()) {
                 self.advance_cursor();
             }
-    
+
             let mut node = Box::from_raw(node.as_ptr());
             self.head = node.next;
 
@@ -639,7 +639,7 @@ mod tests {
         // Next will be "b", but we call pop_front twice to remove "a" and "b".
         deque.pop_front(); // "a"
         deque.pop_front(); // "b"
-        // Now, next should be "c".
+                           // Now, next should be "c".
         assert_eq!((&mut deque).next(), Some(&"c".into()));
         assert!((&mut deque).next().is_none());
 

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,0 +1,11 @@
+#[derive(thiserror::Error, Debug)]
+pub enum PredicateRegistrationError {
+    #[error(
+        "Support for invalidation closures is disabled. \
+    Please enable it by calling the support_invalidation_closures method \
+    of the builder at the cache creation time"
+    )]
+    InvalidationClosuresDisabled,
+    #[error("No space left in the predicate registry")]
+    NoSpaceLeft,
+}

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -2,7 +2,7 @@
 pub enum PredicateRegistrationError {
     #[error(
         "Support for invalidation closures is disabled. \
-    Please enable it by calling the support_invalidation_closures method \
+    Please enable it by calling the enable_invalidation_with_closures method \
     of the builder at the cache creation time"
     )]
     InvalidationClosuresDisabled,

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -4,17 +4,17 @@
 /// [invalidate-if]: ./sync/struct.Cache.html#method.invalidate_entries_if
 #[derive(thiserror::Error, Debug)]
 pub enum PredicateError {
-    /// This cache does not have a necessary configuration enabled for supporting
-    /// invalidation closures.
+    /// This cache does not have a necessary configuration enabled to support
+    /// invalidating entries with a closure.
     ///
-    /// You can enable the configuration by calling the
-    /// [`CacheBuilder::enable_invalidation_with_closures`][enable-invalidation-closures]
+    /// To enable the configuration, call
+    /// [`CacheBuilder::support_invalidation_closures`][support-invalidation-closures]
     /// method at the cache creation time.
     ///
-    /// [enable-invalidation-closures]: ./sync/struct.CacheBuilder.html#method.enable_invalidation_with_closures
+    /// [support-invalidation-closures]: ./sync/struct.CacheBuilder.html#method.support_invalidation_closures
     #[error(
         "Support for invalidation closures is disabled in this cache. \
-    Please enable it by calling the enable_invalidation_with_closures method \
+    Please enable it by calling the support_invalidation_closures method \
     of the builder at the cache creation time"
     )]
     InvalidationClosuresDisabled,

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,11 +1,21 @@
+/// The error type for the functionalities around
+/// [`Cache#invalidate_entries_if`][invalidate-if] method.
+///
+/// [invalidate-if]: ./sync/struct.Cache.html#method.invalidate_entries_if
 #[derive(thiserror::Error, Debug)]
-pub enum PredicateRegistrationError {
+pub enum PredicateError {
+    /// This cache does not have a necessary configuration enabled for supporting
+    /// invalidation closures.
+    ///
+    /// You can enable the configuration by calling the
+    /// [`CacheBuilder::enable_invalidation_with_closures`][enable-invalidation-closures]
+    /// method at the cache creation time.
+    ///
+    /// [enable-invalidation-closures]: ./sync/struct.CacheBuilder.html#method.enable_invalidation_with_closures
     #[error(
-        "Support for invalidation closures is disabled. \
+        "Support for invalidation closures is disabled in this cache. \
     Please enable it by calling the enable_invalidation_with_closures method \
     of the builder at the cache creation time"
     )]
     InvalidationClosuresDisabled,
-    #[error("No space left in the predicate registry")]
-    NoSpaceLeft,
 }

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -42,6 +42,7 @@ pub struct CacheBuilder<C> {
     // num_segments: Option<usize>,
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
+    invalidator_enabled: bool,
     cache_type: PhantomData<C>,
 }
 
@@ -59,6 +60,7 @@ where
             // num_segments: None,
             time_to_live: None,
             time_to_idle: None,
+            invalidator_enabled: false,
             cache_type: PhantomData::default(),
         }
     }
@@ -72,6 +74,7 @@ where
             build_hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 
@@ -86,6 +89,7 @@ where
             hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 }
@@ -117,6 +121,13 @@ impl<C> CacheBuilder<C> {
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),
+            ..self
+        }
+    }
+
+    pub fn support_invalidation_closures(self) -> Self {
+        Self {
+            invalidator_enabled: true,
             ..self
         }
     }

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -48,7 +48,7 @@ pub struct CacheBuilder<C> {
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
     K: Eq + Hash + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
     /// up to `max_capacity` entries.

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -78,7 +78,7 @@ where
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
-        S: BuildHasher + Clone + Send + 'static,
+        S: BuildHasher + Clone + Send + Sync + 'static,
     {
         Cache::with_everything(
             self.max_capacity,

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -132,7 +132,7 @@ impl<C> CacheBuilder<C> {
     /// `invalidate_entries_if` method.
     ///
     /// [cache-invalidate-if]: ./struct.Cache.html#method.invalidate_entries_if
-    pub fn enable_invalidation_with_closures(self) -> Self {
+    pub fn support_invalidation_closures(self) -> Self {
         Self {
             invalidator_enabled: true,
             ..self

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -125,7 +125,14 @@ impl<C> CacheBuilder<C> {
         }
     }
 
-    pub fn support_invalidation_closures(self) -> Self {
+    /// Enables support for [Cache::invalidate_entries_if][cache-invalidate-if]
+    /// method.
+    ///
+    /// The cache will maintain additional internal data structures to support
+    /// `invalidate_entries_if` method.
+    ///
+    /// [cache-invalidate-if]: ./struct.Cache.html#method.invalidate_entries_if
+    pub fn enable_invalidation_with_closures(self) -> Self {
         Self {
             invalidator_enabled: true,
             ..self

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -47,8 +47,8 @@ pub struct CacheBuilder<C> {
 
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
-    K: Eq + Hash,
-    V: Clone,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + 'static,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
     /// up to `max_capacity` entries.
@@ -78,7 +78,7 @@ where
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
-        S: BuildHasher + Clone,
+        S: BuildHasher + Clone + Send + 'static,
     {
         Cache::with_everything(
             self.max_capacity,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -209,8 +209,8 @@ where
 
 impl<K, V> Cache<K, V, RandomState>
 where
-    K: Hash + Eq,
-    V: Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + 'static,
 {
     /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity` entries.
     ///
@@ -226,9 +226,9 @@ where
 
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     pub(crate) fn with_everything(
         max_capacity: usize,
@@ -366,8 +366,9 @@ where
 
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     fn sync(&self) {
         self.base.inner.sync(MAX_SYNC_REPEATS);
@@ -377,9 +378,9 @@ where
 // private methods
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     async fn insert_with_hash(&self, key: K, hash: u64, value: V) {
         let op = self.base.do_insert_with_hash(key, hash, value);
@@ -444,8 +445,9 @@ where
 #[cfg(test)]
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -346,6 +346,31 @@ where
         self.base.invalidate_all();
     }
 
+    /// Discards cached values that satisfy a predicate.
+    ///
+    /// `invalidate_entries_if` takes a closure that returns `true` or `false`. This
+    /// method returns immediately and a background thread will apply the closure to
+    /// each value inserted before the time when `invalidate_entries_if` was
+    /// called. If the closure returns `true` on a value, that value will be evicted
+    /// from the cache.
+    ///
+    /// Also the `get` method will apply the closure to a value to determine if it
+    /// has been invalidated. Therefore, it is guaranteed that the `get` method must
+    /// not return invalidated values.
+    ///
+    /// Note that you must call
+    /// [`CacheBuilder::enable_invalidation_with_closures`][enable-invalidation-closures]
+    /// at the cache creation time as the cache will maintain additional internal
+    /// data structures to support this method. Otherwise, calling this method will
+    /// fail with a
+    /// [`PredicateRegistrationError::InvalidationClosuresDisabled`][invalidation-disabled-error].
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
+    ///
+    /// [enable-invalidation-closures]: ./struct.CacheBuilder.html#method.enable_invalidation_with_closures
+    /// [invalidation-disabled-error]: ../enum.PredicateRegistrationError.html#variant.InvalidationClosuresDisabled
     pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<u64, PredicateRegistrationError>
     where
         F: Fn(&K, &V) -> bool + Send + Sync + 'static,
@@ -638,7 +663,7 @@ mod tests {
         use std::collections::HashSet;
 
         let mut cache = CacheBuilder::new(100)
-            .support_invalidation_closures()
+            .enable_invalidation_with_closures()
             .build();
         cache.reconfigure_for_testing();
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -354,7 +354,7 @@ where
     /// not return invalidated values.
     ///
     /// Note that you must call
-    /// [`CacheBuilder::enable_invalidation_with_closures`][enable-invalidation-closures]
+    /// [`CacheBuilder::support_invalidation_closures`][support-invalidation-closures]
     /// at the cache creation time as the cache will maintain additional internal
     /// data structures to support this method. Otherwise, calling this method will
     /// fail with a
@@ -364,7 +364,7 @@ where
     /// popularity estimator of keys so that it retains the client activities of
     /// trying to retrieve an item.
     ///
-    /// [enable-invalidation-closures]: ./struct.CacheBuilder.html#method.enable_invalidation_with_closures
+    /// [support-invalidation-closures]: ./struct.CacheBuilder.html#method.support_invalidation_closures
     /// [invalidation-disabled-error]: ../enum.PredicateError.html#variant.InvalidationClosuresDisabled
     pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<PredicateId, PredicateError>
     where
@@ -658,7 +658,7 @@ mod tests {
         use std::collections::HashSet;
 
         let mut cache = CacheBuilder::new(100)
-            .enable_invalidation_with_closures()
+            .support_invalidation_closures()
             .build();
         cache.reconfigure_for_testing();
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -210,7 +210,7 @@ where
 impl<K, V> Cache<K, V, RandomState>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity` entries.
     ///
@@ -227,7 +227,7 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     pub(crate) fn with_everything(
@@ -367,7 +367,7 @@ where
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: 'static,
+    V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     fn sync(&self) {
@@ -379,7 +379,7 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     async fn insert_with_hash(&self, key: K, hash: u64, value: V) {
@@ -446,7 +446,7 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: 'static,
+    V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     fn reconfigure_for_testing(&mut self) {

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -228,7 +228,7 @@ impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn with_everything(
         max_capacity: usize,
@@ -368,7 +368,7 @@ impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self) {
         self.base.inner.sync(MAX_SYNC_REPEATS);
@@ -380,7 +380,7 @@ impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     async fn insert_with_hash(&self, key: K, hash: u64, value: V) {
         let op = self.base.do_insert_with_hash(key, hash, value);
@@ -447,7 +447,7 @@ impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -3,9 +3,9 @@ use crate::{
     sync::{
         base_cache::{BaseCache, HouseKeeperArc, MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
         housekeeper::InnerSync,
-        WriteOp,
+        PredicateId, WriteOp,
     },
-    PredicateRegistrationError,
+    PredicateError,
 };
 
 use crossbeam_channel::{Sender, TrySendError};
@@ -363,15 +363,15 @@ where
     /// at the cache creation time as the cache will maintain additional internal
     /// data structures to support this method. Otherwise, calling this method will
     /// fail with a
-    /// [`PredicateRegistrationError::InvalidationClosuresDisabled`][invalidation-disabled-error].
+    /// [`PredicateError::InvalidationClosuresDisabled`][invalidation-disabled-error].
     ///
     /// Like the `invalidate` method, this method does not clear the historic
     /// popularity estimator of keys so that it retains the client activities of
     /// trying to retrieve an item.
     ///
     /// [enable-invalidation-closures]: ./struct.CacheBuilder.html#method.enable_invalidation_with_closures
-    /// [invalidation-disabled-error]: ../enum.PredicateRegistrationError.html#variant.InvalidationClosuresDisabled
-    pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<u64, PredicateRegistrationError>
+    /// [invalidation-disabled-error]: ../enum.PredicateError.html#variant.InvalidationClosuresDisabled
+    pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<PredicateId, PredicateError>
     where
         F: Fn(&K, &V) -> bool + Send + Sync + 'static,
     {

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -49,7 +49,7 @@ use std::{
 /// // Cargo.toml
 /// //
 /// // [dependencies]
-/// // moka = { version = "0.3", features = ["future"] }
+/// // moka = { version = "0.4", features = ["future"] }
 /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 /// // futures = "0.3"
 ///

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -345,17 +345,17 @@ where
     ///
     /// `invalidate_entries_if` takes a closure that returns `true` or `false`. This
     /// method returns immediately and a background thread will apply the closure to
-    /// each value inserted before the time when `invalidate_entries_if` was
+    /// each cached value inserted before the time when `invalidate_entries_if` was
     /// called. If the closure returns `true` on a value, that value will be evicted
     /// from the cache.
     ///
     /// Also the `get` method will apply the closure to a value to determine if it
-    /// has been invalidated. Therefore, it is guaranteed that the `get` method must
-    /// not return invalidated values.
+    /// should have been invalidated. Therefore, it is guaranteed that the `get`
+    /// method must not return invalidated values.
     ///
     /// Note that you must call
     /// [`CacheBuilder::support_invalidation_closures`][support-invalidation-closures]
-    /// at the cache creation time as the cache will maintain additional internal
+    /// at the cache creation time as the cache needs to maintain additional internal
     /// data structures to support this method. Otherwise, calling this method will
     /// fail with a
     /// [`PredicateError::InvalidationClosuresDisabled`][invalidation-disabled-error].
@@ -481,6 +481,18 @@ where
     V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
+    fn is_table_empty(&self) -> bool {
+        self.table_size() == 0
+    }
+
+    fn table_size(&self) -> usize {
+        self.base.table_size()
+    }
+
+    fn invalidation_predicate_count(&self) -> usize {
+        self.base.invalidation_predicate_count()
+    }
+
     fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();
     }
@@ -682,7 +694,7 @@ mod tests {
 
         let names = ["alice", "alex"].iter().cloned().collect::<HashSet<_>>();
         cache.invalidate_entries_if(move |_k, &v| names.contains(v))?;
-        assert_eq!(cache.base.invalidation_predicate_count(), 1);
+        assert_eq!(cache.invalidation_predicate_count(), 1);
 
         mock.increment(Duration::from_secs(5)); // 10 secs from the start.
 
@@ -699,14 +711,14 @@ mod tests {
         assert_eq!(cache.get(&1), Some("bob"));
         // This should survive as it was inserted after calling invalidate_entries_if.
         assert_eq!(cache.get(&3), Some("alice"));
-        assert_eq!(cache.base.len(), 2);
-        assert_eq!(cache.base.invalidation_predicate_count(), 0);
+        assert_eq!(cache.table_size(), 2);
+        assert_eq!(cache.invalidation_predicate_count(), 0);
 
         mock.increment(Duration::from_secs(5)); // 15 secs from the start.
 
         cache.invalidate_entries_if(|_k, &v| v == "alice")?;
         cache.invalidate_entries_if(|_k, &v| v == "bob")?;
-        assert_eq!(cache.base.invalidation_predicate_count(), 2);
+        assert_eq!(cache.invalidation_predicate_count(), 2);
 
         // Run the invalidation task and wait for it to finish. (TODO: Need a better way than sleeping)
         cache.sync(); // To submit the invalidation task.
@@ -716,8 +728,8 @@ mod tests {
 
         assert!(cache.get(&1).is_none());
         assert!(cache.get(&3).is_none());
-        assert_eq!(cache.base.len(), 0);
-        assert_eq!(cache.base.invalidation_predicate_count(), 0);
+        assert_eq!(cache.table_size(), 0);
+        assert_eq!(cache.invalidation_predicate_count(), 0);
 
         Ok(())
     }
@@ -748,18 +760,18 @@ mod tests {
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
-        assert!(cache.base.is_empty());
+        assert!(cache.is_table_empty());
 
         cache.insert("b", "bob").await;
         cache.sync();
 
-        assert_eq!(cache.base.len(), 1);
+        assert_eq!(cache.table_size(), 1);
 
         mock.increment(Duration::from_secs(5)); // 15 secs.
         cache.sync();
 
         assert_eq!(cache.get(&"b"), Some("bob"));
-        assert_eq!(cache.base.len(), 1);
+        assert_eq!(cache.table_size(), 1);
 
         cache.insert("b", "bill").await;
         cache.sync();
@@ -768,14 +780,14 @@ mod tests {
         cache.sync();
 
         assert_eq!(cache.get(&"b"), Some("bill"));
-        assert_eq!(cache.base.len(), 1);
+        assert_eq!(cache.table_size(), 1);
 
         mock.increment(Duration::from_secs(5)); // 25 secs
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
-        assert!(cache.base.is_empty());
+        assert!(cache.is_table_empty());
     }
 
     #[tokio::test]
@@ -806,20 +818,20 @@ mod tests {
         cache.insert("b", "bob").await;
         cache.sync();
 
-        assert_eq!(cache.base.len(), 2);
+        assert_eq!(cache.table_size(), 2);
 
         mock.increment(Duration::from_secs(5)); // 15 secs.
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), Some("bob"));
-        assert_eq!(cache.base.len(), 1);
+        assert_eq!(cache.table_size(), 1);
 
         mock.increment(Duration::from_secs(10)); // 25 secs
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
-        assert!(cache.base.is_empty());
+        assert!(cache.is_table_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,3 +157,5 @@ pub mod sync;
 pub mod unsync;
 
 pub(crate) mod common;
+
+pub use common::error::PredicateRegistrationError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,4 +158,4 @@ pub mod unsync;
 
 pub(crate) mod common;
 
-pub use common::error::PredicateRegistrationError;
+pub use common::error::PredicateError;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -92,10 +92,7 @@ struct DeqNodes<K> {
     write_order_q_node: Option<KeyDeqNodeWo<K>>,
 }
 
-#[cfg(feature = "future")]
-// Multi-threaded async runtimes require ValueEntry to be Send, but it will
-// not be without this `unsafe impl`. This is because DeqNodes have NonNull
-// pointers.
+// We need this `unsafe impl` as DeqNodes have NonNull pointers.
 unsafe impl<K> Send for DeqNodes<K> {}
 
 pub(crate) struct ValueEntry<K, V> {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -59,6 +59,10 @@ impl<K> KeyDate<K> {
     pub(crate) fn new(key: Arc<K>, timestamp: Arc<AtomicU64>) -> Self {
         Self { key, timestamp }
     }
+
+    pub(crate) fn timestamp(&self) -> Option<Instant> {
+        u64_to_instant(self.timestamp.load(Ordering::Acquire))
+    }
 }
 
 pub(crate) struct KeyHashDate<K> {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -24,6 +24,16 @@ pub use builder::CacheBuilder;
 pub use cache::Cache;
 pub use segment::SegmentedCache;
 
+/// The type of the unique ID to identify a predicate used by
+/// [`Cache#invalidate_entries_if`][invalidate-if] method.
+///
+/// A `PredicateId` is a `String` of UUID (version 4).
+///
+/// [invalidate-if]: ./struct.Cache.html#method.invalidate_entries_if
+pub type PredicateId = String;
+
+pub(crate) type PredicateIdStr<'a> = &'a str;
+
 /// Provides extra methods that will be useful for testing.
 pub trait ConcurrentCacheExt<K, V> {
     /// Performs any pending maintenance operations needed by the cache.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -17,6 +17,7 @@ mod builder;
 pub(crate) mod cache;
 pub(crate) mod deques;
 pub(crate) mod housekeeper;
+mod invalidator;
 mod segment;
 
 pub use builder::CacheBuilder;

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -511,9 +511,9 @@ where
                 || self.write_op_ch.len() >= WRITE_LOG_FLUSH_POINT;
         }
 
-            if self.has_expiry() || self.has_valid_after() {
-                self.evict(&mut deqs, EVICTION_BATCH_SIZE);
-            }
+        if self.has_expiry() || self.has_valid_after() {
+            self.evict(&mut deqs, EVICTION_BATCH_SIZE);
+        }
 
         if let Some(inv) = &self.invalidator {
             if !inv.is_empty() {

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -306,6 +306,9 @@ where
     }
 }
 
+//
+// for testing
+//
 #[cfg(test)]
 impl<K, V, S> BaseCache<K, V, S>
 where
@@ -319,6 +322,10 @@ where
 
     pub(crate) fn len(&self) -> usize {
         self.inner.len()
+    }
+
+    pub(crate) fn invalidation_predicate_count(&self) -> usize {
+        self.inner.invalidation_predicate_count()
     }
 
     pub(crate) fn reconfigure_for_testing(&mut self) {
@@ -965,6 +972,14 @@ where
 {
     fn len(&self) -> usize {
         self.cache.len()
+    }
+
+    fn invalidation_predicate_count(&self) -> usize {
+        self.invalidator
+            .lock()
+            .as_ref()
+            .map(|inv| inv.predicate_count())
+            .unwrap_or(0)
     }
 
     fn set_expiration_clock(&self, clock: Option<quanta::Clock>) {

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -2,7 +2,7 @@ use super::{
     deques::Deques,
     housekeeper::{Housekeeper, InnerSync, SyncPace},
     invalidator::{GetOrRemoveEntry, InvalidationResult, Invalidator, KeyDateLite, PredicateFun},
-    KeyDate, KeyHash, KeyHashDate, ReadOp, ValueEntry, WriteOp,
+    KeyDate, KeyHash, KeyHashDate, PredicateId, ReadOp, ValueEntry, WriteOp,
 };
 use crate::{
     common::{
@@ -10,7 +10,7 @@ use crate::{
         frequency_sketch::FrequencySketch,
         AccessTime,
     },
-    PredicateRegistrationError,
+    PredicateError,
 };
 
 use crossbeam_channel::{Receiver, Sender, TrySendError};
@@ -191,7 +191,7 @@ where
     pub(crate) fn invalidate_entries_if(
         &self,
         predicate: PredicateFun<K, V>,
-    ) -> Result<u64, PredicateRegistrationError> {
+    ) -> Result<PredicateId, PredicateError> {
         let now = self.inner.current_time_from_expiration_clock();
         self.inner.register_invalidation_predicate(predicate, now)
     }
@@ -499,11 +499,11 @@ where
         &self,
         predicate: PredicateFun<K, V>,
         registered_at: Instant,
-    ) -> Result<u64, PredicateRegistrationError> {
+    ) -> Result<PredicateId, PredicateError> {
         if let Some(inv) = &*self.invalidator.read() {
             inv.register_predicate(predicate, registered_at)
         } else {
-            Err(PredicateRegistrationError::InvalidationClosuresDisabled)
+            Err(PredicateError::InvalidationClosuresDisabled)
         }
     }
 

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -80,7 +80,7 @@ impl<K, V, S> BaseCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn new(
         max_capacity: usize,
@@ -211,7 +211,7 @@ impl<K, V, S> BaseCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     #[inline]
     fn record_read_op(&self, op: ReadOp<K, V>) -> Result<(), TrySendError<ReadOp<K, V>>> {
@@ -314,7 +314,7 @@ impl<K, V, S> BaseCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.len() == 0
@@ -519,7 +519,7 @@ impl<K, V, S> InnerSync for Inner<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self, max_repeats: usize) -> Option<SyncPace> {
         const EVICTION_BATCH_SIZE: usize = 500;
@@ -573,7 +573,7 @@ impl<K, V, S> Inner<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn apply_reads(&self, deqs: &mut Deques<K>, count: usize) {
         use ReadOp::*;

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -96,7 +96,8 @@ where
             time_to_live,
             time_to_idle,
         ));
-        let housekeeper = Housekeeper::new(Arc::downgrade(&inner));
+        let enable_invalidator = false;
+        let housekeeper = Housekeeper::new(Arc::downgrade(&inner), enable_invalidator);
 
         Self {
             inner,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -50,7 +50,7 @@ pub struct CacheBuilder<C> {
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
     K: Eq + Hash + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
     /// `SegmentedCache` holding up to `max_capacity` entries.
@@ -119,7 +119,7 @@ where
 impl<K, V> CacheBuilder<SegmentedCache<K, V, RandomState>>
 where
     K: Eq + Hash + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Builds a `SegmentedCache<K, V>`.
     ///

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -44,6 +44,7 @@ pub struct CacheBuilder<C> {
     num_segments: Option<usize>,
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
+    invalidator_enabled: bool,
     cache_type: PhantomData<C>,
 }
 
@@ -61,6 +62,7 @@ where
             num_segments: None,
             time_to_live: None,
             time_to_idle: None,
+            invalidator_enabled: false,
             cache_type: PhantomData::default(),
         }
     }
@@ -79,6 +81,7 @@ where
             num_segments: Some(num_segments),
             time_to_live: self.time_to_live,
             time_to_idle: self.time_to_idle,
+            invalidator_enabled: self.invalidator_enabled,
             cache_type: PhantomData::default(),
         }
     }
@@ -95,6 +98,7 @@ where
             build_hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 
@@ -112,6 +116,7 @@ where
             hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 }
@@ -134,6 +139,7 @@ where
             build_hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 
@@ -152,6 +158,7 @@ where
             hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 }
@@ -183,6 +190,13 @@ impl<C> CacheBuilder<C> {
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),
+            ..self
+        }
+    }
+
+    pub fn support_invalidation_closures(self) -> Self {
+        Self {
+            invalidator_enabled: true,
             ..self
         }
     }

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -104,7 +104,7 @@ where
     /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
-        S: BuildHasher + Clone + Send + 'static,
+        S: BuildHasher + Clone + Send + Sync + 'static,
     {
         Cache::with_everything(
             self.max_capacity,
@@ -143,7 +143,7 @@ where
     /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> SegmentedCache<K, V, S>
     where
-        S: BuildHasher + Clone + Send + 'static,
+        S: BuildHasher + Clone + Send + Sync + 'static,
     {
         SegmentedCache::with_everything(
             self.max_capacity,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -201,7 +201,7 @@ impl<C> CacheBuilder<C> {
     /// `invalidate_entries_if` method.
     ///
     /// [cache-invalidate-if]: ./struct.Cache.html#method.invalidate_entries_if
-    pub fn enable_invalidation_with_closures(self) -> Self {
+    pub fn support_invalidation_closures(self) -> Self {
         Self {
             invalidator_enabled: true,
             ..self

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -194,7 +194,14 @@ impl<C> CacheBuilder<C> {
         }
     }
 
-    pub fn support_invalidation_closures(self) -> Self {
+    /// Enables support for [Cache::invalidate_entries_if][cache-invalidate-if]
+    /// method.
+    ///
+    /// The cache will maintain additional internal data structures to support
+    /// `invalidate_entries_if` method.
+    ///
+    /// [cache-invalidate-if]: ./struct.Cache.html#method.invalidate_entries_if
+    pub fn enable_invalidation_with_closures(self) -> Self {
         Self {
             invalidator_enabled: true,
             ..self

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -49,8 +49,8 @@ pub struct CacheBuilder<C> {
 
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
-    K: Eq + Hash,
-    V: Clone,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + 'static,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
     /// `SegmentedCache` holding up to `max_capacity` entries.
@@ -104,7 +104,7 @@ where
     /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
-        S: BuildHasher + Clone,
+        S: BuildHasher + Clone + Send + 'static,
     {
         Cache::with_everything(
             self.max_capacity,
@@ -118,8 +118,8 @@ where
 
 impl<K, V> CacheBuilder<SegmentedCache<K, V, RandomState>>
 where
-    K: Eq + Hash,
-    V: Clone,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + 'static,
 {
     /// Builds a `SegmentedCache<K, V>`.
     ///
@@ -143,7 +143,7 @@ where
     /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> SegmentedCache<K, V, S>
     where
-        S: BuildHasher + Clone,
+        S: BuildHasher + Clone + Send + 'static,
     {
         SegmentedCache::with_everything(
             self.max_capacity,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -306,7 +306,7 @@ where
     /// not return invalidated values.
     ///
     /// Note that you must call
-    /// [`CacheBuilder::enable_invalidation_with_closures`][enable-invalidation-closures]
+    /// [`CacheBuilder::support_invalidation_closures`][support-invalidation-closures]
     /// at the cache creation time as the cache will maintain additional internal
     /// data structures to support this method. Otherwise, calling this method will
     /// fail with a
@@ -316,7 +316,7 @@ where
     /// popularity estimator of keys so that it retains the client activities of
     /// trying to retrieve an item.
     ///
-    /// [enable-invalidation-closures]: ./struct.CacheBuilder.html#method.enable_invalidation_with_closures
+    /// [support-invalidation-closures]: ./struct.CacheBuilder.html#method.support_invalidation_closures
     /// [invalidation-disabled-error]: ../enum.PredicateError.html#variant.InvalidationClosuresDisabled
     pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<PredicateId, PredicateError>
     where
@@ -522,7 +522,7 @@ mod tests {
         use std::collections::HashSet;
 
         let mut cache = CacheBuilder::new(100)
-            .enable_invalidation_with_closures()
+            .support_invalidation_closures()
             .build();
         cache.reconfigure_for_testing();
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1,9 +1,9 @@
 use super::{
     base_cache::{BaseCache, HouseKeeperArc, MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
     housekeeper::InnerSync,
-    invalidator::PredicateRegistrationError,
     ConcurrentCacheExt, WriteOp,
 };
+use crate::PredicateRegistrationError;
 
 use crossbeam_channel::{Sender, TrySendError};
 use std::{
@@ -199,7 +199,7 @@ where
     /// [builder-struct]: ./struct.CacheBuilder.html
     pub fn new(max_capacity: usize) -> Self {
         let build_hasher = RandomState::default();
-        Self::with_everything(max_capacity, None, build_hasher, None, None)
+        Self::with_everything(max_capacity, None, build_hasher, None, None, false)
     }
 }
 
@@ -215,6 +215,7 @@ where
         build_hasher: S,
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
+        invalidator_enabled: bool,
     ) -> Self {
         Self {
             base: BaseCache::new(
@@ -223,6 +224,7 @@ where
                 build_hasher,
                 time_to_live,
                 time_to_idle,
+                invalidator_enabled,
             ),
         }
     }
@@ -501,7 +503,7 @@ mod tests {
         use std::collections::HashSet;
 
         let mut cache = CacheBuilder::new(100)
-            .time_to_live(Duration::from_secs(60 * 60))
+            .support_invalidation_closures()
             .build();
         cache.reconfigure_for_testing();
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -189,7 +189,7 @@ where
 impl<K, V> Cache<K, V, RandomState>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity` entries.
     ///
@@ -206,7 +206,7 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     pub(crate) fn with_everything(
@@ -330,7 +330,7 @@ where
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: 'static,
+    V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     fn sync(&self) {
@@ -342,7 +342,7 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     #[inline]
@@ -377,7 +377,7 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: 'static,
+    V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     pub(crate) fn reconfigure_for_testing(&mut self) {
@@ -531,8 +531,10 @@ mod tests {
         cache.insert(3, "alice");
 
         // Run the invalidation task and wait for it to finish. (TODO: Need a better way than sleeping)
-        cache.sync();
-        std::thread::sleep(Duration::from_millis(500));
+        cache.sync(); // To submit the invalidation task.
+        std::thread::sleep(Duration::from_millis(200));
+        cache.sync(); // To process the task result.
+        std::thread::sleep(Duration::from_millis(200));
 
         assert!(cache.get(&0).is_none());
         assert!(cache.get(&2).is_none());

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -207,7 +207,7 @@ impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn with_everything(
         max_capacity: usize,
@@ -331,7 +331,7 @@ impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self) {
         self.base.inner.sync(MAX_SYNC_REPEATS);
@@ -343,7 +343,7 @@ impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     #[inline]
     fn schedule_write_op(
@@ -378,7 +378,7 @@ impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1,9 +1,9 @@
 use super::{
     base_cache::{BaseCache, HouseKeeperArc, MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
     housekeeper::InnerSync,
-    ConcurrentCacheExt, WriteOp,
+    ConcurrentCacheExt, PredicateId, WriteOp,
 };
-use crate::PredicateRegistrationError;
+use crate::PredicateError;
 
 use crossbeam_channel::{Sender, TrySendError};
 use std::{
@@ -316,15 +316,15 @@ where
     /// at the cache creation time as the cache will maintain additional internal
     /// data structures to support this method. Otherwise, calling this method will
     /// fail with a
-    /// [`PredicateRegistrationError::InvalidationClosuresDisabled`][invalidation-disabled-error].
+    /// [`PredicateError::InvalidationClosuresDisabled`][invalidation-disabled-error].
     ///
     /// Like the `invalidate` method, this method does not clear the historic
     /// popularity estimator of keys so that it retains the client activities of
     /// trying to retrieve an item.
     ///
     /// [enable-invalidation-closures]: ./struct.CacheBuilder.html#method.enable_invalidation_with_closures
-    /// [invalidation-disabled-error]: ../enum.PredicateRegistrationError.html#variant.InvalidationClosuresDisabled
-    pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<u64, PredicateRegistrationError>
+    /// [invalidation-disabled-error]: ../enum.PredicateError.html#variant.InvalidationClosuresDisabled
+    pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<PredicateId, PredicateError>
     where
         F: Fn(&K, &V) -> bool + Send + Sync + 'static,
     {

--- a/src/sync/housekeeper.rs
+++ b/src/sync/housekeeper.rs
@@ -40,7 +40,10 @@ pub(crate) trait InnerSync {
 
 pub(crate) struct Housekeeper<T> {
     inner: Arc<Mutex<UnsafeWeakPointer>>,
-    thread_pool: Arc<ThreadPool>,
+    // A shared thead pool for housekeepers.
+    hk_thread_pool: Arc<ThreadPool>,
+    // An optional shared thead pool for invalidators.
+    iv_thread_pool: Option<Arc<ThreadPool>>,
     is_shutting_down: Arc<AtomicBool>,
     periodical_sync_job: Mutex<Option<JobHandle>>,
     periodical_sync_running: Arc<Mutex<()>>,
@@ -52,6 +55,10 @@ impl<T> Drop for Housekeeper<T> {
     fn drop(&mut self) {
         // Disallow to create and/or run sync jobs by now.
         self.is_shutting_down.store(true, Ordering::Release);
+
+        if let Some(pool) = &self.iv_thread_pool {
+            ThreadPoolRegistry::release_pool(pool);
+        }
 
         // Cancel the periodical sync job. (This will not abort the job if it is
         // already running)
@@ -68,40 +75,65 @@ impl<T> Drop for Housekeeper<T> {
         }
 
         // All sync jobs should have been finished by now. Clean other stuff up.
-        ThreadPoolRegistry::release_pool(&self.thread_pool);
+        ThreadPoolRegistry::release_pool(&self.hk_thread_pool);
         std::mem::drop(unsafe { self.inner.lock().as_weak_arc::<T>() });
     }
 }
 
 // functions/methods used by Cache
 impl<T: InnerSync> Housekeeper<T> {
-    pub(crate) fn new(inner: Weak<T>) -> Self {
-        let thread_pool = ThreadPoolRegistry::acquire_default_pool();
+    pub(crate) fn new(inner: Weak<T>, enable_invalidator: bool) -> Self {
+        use crate::common::thread_pool::PoolName;
+
+        let hk_thread_pool = ThreadPoolRegistry::acquire_pool(PoolName::Housekeeper);
+        let iv_thread_pool = if enable_invalidator {
+            Some(ThreadPoolRegistry::acquire_pool(PoolName::Invalidator))
+        } else {
+            None
+        };
 
         let inner_ptr = Arc::new(Mutex::new(UnsafeWeakPointer::from_weak_arc(inner)));
         let is_shutting_down = Arc::new(AtomicBool::new(false));
         let periodical_sync_running = Arc::new(Mutex::new(()));
-        let periodical_sync_pace = Arc::new(Mutex::new(SyncPace::Normal));
+
+        let sync_job = Self::start_periodical_sync_job(
+            &hk_thread_pool,
+            Arc::clone(&inner_ptr),
+            Arc::clone(&is_shutting_down),
+            Arc::clone(&periodical_sync_running),
+        );
+
+        Self {
+            inner: inner_ptr,
+            hk_thread_pool,
+            iv_thread_pool,
+            is_shutting_down,
+            periodical_sync_job: Mutex::new(Some(sync_job)),
+            periodical_sync_running,
+            on_demand_sync_scheduled: Arc::new(AtomicBool::new(false)),
+            _marker: PhantomData::default(),
+        }
+    }
+
+    fn start_periodical_sync_job(
+        thread_pool: &Arc<ThreadPool>,
+        unsafe_weak_ptr: Arc<Mutex<UnsafeWeakPointer>>,
+        is_shutting_down: Arc<AtomicBool>,
+        periodical_sync_running: Arc<Mutex<()>>,
+    ) -> JobHandle {
+        let mut sync_pace = SyncPace::Normal;
 
         let housekeeper_closure = {
-            // The following Arc clones will be moved into the housekeeper closure.
-            let unsafe_weak_ptr = Arc::clone(&inner_ptr);
-            let shutting_down = Arc::clone(&is_shutting_down);
-            let sync_running = Arc::clone(&periodical_sync_running);
-            let sync_pace = Arc::clone(&periodical_sync_pace);
-
             move || {
-                // To avoid dead-locking with other thread, acquire the lock at very beginning.
-                let mut sync_pace = sync_pace.lock();
-                if !shutting_down.load(Ordering::Acquire) {
-                    let _lock = sync_running.lock();
+                if !is_shutting_down.load(Ordering::Acquire) {
+                    let _lock = periodical_sync_running.lock();
                     if let Some(new_pace) = Self::call_sync(&unsafe_weak_ptr) {
-                        if *sync_pace != new_pace {
-                            *sync_pace = new_pace
+                        if sync_pace != new_pace {
+                            sync_pace = new_pace
                         }
                     }
                 }
-                // TODO: Check what would happen if the closure returns None.
+
                 Some(sync_pace.make_duration())
             }
         };
@@ -109,19 +141,9 @@ impl<T: InnerSync> Housekeeper<T> {
         let initial_delay = Duration::from_millis(PERIODICAL_SYNC_INITIAL_DELAY_MILLIS);
 
         // Execute a task in a worker thread.
-        let job = thread_pool
+        thread_pool
             .pool
-            .execute_with_dynamic_delay(initial_delay, housekeeper_closure);
-
-        Self {
-            inner: inner_ptr,
-            thread_pool,
-            is_shutting_down,
-            periodical_sync_job: Mutex::new(Some(job)),
-            periodical_sync_running,
-            on_demand_sync_scheduled: Arc::new(AtomicBool::new(false)),
-            _marker: PhantomData::default(),
-        }
+            .execute_with_dynamic_delay(initial_delay, housekeeper_closure)
     }
 
     pub(crate) fn try_schedule_sync(&self) -> bool {
@@ -143,7 +165,7 @@ impl<T: InnerSync> Housekeeper<T> {
                 let unsafe_weak_ptr = Arc::clone(&self.inner);
                 let sync_scheduled = Arc::clone(&self.on_demand_sync_scheduled);
                 // Execute a task in a worker thread.
-                self.thread_pool.pool.execute(move || {
+                self.hk_thread_pool.pool.execute(move || {
                     Self::call_sync(&unsafe_weak_ptr);
                     sync_scheduled.store(false, Ordering::Release);
                 });

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -1,9 +1,12 @@
 #![allow(unused)]
 
-use crate::common::{
-    thread_pool::{PoolName, ThreadPool, ThreadPoolRegistry},
-    unsafe_weak_pointer::UnsafeWeakPointer,
-    AccessTime,
+use crate::{
+    common::{
+        thread_pool::{PoolName, ThreadPool, ThreadPoolRegistry},
+        unsafe_weak_pointer::UnsafeWeakPointer,
+        AccessTime,
+    },
+    PredicateRegistrationError,
 };
 
 use super::{base_cache::Inner, ValueEntry};
@@ -448,12 +451,4 @@ impl<K, V> Default for ScanResult<K, V> {
             newest_timestamp: None,
         }
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum PredicateRegistrationError {
-    #[error("The write-order queue is disabled. Please enable it using the builder at the cache creation time")]
-    WriteOrderQueueDisabled,
-    #[error("No space left in the predicate registry")]
-    NoSpaceLeft,
 }

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -24,21 +24,6 @@ use std::{
     time::Duration,
 };
 
-// TODO: Do a research on concurrent/persistent data structures that could
-// replace RwLock<HashMap<_, _>> to store predicates.
-//
-// Requirements:
-// - A write will not block reads or other writes.
-// - Provides a way to iterate through the predicates.
-//
-// Candidates (concurrent data structure):
-// - cht crate's HashMap, once iterator is implemented.
-//     - https://github.com/Gregory-Meyer/cht/issues/20
-//
-// Candidates (persistent data structure):
-// - im crate's Vector or HashMap.
-// - rpds crate's Vector or RedBlackTreeMap.
-
 pub(crate) type PredicateFun<K, V> = Arc<dyn Fn(&K, &V) -> bool + Send + Sync + 'static>;
 
 pub(crate) trait GetOrRemoveEntry<K, V> {
@@ -87,6 +72,8 @@ impl<K, V> InvalidationResult<K, V> {
 }
 
 pub(crate) struct Invalidator<K, V, S> {
+    // TODO: Replace this RwLock<std::collections::HashMap<_, _>> with cht::HashMap
+    // once iterator is implemented. https://github.com/Gregory-Meyer/cht/issues/20
     predicates: RwLock<HashMap<u64, Predicate<K, V>>>,
     is_empty: AtomicBool,
     last_predicate_id: AtomicU64,

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -77,7 +77,6 @@ pub(crate) struct Invalidator<K, V, S> {
     // once iterator is implemented. https://github.com/Gregory-Meyer/cht/issues/20
     predicates: RwLock<HashMap<PredicateId, Predicate<K, V>>>,
     is_empty: AtomicBool,
-    last_predicate_id: AtomicU64,
     scan_context: Arc<ScanContext<K, V, S>>,
     thread_pool: Arc<ThreadPool>,
 }
@@ -106,7 +105,6 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
-            last_predicate_id: AtomicU64::new(std::u64::MAX),
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -209,7 +209,7 @@ impl<K, V, S> Invalidator<K, V, S> {
                             }
                         }
 
-                        // Remove the predicates from from the scan context.
+                        // Remove the predicates from the scan context.
                         let ps = predicates
                             .drain(..)
                             .filter(|p| p.is_applicable(ts))
@@ -253,6 +253,16 @@ impl<K, V, S> Invalidator<K, V, S> {
             }
         }
         false
+    }
+}
+
+//
+// for testing
+//
+#[cfg(test)]
+impl<K, V, S> Invalidator<K, V, S> {
+    pub(crate) fn predicate_count(&self) -> usize {
+        self.predicates.read().len()
     }
 }
 

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -1,0 +1,230 @@
+#![allow(unused)]
+
+use crate::common::AccessTime;
+
+use super::ValueEntry;
+
+use crossbeam_channel::{Receiver, Sender};
+use parking_lot::{Mutex, RwLock};
+use quanta::Instant;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+// TODO: Do a research on concurrent/persistent data structures that could
+// replace RwLock<HashMap<_, _>> to store predicates.
+//
+// Requirements:
+// - A write will not block reads or other writes.
+// - Provides a way to iterate through the predicates.
+//
+// Candidates (concurrent data structure):
+// - cht crate's HashMap, once iterator is implemented.
+//     - https://github.com/Gregory-Meyer/cht/issues/20
+//
+// Candidates (persistent data structure):
+// - im crate's Vector or HashMap.
+// - rpds crate's Vector or RedBlackTreeMap.
+
+pub(crate) struct Invalidator<K, V> {
+    predicates: RwLock<HashMap<u64, PredicateImpl<K, V>>>,
+    is_empty: AtomicBool,
+    last_key: AtomicU64,
+    scan_context: ScanContext<K, V>,
+}
+
+impl<K, V> Default for Invalidator<K, V> {
+    fn default() -> Self {
+        Self {
+            predicates: RwLock::new(HashMap::new()),
+            is_empty: AtomicBool::new(true),
+            last_key: AtomicU64::new(std::u64::MAX),
+            scan_context: ScanContext::default(),
+        }
+    }
+}
+
+impl<K, V> Invalidator<K, V>
+where
+    K: 'static,
+    V: 'static,
+{
+    pub(crate) fn register_predicate(
+        &self,
+        predicate: PredicateFun<K, V>,
+        registered_at: Instant,
+    ) -> Result<u64, PredicateRegistrationError> {
+        const MAX_RETRY: usize = 10_000;
+        let mut tries = 0;
+        let mut preds = self.predicates.write();
+
+        while tries < MAX_RETRY {
+            // NOTE: fetch_add operation wraps around on overflow.
+            let id = self.last_key.fetch_add(1, Ordering::SeqCst);
+            if preds.contains_key(&id) {
+                tries += 1;
+
+                continue; // Retry
+            }
+            let pred = PredicateImpl::new(predicate, registered_at);
+            preds.insert(id, pred);
+            self.is_empty.store(false, Ordering::Release);
+
+            return Ok(id);
+        }
+
+        Err(PredicateRegistrationError::NoSpaceLeft)
+    }
+
+    pub(crate) fn remove_predicate(&self, id: u64) {
+        let mut preds = self.predicates.write();
+        preds.remove(&id);
+        if preds.is_empty() {
+            self.is_empty.store(true, Ordering::Release);
+        }
+    }
+
+    // This method will be called by the get method of Cache.
+    pub(crate) fn apply_predicates(&self, key: &Arc<K>, entry: &Arc<ValueEntry<K, V>>) -> bool {
+        if self.is_empty.load(Ordering::Acquire) {
+            false
+        } else {
+            Self::do_apply_predicates(self.predicates.read().values(), key, entry)
+        }
+    }
+
+    // This method will be called by eviction scan.
+    pub(crate) fn process_candidates(&self, remover: impl Fn(K, &PredicateFun<K, V>) -> Option<V>) {
+        todo!()
+    }
+
+    fn do_apply_predicates<'a, I, P>(
+        predicates: I,
+        key: &Arc<K>,
+        entry: &Arc<ValueEntry<K, V>>,
+    ) -> bool
+    where
+        I: Iterator<Item = &'a P>,
+        P: Predicate<K, V> + 'static,
+    {
+        if let Some(ts) = entry.last_modified() {
+            predicates
+                .filter(|pred| pred.is_applicable(ts))
+                .any(|pred| pred.apply(key, &entry.value))
+        } else {
+            false
+        }
+    }
+}
+
+struct ScanContext<K, V> {
+    predicates: Mutex<Vec<PredicateImplLite<K, V>>>,
+    newest_timestamp: AtomicU64,
+    snd: Sender<CacheEntry<K>>,
+    rcv: Receiver<CacheEntry<K>>,
+}
+
+impl<K, V> Default for ScanContext<K, V> {
+    fn default() -> Self {
+        let (snd, rcv) = crossbeam_channel::unbounded();
+        Self {
+            predicates: Mutex::new(Vec::default()),
+            newest_timestamp: AtomicU64::new(0),
+            snd,
+            rcv,
+        }
+    }
+}
+
+type PredicateFun<K, V> = Arc<dyn Fn(&K, &V) -> bool + Send + Sync + 'static>;
+
+trait Predicate<K, V> {
+    fn is_applicable(&self, last_modified: Instant) -> bool;
+    fn apply(&self, key: &K, value: &V) -> bool;
+}
+
+struct PredicateImpl<K, V> {
+    f: PredicateFun<K, V>,
+    registered_at: Instant,
+    // The oldest timestamp of the entries checked by this predicate.
+    oldest: AtomicU64,
+    // The newest timestamp of the entries checked by this predicate.
+    newest: AtomicU64,
+}
+
+impl<K, V> PredicateImpl<K, V> {
+    fn new(f: PredicateFun<K, V>, registered_at: Instant) -> Self {
+        Self {
+            f,
+            registered_at,
+            oldest: AtomicU64::new(std::u64::MAX),
+            newest: AtomicU64::new(std::u64::MIN),
+        }
+    }
+}
+
+impl<K, V> Predicate<K, V> for PredicateImpl<K, V> {
+    fn is_applicable(&self, last_modified: Instant) -> bool {
+        last_modified <= self.registered_at
+            && (last_modified.as_u64() < self.oldest.load(Ordering::Acquire)
+                || last_modified.as_u64() > self.newest.load(Ordering::Acquire))
+    }
+
+    fn apply(&self, key: &K, value: &V) -> bool {
+        (self.f)(key, value)
+    }
+}
+
+// PredicateImplLite is optimized for batch eviction process. Unlike PredicateImpl, it has
+// no synchronization primitives such as AtomicU64.
+struct PredicateImplLite<K, V> {
+    f: PredicateFun<K, V>,
+    registered_at: Instant,
+    // The oldest timestamp of the entries checked by this predicate.
+    oldest: Instant,
+    // The newest timestamp of the entries checked by this predicate.
+    newest: Instant,
+}
+
+impl<K, V> PredicateImplLite<K, V> {
+    fn new(pred: &PredicateImpl<K, V>) -> Self {
+        Self {
+            f: Arc::clone(&pred.f),
+            registered_at: pred.registered_at,
+            oldest: unsafe { std::mem::transmute(pred.oldest.load(Ordering::Acquire)) },
+            newest: unsafe { std::mem::transmute(pred.newest.load(Ordering::Acquire)) },
+        }
+    }
+}
+
+impl<K, V> Predicate<K, V> for PredicateImplLite<K, V> {
+    fn is_applicable(&self, last_modified: Instant) -> bool {
+        last_modified <= self.registered_at
+            && (last_modified < self.oldest || last_modified > self.newest)
+    }
+
+    fn apply(&self, key: &K, value: &V) -> bool {
+        (self.f)(key, value)
+    }
+}
+
+enum CacheEntry<K> {
+    // The timestamp of the first entry of a scan.
+    Begin(u64),
+    // Entry's key
+    Item(Arc<K>),
+    // The timestamp of the last entry of a scan.
+    End(u64),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PredicateRegistrationError {
+    #[error("The write-order queue is disabled. Please enable it using the builder at the cache creation time")]
+    WriteOrderQueueDisabled,
+    #[error("No space left in the predicate registry")]
+    NoSpaceLeft,
+}

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -11,10 +11,14 @@ use super::ValueEntry;
 // use crossbeam_channel::{Receiver, Sender};
 use parking_lot::{Mutex, RwLock};
 use quanta::Instant;
-use std::{collections::HashMap, hash::{BuildHasher, Hash}, sync::{
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, Hash},
+    sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
-    }};
+    },
+};
 
 // TODO: Do a research on concurrent/persistent data structures that could
 // replace RwLock<HashMap<_, _>> to store predicates.
@@ -279,7 +283,7 @@ pub(crate) trait GetOrRemoveEntry<K, V> {
         F: FnMut(&Arc<K>, &Arc<ValueEntry<K, V>>) -> bool;
 }
 
-// impl<K, V, S> GetOrRemoveEntry<K, V> for cht::SegmentedHashMap<Arc<K>, Arc<ValueEntry<K, V>>, S> 
+// impl<K, V, S> GetOrRemoveEntry<K, V> for cht::SegmentedHashMap<Arc<K>, Arc<ValueEntry<K, V>>, S>
 // where K: Hash + Eq,
 // S: BuildHasher,
 

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -53,7 +53,7 @@ impl<K, V, S> Clone for SegmentedCache<K, V, S> {
 impl<K, V> SegmentedCache<K, V, RandomState>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Constructs a new `SegmentedCache<K, V>` that has multiple internal
     /// segments and will store up to the `max_capacity` entries.
@@ -75,7 +75,7 @@ where
 impl<K, V, S> SegmentedCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     /// # Panics
@@ -180,7 +180,7 @@ where
 impl<K, V, S> ConcurrentCacheExt<K, V> for SegmentedCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: 'static,
+    V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     fn sync(&self) {
@@ -195,7 +195,7 @@ where
 impl<K, V, S> SegmentedCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: 'static,
+    V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
@@ -218,7 +218,7 @@ struct Inner<K, V, S> {
 impl<K, V, S> Inner<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + 'static,
 {
     /// # Panics

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -76,7 +76,7 @@ impl<K, V, S> SegmentedCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     /// # Panics
     ///
@@ -181,7 +181,7 @@ impl<K, V, S> ConcurrentCacheExt<K, V> for SegmentedCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self) {
         for segment in self.inner.segments.iter() {
@@ -196,7 +196,7 @@ impl<K, V, S> SegmentedCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
         let inner = Arc::get_mut(&mut self.inner)
@@ -219,7 +219,7 @@ impl<K, V, S> Inner<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     /// # Panics
     ///

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -68,7 +68,15 @@ where
     /// Panics if `num_segments` is 0.
     pub fn new(max_capacity: usize, num_segments: usize) -> Self {
         let build_hasher = RandomState::default();
-        Self::with_everything(max_capacity, None, num_segments, build_hasher, None, None)
+        Self::with_everything(
+            max_capacity,
+            None,
+            num_segments,
+            build_hasher,
+            None,
+            None,
+            false,
+        )
     }
 }
 
@@ -88,6 +96,7 @@ where
         build_hasher: S,
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
+        invalidator_enabled: bool,
     ) -> Self {
         Self {
             inner: Arc::new(Inner::new(
@@ -97,6 +106,7 @@ where
                 build_hasher,
                 time_to_live,
                 time_to_idle,
+                invalidator_enabled,
             )),
         }
     }
@@ -231,6 +241,7 @@ where
         build_hasher: S,
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
+        invalidator_enabled: bool,
     ) -> Self {
         assert!(num_segments > 0);
 
@@ -249,6 +260,7 @@ where
                     build_hasher.clone(),
                     time_to_live,
                     time_to_idle,
+                    invalidator_enabled,
                 )
             })
             .collect::<Vec<_>>();

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1,5 +1,5 @@
-use crate::PredicateError;
 use super::{cache::Cache, ConcurrentCacheExt};
+use crate::PredicateError;
 
 use std::{
     borrow::Borrow,

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -52,8 +52,8 @@ impl<K, V, S> Clone for SegmentedCache<K, V, S> {
 
 impl<K, V> SegmentedCache<K, V, RandomState>
 where
-    K: Hash + Eq,
-    V: Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + 'static,
 {
     /// Constructs a new `SegmentedCache<K, V>` that has multiple internal
     /// segments and will store up to the `max_capacity` entries.
@@ -74,9 +74,9 @@ where
 
 impl<K, V, S> SegmentedCache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     /// # Panics
     ///
@@ -179,8 +179,9 @@ where
 
 impl<K, V, S> ConcurrentCacheExt<K, V> for SegmentedCache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     fn sync(&self) {
         for segment in self.inner.segments.iter() {
@@ -193,8 +194,9 @@ where
 #[cfg(test)]
 impl<K, V, S> SegmentedCache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
         let inner = Arc::get_mut(&mut self.inner)
@@ -215,9 +217,9 @@ struct Inner<K, V, S> {
 
 impl<K, V, S> Inner<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + 'static,
+    S: BuildHasher + Clone + Send + 'static,
 {
     /// # Panics
     ///

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1,3 +1,4 @@
+use crate::PredicateError;
 use super::{cache::Cache, ConcurrentCacheExt};
 
 use std::{
@@ -151,10 +152,56 @@ where
         self.inner.select(hash).invalidate(key);
     }
 
+    /// Discards all cached values.
+    ///
+    /// This method returns immediately and a background thread will evict all the
+    /// cached values inserted before the time when this method was called. It is
+    /// guaranteed that the `get` method must not return these invalidated values
+    /// even if they have not been evicted.
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
     pub fn invalidate_all(&self) {
         for segment in self.inner.segments.iter() {
             segment.invalidate_all();
         }
+    }
+
+    /// Discards cached values that satisfy a predicate.
+    ///
+    /// `invalidate_entries_if` takes a closure that returns `true` or `false`. This
+    /// method returns immediately and a background thread will apply the closure to
+    /// each cached value inserted before the time when `invalidate_entries_if` was
+    /// called. If the closure returns `true` on a value, that value will be evicted
+    /// from the cache.
+    ///
+    /// Also the `get` method will apply the closure to a value to determine if it
+    /// should have been invalidated. Therefore, it is guaranteed that the `get`
+    /// method must not return invalidated values.
+    ///
+    /// Note that you must call
+    /// [`CacheBuilder::support_invalidation_closures`][support-invalidation-closures]
+    /// at the cache creation time as the cache needs to maintain additional internal
+    /// data structures to support this method. Otherwise, calling this method will
+    /// fail with a
+    /// [`PredicateError::InvalidationClosuresDisabled`][invalidation-disabled-error].
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
+    ///
+    /// [support-invalidation-closures]: ./struct.CacheBuilder.html#method.support_invalidation_closures
+    /// [invalidation-disabled-error]: ../enum.PredicateError.html#variant.InvalidationClosuresDisabled
+    pub fn invalidate_entries_if<F>(&self, predicate: F) -> Result<(), PredicateError>
+    where
+        F: Fn(&K, &V) -> bool + Send + Sync + 'static,
+    {
+        let pred = Arc::new(predicate);
+        for segment in self.inner.segments.iter() {
+            segment.invalidate_entries_with_arc_fun(Arc::clone(&pred))?;
+        }
+        Ok(())
     }
 
     /// Returns the `max_capacity` of this cache.
@@ -208,12 +255,52 @@ where
     V: Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
+    fn table_size(&self) -> usize {
+        self.inner.segments.iter().map(|seg| seg.table_size()).sum()
+    }
+
+    fn invalidation_predicate_count(&self) -> usize {
+        self.inner
+            .segments
+            .iter()
+            .map(|seg| seg.invalidation_predicate_count())
+            .sum()
+    }
+
     fn reconfigure_for_testing(&mut self) {
         let inner = Arc::get_mut(&mut self.inner)
             .expect("There are other strong reference to self.inner Arc");
 
         for segment in inner.segments.iter_mut() {
             segment.reconfigure_for_testing();
+        }
+    }
+
+    fn create_mock_expiration_clock(&self) -> MockExpirationClock {
+        let mut exp_clock = MockExpirationClock::default();
+
+        for segment in self.inner.segments.iter() {
+            let (clock, mock) = quanta::Clock::mock();
+            segment.set_expiration_clock(Some(clock));
+            exp_clock.mocks.push(mock);
+        }
+
+        exp_clock
+    }
+}
+
+// For unit tests.
+#[cfg(test)]
+#[derive(Default)]
+struct MockExpirationClock {
+    mocks: Vec<Arc<quanta::Mock>>,
+}
+
+#[cfg(test)]
+impl MockExpirationClock {
+    fn increment(&mut self, duration: Duration) {
+        for mock in &mut self.mocks {
+            mock.increment(duration);
         }
     }
 }
@@ -303,6 +390,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{ConcurrentCacheExt, SegmentedCache};
+    use crate::sync::CacheBuilder;
+    use std::time::Duration;
 
     #[test]
     fn basic_single_thread() {
@@ -407,5 +496,75 @@ mod tests {
         assert!(cache.get(&"b").is_none());
         assert!(cache.get(&"c").is_none());
         assert_eq!(cache.get(&"d"), Some("david"));
+    }
+
+    #[test]
+    fn invalidate_entries_if() -> Result<(), Box<dyn std::error::Error>> {
+        use std::collections::HashSet;
+
+        const SEGMENTS: usize = 4;
+
+        let mut cache = CacheBuilder::new(100)
+            .segments(SEGMENTS)
+            .support_invalidation_closures()
+            .build();
+        cache.reconfigure_for_testing();
+
+        let mut mock = cache.create_mock_expiration_clock();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert(0, "alice");
+        cache.insert(1, "bob");
+        cache.insert(2, "alex");
+        cache.sync();
+        mock.increment(Duration::from_secs(5)); // 5 secs from the start.
+        cache.sync();
+
+        assert_eq!(cache.get(&0), Some("alice"));
+        assert_eq!(cache.get(&1), Some("bob"));
+        assert_eq!(cache.get(&2), Some("alex"));
+
+        let names = ["alice", "alex"].iter().cloned().collect::<HashSet<_>>();
+        cache.invalidate_entries_if(move |_k, &v| names.contains(v))?;
+        assert_eq!(cache.invalidation_predicate_count(), SEGMENTS * 1);
+
+        mock.increment(Duration::from_secs(5)); // 10 secs from the start.
+
+        cache.insert(3, "alice");
+
+        // Run the invalidation task and wait for it to finish. (TODO: Need a better way than sleeping)
+        cache.sync(); // To submit the invalidation task.
+        std::thread::sleep(Duration::from_millis(200));
+        cache.sync(); // To process the task result.
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(cache.get(&0).is_none());
+        assert!(cache.get(&2).is_none());
+        assert_eq!(cache.get(&1), Some("bob"));
+        // This should survive as it was inserted after calling invalidate_entries_if.
+        assert_eq!(cache.get(&3), Some("alice"));
+        assert_eq!(cache.table_size(), 2);
+        assert_eq!(cache.invalidation_predicate_count(), SEGMENTS * 0);
+
+        mock.increment(Duration::from_secs(5)); // 15 secs from the start.
+
+        cache.invalidate_entries_if(|_k, &v| v == "alice")?;
+        cache.invalidate_entries_if(|_k, &v| v == "bob")?;
+        assert_eq!(cache.invalidation_predicate_count(), SEGMENTS * 2);
+
+        // Run the invalidation task and wait for it to finish. (TODO: Need a better way than sleeping)
+        cache.sync(); // To submit the invalidation task.
+        std::thread::sleep(Duration::from_millis(200));
+        cache.sync(); // To process the task result.
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(cache.get(&1).is_none());
+        assert!(cache.get(&3).is_none());
+        assert_eq!(cache.table_size(), 0);
+        assert_eq!(cache.invalidation_predicate_count(), SEGMENTS * 0);
+
+        Ok(())
     }
 }

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -41,6 +41,7 @@ pub struct CacheBuilder<C> {
     initial_capacity: Option<usize>,
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
+    invalidator_enabled: bool,
     cache_type: PhantomData<C>,
 }
 
@@ -56,6 +57,7 @@ where
             initial_capacity: None,
             time_to_live: None,
             time_to_idle: None,
+            invalidator_enabled: false,
             cache_type: PhantomData::default(),
         }
     }
@@ -69,6 +71,7 @@ where
             build_hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 
@@ -83,6 +86,7 @@ where
             hasher,
             self.time_to_live,
             self.time_to_idle,
+            self.invalidator_enabled,
         )
     }
 }
@@ -114,6 +118,13 @@ impl<C> CacheBuilder<C> {
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),
+            ..self
+        }
+    }
+
+    pub fn support_invalidation_closures(self) -> Self {
+        Self {
+            invalidator_enabled: true,
             ..self
         }
     }

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -41,7 +41,6 @@ pub struct CacheBuilder<C> {
     initial_capacity: Option<usize>,
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
-    invalidator_enabled: bool,
     cache_type: PhantomData<C>,
 }
 
@@ -57,7 +56,6 @@ where
             initial_capacity: None,
             time_to_live: None,
             time_to_idle: None,
-            invalidator_enabled: false,
             cache_type: PhantomData::default(),
         }
     }
@@ -71,7 +69,6 @@ where
             build_hasher,
             self.time_to_live,
             self.time_to_idle,
-            self.invalidator_enabled,
         )
     }
 
@@ -86,7 +83,6 @@ where
             hasher,
             self.time_to_live,
             self.time_to_idle,
-            self.invalidator_enabled,
         )
     }
 }
@@ -118,13 +114,6 @@ impl<C> CacheBuilder<C> {
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),
-            ..self
-        }
-    }
-
-    pub fn support_invalidation_closures(self) -> Self {
-        Self {
-            invalidator_enabled: true,
             ..self
         }
     }

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -251,9 +251,8 @@ where
     /// Discards cached values that satisfy a predicate.
     ///
     /// `invalidate_entries_if` takes a closure that returns `true` or
-    /// `false`. `invalidate_entries_if` will apply the closure to each value
-    /// inserted before the time when it was called. If the closure returns `true` on
-    /// a value, that value will be invalidated.
+    /// `false`. `invalidate_entries_if` will apply the closure to each value,
+    /// and if the closure returns `true`, the value will be invalidated.
     ///
     /// Like the `invalidate` method, this method does not clear the historic
     /// popularity estimator of keys so that it retains the client activities of

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1,8 +1,11 @@
 use super::{deques::Deques, KeyDate, KeyHashDate, ValueEntry};
-use crate::common::{
-    deque::{CacheRegion, DeqNode, Deque},
-    frequency_sketch::FrequencySketch,
-    AccessTime,
+use crate::{
+    common::{
+        deque::{CacheRegion, DeqNode, Deque},
+        frequency_sketch::FrequencySketch,
+        AccessTime,
+    },
+    PredicateRegistrationError,
 };
 
 use quanta::{Clock, Instant};
@@ -117,6 +120,7 @@ pub struct Cache<K, V, S = RandomState> {
     frequency_sketch: FrequencySketch,
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
+    invalidator_enabled: bool,
     expiration_clock: Option<Clock>,
 }
 
@@ -132,7 +136,7 @@ where
     /// [builder-struct]: ./struct.CacheBuilder.html
     pub fn new(max_capacity: usize) -> Self {
         let build_hasher = RandomState::default();
-        Self::with_everything(max_capacity, None, build_hasher, None, None)
+        Self::with_everything(max_capacity, None, build_hasher, None, None, false)
     }
 }
 
@@ -150,6 +154,7 @@ where
         build_hasher: S,
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
+        invalidator_enabled: bool,
     ) -> Self {
         let cache = HashMap::with_capacity_and_hasher(
             initial_capacity.unwrap_or_default(),
@@ -165,6 +170,7 @@ where
             frequency_sketch,
             time_to_live,
             time_to_idle,
+            invalidator_enabled,
             expiration_clock: None,
         }
     }
@@ -246,6 +252,18 @@ where
     pub fn invalidate_all(&mut self) {
         self.cache.clear();
         self.deques.clear();
+    }
+
+    pub fn invalidate_entries_if(
+        &mut self,
+        predicate: impl FnMut(&K, &V) -> bool,
+    ) -> Result<(), PredicateRegistrationError> {
+        if self.invalidator_enabled {
+            self.do_invalidate_entries(predicate);
+            Ok(())
+        } else {
+            Err(PredicateRegistrationError::InvalidationClosuresDisabled)
+        }
     }
 
     /// Returns the `max_capacity` of this cache.
@@ -353,7 +371,7 @@ where
                 KeyHashDate::new(Rc::clone(&key), hash, timestamp),
                 &mut entry,
             );
-            if self.time_to_live.is_some() {
+            if self.time_to_live.is_some() || self.invalidator_enabled {
                 deqs.push_back_wo(KeyDate::new(key, timestamp), &mut entry);
             }
         } else {
@@ -382,7 +400,7 @@ where
                     KeyHashDate::new(Rc::clone(&key), hash, timestamp),
                     &mut entry,
                 );
-                if self.time_to_live.is_some() {
+                if self.time_to_live.is_some() || self.invalidator_enabled {
                     deqs.push_back_wo(KeyDate::new(key, timestamp), &mut entry);
                 }
             } else {
@@ -530,6 +548,31 @@ where
             }
         }
     }
+
+    // Avoid a false Clippy warning about needless collect to create keys_to_invalidate.
+    // clippy 0.1.52 (9a1dfd2dc5c 2021-04-30) in Rust 1.52.0-beta.7
+    #[allow(clippy::needless_collect)]
+    fn do_invalidate_entries(&mut self, mut predicate: impl FnMut(&K, &V) -> bool) {
+        let Self { cache, deques, .. } = self;
+
+        let keys_to_invalidate = (&mut deques.write_order)
+            .filter(|kd| {
+                if let Some((k, entry)) = cache.get_key_value(&kd.key) {
+                    (predicate)(k, &entry.value)
+                } else {
+                    false
+                }
+            })
+            .map(|kd| Rc::clone(&kd.key))
+            .collect::<Vec<_>>();
+
+        keys_to_invalidate.into_iter().for_each(|k| {
+            if let Some(mut entry) = cache.remove(&k) {
+                deques.unlink_ao(&mut entry);
+                Deques::unlink_wo(&mut deques.write_order, &mut entry);
+            }
+        });
+    }
 }
 
 //
@@ -611,6 +654,53 @@ mod tests {
         assert!(cache.get(&"b").is_none());
         assert!(cache.get(&"c").is_none());
         assert_eq!(cache.get(&"d"), Some(&"david"));
+    }
+
+    #[test]
+    fn invalidate_entries_if() -> Result<(), Box<dyn std::error::Error>> {
+        use std::collections::HashSet;
+
+        let mut cache = CacheBuilder::new(100)
+            .support_invalidation_closures()
+            .build();
+
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
+
+        cache.insert(0, "alice");
+        cache.insert(1, "bob");
+        cache.insert(2, "alex");
+
+        mock.increment(Duration::from_secs(5)); // 5 secs from the start.
+
+        assert_eq!(cache.get(&0), Some(&"alice"));
+        assert_eq!(cache.get(&1), Some(&"bob"));
+        assert_eq!(cache.get(&2), Some(&"alex"));
+
+        let names = ["alice", "alex"].iter().cloned().collect::<HashSet<_>>();
+        cache.invalidate_entries_if(move |_k, &v| names.contains(v))?;
+
+        mock.increment(Duration::from_secs(5)); // 10 secs from the start.
+
+        cache.insert(3, "alice");
+
+        assert!(cache.get(&0).is_none());
+        assert!(cache.get(&2).is_none());
+        assert_eq!(cache.get(&1), Some(&"bob"));
+        // This should survive as it was inserted after calling invalidate_entries_if.
+        assert_eq!(cache.get(&3), Some(&"alice"));
+        assert_eq!(cache.cache.len(), 2);
+
+        mock.increment(Duration::from_secs(5)); // 15 secs from the start.
+
+        cache.invalidate_entries_if(|_k, &v| v == "alice")?;
+        cache.invalidate_entries_if(|_k, &v| v == "bob")?;
+
+        assert!(cache.get(&1).is_none());
+        assert!(cache.get(&3).is_none());
+        assert_eq!(cache.cache.len(), 0);
+
+        Ok(())
     }
 
     #[test]

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -248,7 +248,6 @@ where
         self.deques.clear();
     }
 
-
     /// Discards cached values that satisfy a predicate.
     ///
     /// `invalidate_entries_if` takes a closure that returns `true` or

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -265,6 +265,11 @@ where
     pub fn invalidate_entries_if(&mut self, mut predicate: impl FnMut(&K, &V) -> bool) {
         let Self { cache, deques, .. } = self;
 
+        // Since we can't do cache.iter() and cache.remove() at the same time,
+        // invalidation needs to run in two steps:
+        // 1. Examine all entries in this cache and collect keys to invalidate.
+        // 2. Remove entries for the keys.
+
         let keys_to_invalidate = cache
             .iter()
             .filter(|(key, entry)| (predicate)(key, &entry.value))

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -250,8 +250,8 @@ where
 
     /// Discards cached values that satisfy a predicate.
     ///
-    /// `invalidate_entries_if` takes a closure that returns `true` or
-    /// `false`. `invalidate_entries_if` will apply the closure to each value,
+    /// `invalidate_entries_if` takes a closure that returns `true` or `false`.
+    /// `invalidate_entries_if` will apply the closure to each cached value,
     /// and if the closure returns `true`, the value will be invalidated.
     ///
     /// Like the `invalidate` method, this method does not clear the historic

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -248,7 +248,20 @@ where
         self.deques.clear();
     }
 
-    // Avoid a false Clippy warning about needless collect to create keys_to_invalidate.
+
+    /// Discards cached values that satisfy a predicate.
+    ///
+    /// `invalidate_entries_if` takes a closure that returns `true` or
+    /// `false`. `invalidate_entries_if` will apply the closure to each value
+    /// inserted before the time when it was called. If the closure returns `true` on
+    /// a value, that value will be invalidated.
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
+
+    // We need this #[allow(...)] to avoid a false Clippy warning about needless
+    // collect to create keys_to_invalidate.
     // clippy 0.1.52 (9a1dfd2dc5c 2021-04-30) in Rust 1.52.0-beta.7
     #[allow(clippy::needless_collect)]
     pub fn invalidate_entries_if(&mut self, mut predicate: impl FnMut(&K, &V) -> bool) {


### PR DESCRIPTION
This PR adds the `invalidate_entries_if` method and supporting methods to all caches in Moka. `invalidate_entries_if` invalidates the entire cache based on a predicate on the key and value of each cache entry. This method was requested by #10.

## Added

- (API) Add `invalidate_entries_if` method to all cache implementations in Moka:
    - `sync::Cache`
    - `sync::SegmentedCache`
    - `future::Cache`
    - `unsync::Cache`
- (API) Add `support_invalidation_closures` method to the following cache builders:
    - `sync::CacheBuilder`
    - `future::CacheBuilder`
    - Note that for these `sync` and `future` caches, this method must be called at the cache creation time as the cache needs to maintain additional internal data structures to support `invalidate_entries_if` method. Otherwise, calling `invalidate_entries_if` will return a `PredicateError::InvalidationClosuresDisabled`.
- Add an internal `invalidator` module, containing a registry of invalidation predicates and a background invalidator (eviction) task.
- Implement `Iterator` on internal `Deque`.

## Changed

- Update internal `base_cache::Inner` to run a new `invalidate_entries` method periodically.
- Update `get` method in `sync` and `future` caches to check if an entry has been invalidated.
- Lightly refactor test related methods on caches.

----
Fixes #10.