### PR TITLE
Enable hash-arg feature in moka-cht

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 
@@ -24,8 +24,12 @@ default = []
 future = ["async-io", "async-lock"]
 
 [dependencies]
-cht = "0.4"
 crossbeam-channel = "0.5"
+
+# moka-cht = { version = "0.6", default-features = false, features = ["hash-arg"] }
+moka-cht = { git = "https://github.com/moka-rs/moka-cht", branch = "hash-arg", default-features = false, features = ["hash-arg"] }
+# moka-cht = { version = "0.6", path = "../moka-cht", default-features = false, features = ["hash-arg"] }
+
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -27,14 +27,14 @@ use std::{
 /// `Cache` supports full concurrency of retrievals and a high expected concurrency
 /// for updates. It can be accessed inside and outside of asynchronous contexts.
 ///
-/// `Cache` utilizes a lock-free concurrent hash table `cht::SegmentedHashMap` from
-/// the [cht][cht-crate] crate for the central key-value storage. `Cache` performs a
-/// best-effort bounding of the map using an entry replacement algorithm to determine
-/// which entries to evict when the capacity is exceeded.
+/// `Cache` utilizes a lock-free concurrent hash table `SegmentedHashMap` from the
+/// [moka-cht][moka-cht-crate] crate for the central key-value storage. `Cache`
+/// performs a best-effort bounding of the map using an entry replacement algorithm
+/// to determine which entries to evict when the capacity is exceeded.
 ///
 /// To use this cache, enable a crate feature called "future".
 ///
-/// [cht-crate]: https://crates.io/crates/cht
+/// [moka-cht-crate]: https://crates.io/crates/moka-cht
 ///
 /// # Examples
 ///
@@ -171,15 +171,13 @@ use std::{
 /// # Hashing Algorithm
 ///
 /// By default, `Cache` uses a hashing algorithm selected to provide resistance
-/// against HashDoS attacks.
+/// against HashDoS attacks. It will be the same one used by
+/// `std::collections::HashMap`, which is currently SipHash 1-3.
 ///
-/// The default hashing algorithm is the one used by `std::collections::HashMap`,
-/// which is currently SipHash 1-3.
-///
-/// While its performance is very competitive for medium sized keys, other hashing
-/// algorithms will outperform it for small keys such as integers as well as large
-/// keys such as long strings. However those algorithms will typically not protect
-/// against attacks such as HashDoS.
+/// While SipHash's performance is very competitive for medium sized keys, other
+/// hashing algorithms will outperform it for small keys such as integers as well as
+/// large keys such as long strings. However those algorithms will typically not
+/// protect against attacks such as HashDoS.
 ///
 /// The hashing algorithm can be replaced on a per-`Cache` basis using the
 /// [`build_with_hasher`][build-with-hasher-method] method of the
@@ -340,7 +338,8 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if let Some(entry) = self.base.remove(key) {
+        let hash = self.base.hash(key);
+        if let Some(entry) = self.base.remove(key, hash) {
             let op = WriteOp::Remove(entry);
             let hk = self.base.housekeeper.as_ref();
             if Self::schedule_write_op(&self.base.write_op_ch, op, hk)
@@ -362,7 +361,8 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if let Some(entry) = self.base.remove(key) {
+        let hash = self.base.hash(key);
+        if let Some(entry) = self.base.remove(key, hash) {
             let op = WriteOp::Remove(entry);
             let hk = self.base.housekeeper.as_ref();
             if Self::blocking_schedule_write_op(&self.base.write_op_ch, op, hk).is_err() {

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -15,7 +15,7 @@ pub(crate) enum InitResult<V> {
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
-    waiters: cht::HashMap<Arc<K>, Waiter<V>, S>,
+    waiters: moka_cht::SegmentedHashMap<Arc<K>, Waiter<V>, S>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
@@ -26,7 +26,7 @@ where
 {
     pub(crate) fn with_hasher(hasher: S) -> Self {
         Self {
-            waiters: cht::HashMap::with_hasher(hasher),
+            waiters: moka_cht::SegmentedHashMap::with_num_segments_and_hasher(16, hasher),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,19 +6,19 @@
 //!
 //! Moka provides in-memory concurrent cache implementations that support full
 //! concurrency of retrievals and a high expected concurrency for updates. <!-- , and multiple ways to bound the cache. -->
-//! They utilize a lock-free concurrent hash table `cht::SegmentedHashMap` from the
-//! [cht][cht-crate] crate for the central key-value storage.
+//! They utilize a lock-free concurrent hash table `SegmentedHashMap` from the
+//! [moka-cht][moka-cht-crate] crate for the central key-value storage.
 //!
 //! Moka also provides an in-memory, not thread-safe cache implementation for single
 //! thread applications.
 //!
-//! All cache implementations perform a best-effort bounding of the map using an entry
-//! replacement algorithm to determine which entries to evict when the capacity is
-//! exceeded.
+//! All cache implementations perform a best-effort bounding of the map using an
+//! entry replacement algorithm to determine which entries to evict when the capacity
+//! is exceeded.
 //!
 //! [caffeine-git]: https://github.com/ben-manes/caffeine
 //! [ristretto-git]: https://github.com/dgraph-io/ristretto
-//! [cht-crate]: https://crates.io/crates/cht
+//! [moka-cht-crate]: https://crates.io/crates/moka-cht
 //!
 //! # Features
 //!

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -189,7 +189,7 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.inner.hash(key);
-        self.inner.select(hash).invalidate(key);
+        self.inner.select(hash).invalidate_with_hash(key, hash);
     }
 
     /// Discards all cached values.

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -14,7 +14,7 @@ pub(crate) enum InitResult<V> {
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
-    waiters: cht::HashMap<Arc<K>, Waiter<V>, S>,
+    waiters: moka_cht::SegmentedHashMap<Arc<K>, Waiter<V>, S>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
@@ -25,7 +25,7 @@ where
 {
     pub(crate) fn with_hasher(hasher: S) -> Self {
         Self {
-            waiters: cht::HashMap::with_hasher(hasher),
+            waiters: moka_cht::SegmentedHashMap::with_num_segments_and_hasher(16, hasher),
         }
     }
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -91,15 +91,13 @@ type CacheStore<K, V, S> = std::collections::HashMap<Rc<K>, ValueEntry<K, V>, S>
 /// # Hashing Algorithm
 ///
 /// By default, `Cache` uses a hashing algorithm selected to provide resistance
-/// against HashDoS attacks.
+/// against HashDoS attacks. It will the same one used by
+/// `std::collections::HashMap`, which is currently SipHash 1-3.
 ///
-/// The default hashing algorithm is the one used by `std::collections::HashMap`,
-/// which is currently SipHash 1-3.
-///
-/// While its performance is very competitive for medium sized keys, other hashing
-/// algorithms will outperform it for small keys such as integers as well as large
-/// keys such as long strings. However those algorithms will typically not protect
-/// against attacks such as HashDoS.
+/// While SipHash's performance is very competitive for medium sized keys, other
+/// hashing algorithms will outperform it for small keys such as integers as well as
+/// large keys such as long strings. However those algorithms will typically not
+/// protect against attacks such as HashDoS.
 ///
 /// The hashing algorithm can be replaced on a per-`Cache` basis using the
 /// [`build_with_hasher`][build-with-hasher-method] method of the


### PR DESCRIPTION
Utilize moka-cht's `hash-arg` feature to avoid calculating the same hash twice for a key at both Moka cache and cht sides.
