### PR TITLE
Stop skeptic from having to be compiled by all downstream users

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,9 @@ on:
     # Run against the last commit on the default branch on Friday at 8pm (UTC?)
     - cron:  '0 20 * * 5'
 
+env:
+  RUSTFLAGS: '--cfg skeptic'
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,5 @@ getrandom = "0.2"
 skeptic = "0.13"
 tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 
-[build-dependencies]
+[target.'cfg(skeptic)'.build-dependencies]
 skeptic = "0.13"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
+#[cfg(skeptic)]
 fn main() {
     // generates doc tests for `README.md`.
     skeptic::generate_doc_tests(&["README.md"]);
 }
+
+#[cfg(not(skeptic))]
+fn main() {}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,2 @@
+#[cfg(skeptic)]
 include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This stops skeptic from having to be included in the build stage of all downstream users of this crate (which I'm currently getting because of [libunftp](https://crates.io/crates/libunftp) depending on this).

skeptic is a [pretty heavy crate](https://crates.io/crates/skeptic/0.13.6/dependencies), depending on other crates like `cargo_metadata`, `error_chain`, `pulldown_cmark` ecc. which in turn depend on a bunch of other stuff. This doesn't make sense to me, as tests for an external crates shouldn't be run by downstream users.

This PR makes it so skeptic tests are only run when compiling with the `RUSTFLAGS="--cfg skeptic"` flag
