### PR TITLE
Add Send + Sync + 'static bounds to K, V and S of sync and future Caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Moka &mdash; Change Log
 
+## Version 0.4.0
+
+### Fixed
+
+- **Breaking change**: Now `sync::{Cache, SegmentedCache}` and `future::Cache`
+  require `Send`, `Sync` and `'static` bounds for the generic parameters `K` (key),
+  `V` (value) and `S` (hasher state). This is necessary to prevent potential
+  undefined behaviors in applications using single-threaded async runtime such as
+  Actix-rt. ([#19][gh-pull-0019])
+
+
 ## Version 0.3.1
 
 ### Changed
@@ -49,6 +60,7 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
+[gh-pull-0019]: https://github.com/moka-rs/moka/pull/19/
 [gh-pull-0016]: https://github.com/moka-rs/moka/pull/16/
 [gh-pull-0011]: https://github.com/moka-rs/moka/pull/11/
 [gh-pull-0009]: https://github.com/moka-rs/moka/pull/9/

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -47,8 +47,8 @@ pub struct CacheBuilder<C> {
 
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
-    K: Eq + Hash,
-    V: Clone,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
     /// up to `max_capacity` entries.
@@ -78,7 +78,7 @@ where
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
-        S: BuildHasher + Clone,
+        S: BuildHasher + Clone + Send + Sync + 'static,
     {
         Cache::with_everything(
             self.max_capacity,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -209,8 +209,8 @@ where
 
 impl<K, V> Cache<K, V, RandomState>
 where
-    K: Hash + Eq,
-    V: Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity` entries.
     ///
@@ -226,9 +226,9 @@ where
 
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn with_everything(
         max_capacity: usize,
@@ -366,8 +366,9 @@ where
 
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self) {
         self.base.inner.sync(MAX_SYNC_REPEATS);
@@ -377,9 +378,9 @@ where
 // private methods
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     async fn insert_with_hash(&self, key: K, hash: u64, value: V) {
         let op = self.base.do_insert_with_hash(key, hash, value);
@@ -444,8 +445,9 @@ where
 #[cfg(test)]
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -107,20 +107,15 @@ use std::{
 ///     }
 /// }
 /// ```
+///
 /// # Thread Safety
 ///
 /// All methods provided by the `Cache` are considered thread-safe, and can be safely
 /// accessed by multiple concurrent threads.
 ///
-/// `Cache<K, V, S>` will implement `Send` when all of the following conditions meet:
-///
-/// - `K` (key) and `V` (value) implement `Send` and `Sync`.
-/// - `S` (the hash-map state) implements `Send`.
-///
-/// and will implement `Sync` when all of the following conditions meet:
-///
-/// - `K` (key) and `V` (value) implement `Send` and `Sync`.
-/// - `S` (the hash-map state) implements `Sync`.
+/// - `Cache<K, V, S>` requires trait bounds `Send`, `Sync` and `'static` for `K`
+///   (key), `V` (value) and `S` (hasher state).
+/// - `Cache<K, V, S>` will implement `Send` and `Sync`.
 ///
 /// # Sharing a cache across asynchronous tasks
 ///

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -74,9 +74,9 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
 
 impl<K, V, S> BaseCache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn new(
         max_capacity: usize,
@@ -196,9 +196,9 @@ where
 //
 impl<K, V, S> BaseCache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     #[inline]
     fn record_read_op(&self, op: ReadOp<K, V>) -> Result<(), TrySendError<ReadOp<K, V>>> {
@@ -296,8 +296,9 @@ where
 #[cfg(test)]
 impl<K, V, S> BaseCache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.len() == 0
@@ -463,8 +464,9 @@ where
 
 impl<K, V, S> InnerSync for Inner<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self, max_repeats: usize) -> Option<SyncPace> {
         const EVICTION_BATCH_SIZE: usize = 500;
@@ -509,8 +511,9 @@ where
 //
 impl<K, V, S> Inner<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn apply_reads(&self, deqs: &mut Deques<K>, count: usize) {
         use ReadOp::*;

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -49,8 +49,8 @@ pub struct CacheBuilder<C> {
 
 impl<K, V> CacheBuilder<Cache<K, V, RandomState>>
 where
-    K: Eq + Hash,
-    V: Clone,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
     /// `SegmentedCache` holding up to `max_capacity` entries.
@@ -104,7 +104,7 @@ where
     /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
-        S: BuildHasher + Clone,
+        S: BuildHasher + Clone + Send + Sync + 'static,
     {
         Cache::with_everything(
             self.max_capacity,
@@ -118,8 +118,8 @@ where
 
 impl<K, V> CacheBuilder<SegmentedCache<K, V, RandomState>>
 where
-    K: Eq + Hash,
-    V: Clone,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Builds a `SegmentedCache<K, V>`.
     ///
@@ -143,7 +143,7 @@ where
     /// calling this method.
     pub fn build_with_hasher<S>(self, hasher: S) -> SegmentedCache<K, V, S>
     where
-        S: BuildHasher + Clone,
+        S: BuildHasher + Clone + Send + Sync + 'static,
     {
         SegmentedCache::with_everything(
             self.max_capacity,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -187,8 +187,9 @@ where
 
 impl<K, V> Cache<K, V, RandomState>
 where
-    K: Hash + Eq,
-    V: Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity` entries.
     ///
@@ -204,9 +205,9 @@ where
 
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn with_everything(
         max_capacity: usize,
@@ -321,8 +322,9 @@ where
 
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self) {
         self.base.inner.sync(MAX_SYNC_REPEATS);
@@ -332,9 +334,9 @@ where
 // private methods
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     #[inline]
     fn schedule_write_op(
@@ -367,8 +369,9 @@ where
 #[cfg(test)]
 impl<K, V, S> Cache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn reconfigure_for_testing(&mut self) {
         self.base.reconfigure_for_testing();

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -90,15 +90,9 @@ use std::{
 /// All methods provided by the `Cache` are considered thread-safe, and can be safely
 /// accessed by multiple concurrent threads.
 ///
-/// `Cache<K, V, S>` will implement `Send` when all of the following conditions meet:
-///
-/// - `K` (key) and `V` (value) implement `Send` and `Sync`.
-/// - `S` (the hash-map state) implements `Send`.
-///
-/// and will implement `Sync` when all of the following conditions meet:
-///
-/// - `K` (key) and `V` (value) implement `Send` and `Sync`.
-/// - `S` (the hash-map state) implements `Sync`.
+/// - `Cache<K, V, S>` requires trait bounds `Send`, `Sync` and `'static` for `K`
+///   (key), `V` (value) and `S` (hasher state).
+/// - `Cache<K, V, S>` will implement `Send` and `Sync`.
 ///
 /// # Sharing a cache across threads
 ///

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -52,8 +52,8 @@ impl<K, V, S> Clone for SegmentedCache<K, V, S> {
 
 impl<K, V> SegmentedCache<K, V, RandomState>
 where
-    K: Hash + Eq,
-    V: Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     /// Constructs a new `SegmentedCache<K, V>` that has multiple internal
     /// segments and will store up to the `max_capacity` entries.
@@ -74,9 +74,9 @@ where
 
 impl<K, V, S> SegmentedCache<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     /// # Panics
     ///
@@ -179,8 +179,9 @@ where
 
 impl<K, V, S> ConcurrentCacheExt<K, V> for SegmentedCache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn sync(&self) {
         for segment in self.inner.segments.iter() {
@@ -193,8 +194,9 @@ where
 #[cfg(test)]
 impl<K, V, S> SegmentedCache<K, V, S>
 where
-    K: Hash + Eq,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn reconfigure_for_testing(&mut self) {
         let inner = Arc::get_mut(&mut self.inner)
@@ -215,9 +217,9 @@ struct Inner<K, V, S> {
 
 impl<K, V, S> Inner<K, V, S>
 where
-    K: Hash + Eq,
-    V: Clone,
-    S: BuildHasher + Clone,
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
 {
     /// # Panics
     ///


### PR DESCRIPTION
This PR adds `Send`, `Sync` and `'static` bounds to the type parameters `K` (key), `V` (value) and `S` (hasher state) of the following cache implementations:

- `sync::Cache`
- `sync::SegmentedCache`
- `future::Cache`

This will prevent the following usage from drawing undefined behavior:

- Single thread application using an above thread-safe cache.
- Store non-`Send` or non-`Sync` type (such as `std::rc::Rc`) as key (`K`) and/or (`Value`).
- Or, store non static reference type as key and/or value.

Until now, storing such key or value types was possible in _single thread_ application (including single-threaded async runtime such as Actix-rt) because above caches did not ask these bounds explicitly. 

However doing so is incorrect as it can draw undefined behavior. This is because these caches use multiple threads internally for updating internal data structures and evicting cached values.

```rust
use std::{rc::Rc, time::Duration};

// This code will compile, but cat hit an undefined behavior (UB) as breaking
// thread safety guarantee of std::rc::Rc.

// Create a sync::Cache with TTL 1 second.
let cache = moka::sync::CacheBuilder::new(100)
    .time_to_live(Duration::from_secs(1))
    .build();

// Create a Rc, which is !Send and !Sync. (Rc's strong reference count should be 1)
let v = Rc::new("Hello".to_string());

// Insert a clone of RC to the cache. (The strong count should be 2 now)
cache.insert(0, Rc::clone(&v));

// Sleep for 5 seconds.
std::thread::sleep(Duration::from_secs(5));

// While sleeping, the value `v` should have been expired so sync::Cache's
// eviction thread will drop it. Dropping will make the strong count to be
// decremented by 1 but this thread may not see the decrement as Rc is
// neither Send nor Sync.

println!("{}", Rc::strong_count(&v));  // 1 or 2? (*1)
```

Adding `Send`, `Sync` and `'static` bounds should prevent the problem by making such code not to compile by type errors.

Note that multi-thread APIs such as `std::thread::spawn` or multi-threaded async runtime (such as the ones provided by Tokio and async-std) will ask those bounds explicitly. So there should have been no problem with them.

----

*1: I wrote the code for illustrating purpose. If you actually run the code, it will always prints `2`. However, this does not mean you hit the UB, but it is actually an expected behavior. `sync::Cache` and `future::Cache` employ concurrent hash table `cht::SegmentedHashMap` as the main key value storage. cht will not drop a removed value immediately by the spec to provide high concurrency and thread safety. See this issue for more details: https://github.com/Gregory-Meyer/cht/issues/23
