### PR TITLE
Change get_or_try_insert_with to return a concrete error type rather than a trait object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka &mdash; Change Log
 
+## Version 0.6.0 (Unreleased)
+
+### Changed
+
+- Change `get_or_try_insert_with` to return a concrete error type rather
+  than a trait object. ([#23][gh-pull-0023])
+
+
 ## Version 0.5.1
 
 ### Changed
@@ -81,6 +89,7 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
+[gh-pull-0023]: https://github.com/moka-rs/moka/pull/23/
 [gh-pull-0022]: https://github.com/moka-rs/moka/pull/22/
 [gh-pull-0020]: https://github.com/moka-rs/moka/pull/20/
 [gh-pull-0019]: https://github.com/moka-rs/moka/pull/19/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-moka = "0.5"
+moka = "0.6"
 ```
 
 To use the asynchronous cache, enable a crate feature called "future".
 
 ```toml
 [dependencies]
-moka = { version = "0.5", features = ["future"] }
+moka = { version = "0.6", features = ["future"] }
 ```
 
 
@@ -164,7 +164,7 @@ Here is a similar program to the previous example, but using asynchronous cache 
 // Cargo.toml
 //
 // [dependencies]
-// moka = { version = "0.5", features = ["future"] }
+// moka = { version = "0.6", features = ["future"] }
 // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 // futures = "0.3"
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1041,7 +1041,7 @@ mod tests {
             let cache1 = cache.clone();
             async move {
                 // Call `get_or_try_insert_with` immediately.
-                let v: MyResult<_> = cache1
+                let v = cache1
                     .get_or_try_insert_with(KEY, async {
                         // Wait for 300 ms and return an error.
                         Timer::after(Duration::from_millis(300)).await;

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -291,8 +291,8 @@ where
     ///
     /// This method prevents to resolve the init future multiple times on the same
     /// key even if the method is concurrently called by many async tasks; only one
-    /// of the calls resolves its future, and other calls wait for that future to
-    /// complete.
+    /// of the calls resolves its future (as long as these futures return the same
+    /// error type), and other calls wait for that future to complete.
     pub async fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
         F: Future<Output = Result<V, E>>,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -292,15 +292,11 @@ where
     /// key even if the method is concurrently called by many async tasks; only one
     /// of the calls resolves its future, and other calls wait for that future to
     /// complete.
-    #[allow(clippy::redundant_allocation)]
-    // https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
-    // `Arc<Box<dyn ..>>` in the return type creates an extra heap allocation.
-    // This will be addressed by Moka v0.6.0.
     pub async fn get_or_try_insert_with<F>(
         &self,
         key: K,
         init: F,
-    ) -> Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>
+    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
     where
         F: Future<Output = Result<V, Box<dyn Error + Send + Sync + 'static>>>,
     {
@@ -486,16 +482,12 @@ where
         }
     }
 
-    #[allow(clippy::redundant_allocation)]
-    // https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
-    // `Arc<Box<dyn ..>>` in the return type creates an extra heap allocation.
-    // This will be addressed by Moka v0.6.0.
     async fn get_or_try_insert_with_hash_and_fun<F>(
         &self,
         key: Arc<K>,
         hash: u64,
         init: F,
-    ) -> Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>
+    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
     where
         F: Future<Output = Result<V, Box<dyn Error + Send + Sync + 'static>>>,
     {

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -1,21 +1,27 @@
 use async_lock::RwLock;
 use std::{
+    any::{Any, TypeId},
     error::Error,
     future::Future,
     hash::{BuildHasher, Hash},
     sync::Arc,
 };
 
-type Waiter<V> = Arc<RwLock<Option<Result<V, Arc<dyn Error + Send + Sync + 'static>>>>>;
+type ErrorObject = Arc<dyn Any + Send + Sync + 'static>;
+type Waiter<V> = Arc<RwLock<Option<Result<V, ErrorObject>>>>;
 
-pub(crate) enum InitResult<V> {
+pub(crate) enum InitResult<V, E> {
     Initialized(V),
     ReadExisting(V),
-    InitErr(Arc<dyn Error + Send + Sync + 'static>),
+    InitErr(Arc<E>),
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
-    waiters: moka_cht::SegmentedHashMap<Arc<K>, Waiter<V>, S>,
+    // TypeId is the type ID of the concrete error type of generic type E in
+    // try_init_or_read(). We use the type ID as a part of the key to ensure that
+    // we can always downcast the trait object ErrorObject (in Waiter<V>) into
+    // its concrete type.
+    waiters: moka_cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
@@ -30,16 +36,17 @@ where
         }
     }
 
-    pub(crate) async fn init_or_read<F>(&self, key: Arc<K>, init: F) -> InitResult<V>
+    pub(crate) async fn init_or_read<F>(&self, key: Arc<K>, init: F) -> InitResult<V, ()>
     where
         F: Future<Output = V>,
     {
         use InitResult::*;
 
+        let type_id = TypeId::of::<()>();
         let waiter = Arc::new(RwLock::new(None));
         let mut lock = waiter.write().await;
 
-        match self.try_insert_waiter(&key, &waiter) {
+        match self.try_insert_waiter(&key, type_id, &waiter) {
             None => {
                 // Inserted. Resolve the init future.
                 let value = init.await;
@@ -58,16 +65,18 @@ where
         }
     }
 
-    pub(crate) async fn try_init_or_read<F>(&self, key: Arc<K>, init: F) -> InitResult<V>
+    pub(crate) async fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
     where
-        F: Future<Output = Result<V, Box<dyn Error + Send + Sync + 'static>>>,
+        F: Future<Output = Result<V, E>>,
+        E: Error + Send + Sync + 'static,
     {
         use InitResult::*;
 
+        let type_id = TypeId::of::<E>();
         let waiter = Arc::new(RwLock::new(None));
         let mut lock = waiter.write().await;
 
-        match self.try_insert_waiter(&key, &waiter) {
+        match self.try_insert_waiter(&key, type_id, &waiter) {
             None => {
                 // Inserted. Resolve the init future.
                 match init.await {
@@ -76,10 +85,10 @@ where
                         Initialized(value)
                     }
                     Err(e) => {
-                        let err = Arc::from(e);
+                        let err: ErrorObject = Arc::new(e);
                         *lock = Some(Err(Arc::clone(&err)));
-                        self.remove_waiter(&key);
-                        InitErr(err)
+                        self.remove_waiter(&key, type_id);
+                        InitErr(err.downcast().unwrap())
                     }
                 }
             }
@@ -89,7 +98,7 @@ where
                 std::mem::drop(lock);
                 match &*res.read().await {
                     Some(Ok(value)) => ReadExisting(value.clone()),
-                    Some(Err(e)) => InitErr(Arc::clone(e)),
+                    Some(Err(e)) => InitErr(Arc::clone(e).downcast().unwrap()),
                     None => unreachable!(),
                 }
             }
@@ -97,15 +106,21 @@ where
     }
 
     #[inline]
-    pub(crate) fn remove_waiter(&self, key: &Arc<K>) {
-        self.waiters.remove(key);
+    pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
+        let key = Arc::clone(key);
+        self.waiters.remove(&(key, type_id));
     }
 
-    fn try_insert_waiter(&self, key: &Arc<K>, waiter: &Waiter<V>) -> Option<Waiter<V>> {
+    fn try_insert_waiter(
+        &self,
+        key: &Arc<K>,
+        type_id: TypeId,
+        waiter: &Waiter<V>,
+    ) -> Option<Waiter<V>> {
         let key = Arc::clone(key);
         let waiter = Arc::clone(waiter);
 
         self.waiters
-            .insert_with_or_modify(key, || waiter, |_, w| Arc::clone(w))
+            .insert_with_or_modify((key, type_id), || waiter, |_, w| Arc::clone(w))
     }
 }

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -6,16 +6,12 @@ use std::{
     sync::Arc,
 };
 
-type Waiter<V> = Arc<RwLock<Option<Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>>>>;
+type Waiter<V> = Arc<RwLock<Option<Result<V, Arc<dyn Error + Send + Sync + 'static>>>>>;
 
-#[allow(clippy::redundant_allocation)]
-// https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
 pub(crate) enum InitResult<V> {
     Initialized(V),
     ReadExisting(V),
-    // This `Arc<Box<dyn ..>>` creates an extra heap allocation. This will be
-    // addressed by Moka v0.6.0.
-    InitErr(Arc<Box<dyn Error + Send + Sync + 'static>>),
+    InitErr(Arc<dyn Error + Send + Sync + 'static>),
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
@@ -80,7 +76,7 @@ where
                         Initialized(value)
                     }
                     Err(e) => {
-                        let err = Arc::new(e);
+                        let err = Arc::from(e);
                         *lock = Some(Err(Arc::clone(&err)));
                         self.remove_waiter(&key);
                         InitErr(err)

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -255,9 +255,9 @@ where
     /// Ensures the value of the key exists by inserting the result of the init
     /// function if not exist, and returns a _clone_ of the value.
     ///
-    /// This method prevents to evaluate the init function multiple times on the same
+    /// This method prevents to evaluate the init closure multiple times on the same
     /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its function, and other calls wait for that function to
+    /// the calls evaluates its closure, and other calls wait for that closure to
     /// complete.
     pub fn get_or_insert_with(&self, key: K, init: impl FnOnce() -> V) -> V {
         let hash = self.base.hash(&key);
@@ -288,13 +288,13 @@ where
     }
 
     /// Try to ensure the value of the key exists by inserting an `Ok` result of the
-    /// init function if not exist, and returns a _clone_ of the value or the `Err`
-    /// returned by the function.
+    /// init closure if not exist, and returns a _clone_ of the value or the `Err`
+    /// returned by the closure.
     ///
-    /// This method prevents to evaluate the init function multiple times on the same
+    /// This method prevents to evaluate the init closure multiple times on the same
     /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its function, and other calls wait for that function to
-    /// complete.
+    /// the calls evaluates its closure (as long as these closures return the same
+    /// error type), and other calls wait for that closure to complete.
     pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
         F: FnOnce() -> Result<V, E>,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -8,6 +8,7 @@ use crate::{sync::value_initializer::InitResult, PredicateError};
 
 use crossbeam_channel::{Sender, TrySendError};
 use std::{
+    any::TypeId,
     borrow::Borrow,
     collections::hash_map::RandomState,
     error::Error,
@@ -277,7 +278,8 @@ where
         match self.value_initializer.init_or_read(Arc::clone(&key), init) {
             InitResult::Initialized(v) => {
                 self.insert_with_hash(Arc::clone(&key), hash, v.clone());
-                self.value_initializer.remove_waiter(&key);
+                self.value_initializer
+                    .remove_waiter(&key, TypeId::of::<()>());
                 v
             }
             InitResult::ReadExisting(v) => v,
@@ -293,27 +295,25 @@ where
     /// key even if the method is concurrently called by many threads; only one of
     /// the calls evaluates its function, and other calls wait for that function to
     /// complete.
-    pub fn get_or_try_insert_with<F>(
-        &self,
-        key: K,
-        init: F,
-    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
+    pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
-        F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>,
+        F: FnOnce() -> Result<V, E>,
+        E: Error + Send + Sync + 'static,
     {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
         self.get_or_try_insert_with_hash_and_fun(key, hash, init)
     }
 
-    pub(crate) fn get_or_try_insert_with_hash_and_fun<F>(
+    pub(crate) fn get_or_try_insert_with_hash_and_fun<F, E>(
         &self,
         key: Arc<K>,
         hash: u64,
         init: F,
-    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
+    ) -> Result<V, Arc<E>>
     where
-        F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>,
+        F: FnOnce() -> Result<V, E>,
+        E: Error + Send + Sync + 'static,
     {
         if let Some(v) = self.get_with_hash(&key, hash) {
             return Ok(v);
@@ -325,7 +325,8 @@ where
         {
             InitResult::Initialized(v) => {
                 self.insert_with_hash(Arc::clone(&key), hash, v.clone());
-                self.value_initializer.remove_waiter(&key);
+                self.value_initializer
+                    .remove_waiter(&key, TypeId::of::<E>());
                 Ok(v)
             }
             InitResult::ReadExisting(v) => Ok(v),
@@ -878,7 +879,16 @@ mod tests {
 
     #[test]
     fn get_or_try_insert_with() {
-        use std::thread::{sleep, spawn};
+        use std::{
+            sync::Arc,
+            thread::{sleep, spawn},
+        };
+
+        #[derive(thiserror::Error, Debug)]
+        #[error("{}", _0)]
+        pub struct MyError(String);
+
+        type MyResult<T> = Result<T, Arc<MyError>>;
 
         let cache = Cache::new(100);
         const KEY: u32 = 0;
@@ -892,10 +902,10 @@ mod tests {
             let cache1 = cache.clone();
             spawn(move || {
                 // Call `get_or_try_insert_with` immediately.
-                let v = cache1.get_or_try_insert_with(KEY, || {
+                let v: MyResult<_> = cache1.get_or_try_insert_with(KEY, || {
                     // Wait for 300 ms and return an error.
                     sleep(Duration::from_millis(300));
-                    Err("thread1 error".into())
+                    Err(MyError("thread1 error".into()))
                 });
                 assert!(v.is_err());
             })
@@ -910,7 +920,7 @@ mod tests {
             spawn(move || {
                 // Wait for 100 ms before calling `get_or_try_insert_with`.
                 sleep(Duration::from_millis(100));
-                let v = cache2.get_or_try_insert_with(KEY, || unreachable!());
+                let v: MyResult<_> = cache2.get_or_try_insert_with(KEY, || unreachable!());
                 assert!(v.is_err());
             })
         };
@@ -925,7 +935,7 @@ mod tests {
             spawn(move || {
                 // Wait for 400 ms before calling `get_or_try_insert_with`.
                 sleep(Duration::from_millis(400));
-                let v = cache3.get_or_try_insert_with(KEY, || {
+                let v: MyResult<_> = cache3.get_or_try_insert_with(KEY, || {
                     // Wait for 300 ms and return an Ok(&str) value.
                     sleep(Duration::from_millis(300));
                     Ok("thread3")
@@ -942,7 +952,7 @@ mod tests {
             spawn(move || {
                 // Wait for 500 ms before calling `get_or_try_insert_with`.
                 sleep(Duration::from_millis(500));
-                let v = cache4.get_or_try_insert_with(KEY, || unreachable!());
+                let v: MyResult<_> = cache4.get_or_try_insert_with(KEY, || unreachable!());
                 assert_eq!(v.unwrap(), "thread3");
             })
         };
@@ -957,7 +967,7 @@ mod tests {
             spawn(move || {
                 // Wait for 800 ms before calling `get_or_try_insert_with`.
                 sleep(Duration::from_millis(800));
-                let v = cache5.get_or_try_insert_with(KEY, || unreachable!());
+                let v: MyResult<_> = cache5.get_or_try_insert_with(KEY, || unreachable!());
                 assert_eq!(v.unwrap(), "thread3");
             })
         };

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -293,15 +293,11 @@ where
     /// key even if the method is concurrently called by many threads; only one of
     /// the calls evaluates its function, and other calls wait for that function to
     /// complete.
-    #[allow(clippy::redundant_allocation)]
-    // https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
-    // `Arc<Box<dyn ..>>` in the return type creates an extra heap allocation.
-    // This will be addressed by Moka v0.6.0.
     pub fn get_or_try_insert_with<F>(
         &self,
         key: K,
         init: F,
-    ) -> Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>
+    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
     where
         F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>,
     {
@@ -310,16 +306,12 @@ where
         self.get_or_try_insert_with_hash_and_fun(key, hash, init)
     }
 
-    #[allow(clippy::redundant_allocation)]
-    // https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
-    // `Arc<Box<dyn ..>>` in the return type creates an extra heap allocation.
-    // This will be addressed by Moka v0.6.0.
     pub(crate) fn get_or_try_insert_with_hash_and_fun<F>(
         &self,
         key: Arc<K>,
         hash: u64,
         init: F,
-    ) -> Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>
+    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
     where
         F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>,
     {

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -902,7 +902,7 @@ mod tests {
             let cache1 = cache.clone();
             spawn(move || {
                 // Call `get_or_try_insert_with` immediately.
-                let v: MyResult<_> = cache1.get_or_try_insert_with(KEY, || {
+                let v = cache1.get_or_try_insert_with(KEY, || {
                     // Wait for 300 ms and return an error.
                     sleep(Duration::from_millis(300));
                     Err(MyError("thread1 error".into()))

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -155,15 +155,11 @@ where
     /// key even if the method is concurrently called by many threads; only one of
     /// the calls evaluates its function, and other calls wait for that function to
     /// complete.
-    #[allow(clippy::redundant_allocation)]
-    // https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
-    // `Arc<Box<dyn ..>>` in the return type creates an extra heap allocation.
-    // This will be addressed by Moka v0.6.0.
     pub fn get_or_try_insert_with<F>(
         &self,
         key: K,
         init: F,
-    ) -> Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>
+    ) -> Result<V, Arc<dyn Error + Send + Sync + 'static>>
     where
         F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>,
     {

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -712,7 +712,7 @@ mod tests {
             let cache1 = cache.clone();
             spawn(move || {
                 // Call `get_or_try_insert_with` immediately.
-                let v: MyResult<_> = cache1.get_or_try_insert_with(KEY, || {
+                let v = cache1.get_or_try_insert_with(KEY, || {
                     // Wait for 300 ms and return an error.
                     sleep(Duration::from_millis(300));
                     Err(MyError("thread1 error".into()))

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -133,11 +133,11 @@ where
     }
 
     /// Ensures the value of the key exists by inserting the result of the init
-    /// function if not exist, and returns a _clone_ of the value.
+    /// closure if not exist, and returns a _clone_ of the value.
     ///
-    /// This method prevents to evaluate the init function multiple times on the same
+    /// This method prevents to evaluate the init closure multiple times on the same
     /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its function, and other calls wait for that function to
+    /// the calls evaluates its closure, and other calls wait for that closure to
     /// complete.
     pub fn get_or_insert_with(&self, key: K, init: impl FnOnce() -> V) -> V {
         let hash = self.inner.hash(&key);
@@ -148,13 +148,13 @@ where
     }
 
     /// Try to ensure the value of the key exists by inserting an `Ok` result of the
-    /// init function if not exist, and returns a _clone_ of the value or the `Err`
-    /// returned by the function.
+    /// init closure if not exist, and returns a _clone_ of the value or the `Err`
+    /// returned by the closure.
     ///
-    /// This method prevents to evaluate the init function multiple times on the same
+    /// This method prevents to evaluate the init closure multiple times on the same
     /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its function, and other calls wait for that function to
-    /// complete.
+    /// the calls evaluates its closure (as long as these closures return the same
+    /// error type), and other calls wait for that closure to complete.
     pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
         F: FnOnce() -> Result<V, E>,

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -1,20 +1,26 @@
 use parking_lot::RwLock;
 use std::{
+    any::{Any, TypeId},
     error::Error,
     hash::{BuildHasher, Hash},
     sync::Arc,
 };
 
-type Waiter<V> = Arc<RwLock<Option<Result<V, Arc<dyn Error + Send + Sync + 'static>>>>>;
+type ErrorObject = Arc<dyn Any + Send + Sync + 'static>;
+type Waiter<V> = Arc<RwLock<Option<Result<V, ErrorObject>>>>;
 
-pub(crate) enum InitResult<V> {
+pub(crate) enum InitResult<V, E> {
     Initialized(V),
     ReadExisting(V),
-    InitErr(Arc<dyn Error + Send + Sync + 'static>),
+    InitErr(Arc<E>),
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
-    waiters: moka_cht::SegmentedHashMap<Arc<K>, Waiter<V>, S>,
+    // TypeId is the type ID of the concrete error type of generic type E in
+    // try_init_or_read(). We use the type ID as a part of the key to ensure that
+    // we can always downcast the trait object ErrorObject (in Waiter<V>) into
+    // its concrete type.
+    waiters: moka_cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
@@ -29,13 +35,13 @@ where
         }
     }
 
-    pub(crate) fn init_or_read(&self, key: Arc<K>, init: impl FnOnce() -> V) -> InitResult<V> {
+    pub(crate) fn init_or_read(&self, key: Arc<K>, init: impl FnOnce() -> V) -> InitResult<V, ()> {
         use InitResult::*;
 
         let waiter = Arc::new(RwLock::new(None));
         let mut lock = waiter.write();
 
-        match self.try_insert_waiter(&key, &waiter) {
+        match self.try_insert_waiter(&key, TypeId::of::<()>(), &waiter) {
             None => {
                 // Inserted. Evaluate the init closure.
                 let value = init();
@@ -54,16 +60,18 @@ where
         }
     }
 
-    pub(crate) fn try_init_or_read<F>(&self, key: Arc<K>, init: F) -> InitResult<V>
+    pub(crate) fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
     where
-        F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>,
+        F: FnOnce() -> Result<V, E>,
+        E: Error + Send + Sync + 'static,
     {
         use InitResult::*;
 
+        let type_id = TypeId::of::<E>();
         let waiter = Arc::new(RwLock::new(None));
         let mut lock = waiter.write();
 
-        match self.try_insert_waiter(&key, &waiter) {
+        match self.try_insert_waiter(&key, type_id, &waiter) {
             None => {
                 // Inserted. Evaluate the init closure.
                 match init() {
@@ -72,10 +80,10 @@ where
                         Initialized(value)
                     }
                     Err(e) => {
-                        let err = Arc::from(e);
+                        let err: ErrorObject = Arc::new(e);
                         *lock = Some(Err(Arc::clone(&err)));
-                        self.remove_waiter(&key);
-                        InitErr(err)
+                        self.remove_waiter(&key, type_id);
+                        InitErr(err.downcast().unwrap())
                     }
                 }
             }
@@ -85,7 +93,7 @@ where
                 std::mem::drop(lock);
                 match &*res.read() {
                     Some(Ok(value)) => ReadExisting(value.clone()),
-                    Some(Err(e)) => InitErr(Arc::clone(e)),
+                    Some(Err(e)) => InitErr(Arc::clone(e).downcast().unwrap()),
                     None => unreachable!(),
                 }
             }
@@ -93,15 +101,21 @@ where
     }
 
     #[inline]
-    pub(crate) fn remove_waiter(&self, key: &Arc<K>) {
-        self.waiters.remove(key);
+    pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
+        let key = Arc::clone(key);
+        self.waiters.remove(&(key, type_id));
     }
 
-    fn try_insert_waiter(&self, key: &Arc<K>, waiter: &Waiter<V>) -> Option<Waiter<V>> {
+    fn try_insert_waiter(
+        &self,
+        key: &Arc<K>,
+        type_id: TypeId,
+        waiter: &Waiter<V>,
+    ) -> Option<Waiter<V>> {
         let key = Arc::clone(key);
         let waiter = Arc::clone(waiter);
 
         self.waiters
-            .insert_with_or_modify(key, || waiter, |_, w| Arc::clone(w))
+            .insert_with_or_modify((key, type_id), || waiter, |_, w| Arc::clone(w))
     }
 }

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -5,16 +5,12 @@ use std::{
     sync::Arc,
 };
 
-type Waiter<V> = Arc<RwLock<Option<Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>>>>;
+type Waiter<V> = Arc<RwLock<Option<Result<V, Arc<dyn Error + Send + Sync + 'static>>>>>;
 
-#[allow(clippy::redundant_allocation)]
-// https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
 pub(crate) enum InitResult<V> {
     Initialized(V),
     ReadExisting(V),
-    // This `Arc<Box<dyn ..>>` creates an extra heap allocation. This will be
-    // addressed by Moka v0.6.0.
-    InitErr(Arc<Box<dyn Error + Send + Sync + 'static>>),
+    InitErr(Arc<dyn Error + Send + Sync + 'static>),
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
@@ -76,7 +72,7 @@ where
                         Initialized(value)
                     }
                     Err(e) => {
-                        let err = Arc::new(e);
+                        let err = Arc::from(e);
                         *lock = Some(Err(Arc::clone(&err)));
                         self.remove_waiter(&key);
                         InitErr(err)


### PR DESCRIPTION
Change `get_or_try_insert_with` of `sync::{Cache, SegmentedCache}` and `future::Cache` to return a concrete error type rather than a trait object.

**Before** (`sync::Cache`)

```rust
pub fn get_or_try_insert_with<F>(&self, key: K, init: F) ->
    Result<V, Arc<Box<dyn Error + Send + Sync + 'static>>>
where
    F: FnOnce() -> Result<V, Box<dyn Error + Send + Sync + 'static>>
```

**After**

```rust
pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
where
    F: FnOnce() -> Result<V, E>,
    E: Error + Send + Sync + 'static,
```

## Behavior Change

There is a subtle change in the behavior. `get_or_try_insert_with` used to guarantee that the closure `F` to evaluate once even if multiple threads call it at the same time on the same cache key.

Now this is not always true:
- Only one of the closures must be evaluated if the closures in all concurrent calls on the same cache key return _the same_ concrete error type.
- One closure of each error type should be evaluated if the closures in concurrent calls on the same cache key does not return the same concrete error type. 
