### PR TITLE
Raise MSRV for "future" feature to 1.46.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,8 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.45.2  # MSRV
+          - 1.46.0  # MSRV (future)
+          - 1.45.2  # MSRV (no features)
 
     steps:
       - name: Checkout Moka
@@ -50,6 +51,7 @@ jobs:
 
       - name: Run tests (future)
         uses: actions-rs/cargo@v1
+        if: ${{ matrix.rust != '1.45.2' }}
         with:
           command: test
           args: --release --features future

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-io = { version = "1", optional = true }
 [dev-dependencies]
 actix-rt2 = { package = "actix-rt", version = "2", default-features = false }
 actix-rt1 = { package = "actix-rt", version = "1", default-features = false }
-async-std = { version = "1", features = ["attributes"] }
+async-std = { version = "1", default-features = false, features = ["attributes"] }
 futures = "0.3"
 getrandom = "0.2"
 skeptic = "0.13"

--- a/README.md
+++ b/README.md
@@ -310,20 +310,26 @@ available on crates.io, such as the [aHash][ahash-crate] crate.
 [ahash-crate]: https://crates.io/crates/ahash
 
 
-## Minimum Supported Rust Version
+## Minimum Supported Rust Versions
 
-This crate's minimum supported Rust version (MSRV) is 1.45.2.
+This crate's minimum supported Rust versions (MSRV) are the followings:
 
-<!--
-- quanta requires 1.45.
-- aHash 0.5 requires 1.43.
-- cht requires 1.41.
--->
+| Enabled Feature      | MSRV        |
+|:---------------------|:------------|
+| no feature (default) | Rust 1.45.2 |
+| `future`             | Rust 1.46.0 |
 
 If no feature is enabled, MSRV will be updated conservatively. When using other
 features, like `future`, MSRV might be updated more frequently, up to the latest
 stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
 change.
+
+<!--
+- socket2 0.4.0 requires 1.46.
+- quanta requires 1.45.
+- aHash 0.5 requires 1.43.
+- cht requires 1.41.
+-->
 
 
 ## Road Map

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,14 @@
 //! [sync-seg-cache-struct]: ./sync/struct.SegmentedCache.html
 //! [unsync-cache-struct]: ./unsync/struct.Cache.html
 //!
-//! # Minimum Supported Rust Version
+//! # Minimum Supported Rust Versions
 //!
-//! This crate's minimum supported Rust version (MSRV) is 1.45.2.
+//! This crate's minimum supported Rust versions (MSRV) are the followings:
+//!
+//! | Enabled Feature      | MSRV        |
+//! |:---------------------|:------------|
+//! | no feature (default) | Rust 1.45.2 |
+//! | `future`             | Rust 1.46.0 |
 //!
 //! If no crate feature is enabled, MSRV will be updated conservatively. When using
 //! features like `future`, MSRV might be updated more frequently, up to the latest


### PR DESCRIPTION
Moka's minimum supported Rust version (MSRV) is currently 1.45.2. However, it does not compile anymore on 1.45.2 because the latest version of socket2 crate (0.4.0) requires Rust 1.46.0 or newer. 

Moka indirectly depends on socket2 via async-io or async-std crates:

1. Moka depends on async-io only when "future" feature is enabled.
    - Therefore, we will raise the MSRV for future feature to 1.46.0.
2. Moka depends on async-std only for testing (a dev dependency).
    - We want to keep the MSRV as 1.45.2 when no feature is enabled.

This PR does the followings:

- For 1 (MSRV 1.46.0 for future feature):
    - Update a CI (GitHub Action) job for Rust 1.45.2 to skip a step with `cargo test --release --features future`.
    - Add a CI job for Rust 1.46.0 to run the same step.
- For 2 (MSRV 1.45.2 for no feature enabled), updates `Cargo.toml` to disable default features on async-std.
- Update the README and Rustdoc to explain the latest MSRVs.