### PR TITLE
Handle `usize` overflow on big cache capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Moka &mdash; Change Log
 
+## Version 0.5.2
+
+### Fixed
+
+- Handle `usize` overflow on big cache capacity. ([#28][gh-pull-0028])
+
+
 ## Version 0.5.1
 
 ### Changed
@@ -81,6 +88,7 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
+[gh-pull-0028]: https://github.com/moka-rs/moka/pull/28/
 [gh-pull-0022]: https://github.com/moka-rs/moka/pull/22/
 [gh-pull-0020]: https://github.com/moka-rs/moka/pull/20/
 [gh-pull-0019]: https://github.com/moka-rs/moka/pull/19/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Handle `usize` overflow on big cache capacity. ([#28][gh-pull-0028])
+- `usize` overflow on big cache capacity. ([#28][gh-pull-0028])
 
 
 ## Version 0.5.1

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -71,7 +71,7 @@ impl FrequencySketch {
     pub(crate) fn with_capacity(cap: u32) -> Self {
         // The max byte size of the table `[u64; table_size]`:
         // - 8GiB for 32-bit or 64-bit addressing. (Can track about one billion keys)
-        // - 8KiB for 16-bit addressing. (Can track about one thousand keys). 
+        // - 8KiB for 16-bit addressing. (Can track about one thousand keys).
         let maximum = if cfg!(target_pointer_width = "16") {
             cap.min(1024)
         } else {

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -16,7 +16,7 @@
 /// and an aging process periodically halves the popularity of all elements.
 pub(crate) struct FrequencySketch {
     sample_size: u32,
-    table_mask: u32,
+    table_mask: u64,
     table: Box<[u64]>,
     size: u32,
 }
@@ -92,7 +92,7 @@ impl FrequencySketch {
             maximum.next_power_of_two()
         };
         let table = vec![0; table_size as usize].into_boxed_slice();
-        let table_mask = 0.max(table_size - 1);
+        let table_mask = 0.max(table_size - 1) as u64;
         let sample_size = if cap == 0 {
             10
         } else {
@@ -170,7 +170,7 @@ impl FrequencySketch {
         let i = depth as usize;
         let mut hash = hash.wrapping_add(SEED[i]).wrapping_mul(SEED[i]);
         hash += hash >> 32;
-        (hash as u32 & self.table_mask) as usize
+        (hash & self.table_mask) as usize
     }
 }
 

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -174,6 +174,14 @@ impl FrequencySketch {
     }
 }
 
+// Methods only available for testing.
+#[cfg(test)]
+impl FrequencySketch {
+    pub(crate) fn table_len(&self) -> usize {
+        self.table.len()
+    }
+}
+
 // Some test cases were ported from Caffeine at:
 // https://github.com/ben-manes/caffeine/blob/master/caffeine/src/test/java/com/github/benmanes/caffeine/cache/FrequencySketchTest.java
 //

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -19,6 +19,7 @@ use quanta::{Clock, Instant};
 use std::{
     borrow::Borrow,
     collections::hash_map::RandomState,
+    convert::TryInto,
     hash::{BuildHasher, Hash, Hasher},
     ptr::NonNull,
     rc::Rc,
@@ -392,7 +393,12 @@ where
             initial_capacity,
             build_hasher.clone(),
         );
-        let skt_capacity = usize::max(max_capacity * 32, 100);
+
+        // Ensure skt_capacity fits in a range of `128u32..=u32::MAX`.
+        let skt_capacity = max_capacity
+            .try_into() // Convert to u32.
+            .unwrap_or(u32::MAX)
+            .max(128);
         let frequency_sketch = FrequencySketch::with_capacity(skt_capacity);
 
         Self {

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -772,4 +772,44 @@ mod tests {
         assert_eq!(cache.get(&"b"), None);
         assert!(cache.cache.is_empty());
     }
+
+    #[cfg_attr(target_pointer_width = "16", ignore)]
+    #[test]
+    fn test_skt_capacity_will_not_overflow() {
+        // power of two
+        let pot = |exp| 2_usize.pow(exp);
+
+        let ensure_sketch_len = |max_capacity, len, name| {
+            let cache = Cache::<u8, u8>::new(max_capacity);
+            assert_eq!(cache.frequency_sketch.table_len(), len, "{}", name);
+        };
+
+        if cfg!(target_pointer_width = "32") {
+            let pot24 = pot(24);
+            let pot16 = pot(16);
+            ensure_sketch_len(0, 128, "0");
+            ensure_sketch_len(128, 128, "128");
+            ensure_sketch_len(pot16, pot16, "pot16");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot24 - 1, pot24, "pot24 - 1");
+            ensure_sketch_len(pot24, pot24, "pot24");
+            ensure_sketch_len(pot(27), pot24, "pot(27)");
+            ensure_sketch_len(usize::MAX, pot24, "usize::MAX");
+        } else {
+            // target_pointer_width: 64 or larger.
+            let pot30 = pot(30);
+            let pot16 = pot(16);
+            ensure_sketch_len(0, 128, "0");
+            ensure_sketch_len(128, 128, "128");
+            ensure_sketch_len(pot16, pot16, "pot16");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
+            ensure_sketch_len(pot30, pot30, "pot30");
+            ensure_sketch_len(usize::MAX, pot30, "usize::MAX");
+        };
+    }
 }

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -9,6 +9,7 @@ use quanta::{Clock, Instant};
 use std::{
     borrow::Borrow,
     collections::{hash_map::RandomState, HashMap},
+    convert::TryInto,
     hash::{BuildHasher, Hash, Hasher},
     ptr::NonNull,
     rc::Rc,
@@ -153,7 +154,12 @@ where
             initial_capacity.unwrap_or_default(),
             build_hasher.clone(),
         );
-        let skt_capacity = usize::max(max_capacity * 32, 100);
+
+        // Ensure skt_capacity fits in a range of `128u32..=u32::MAX`.
+        let skt_capacity = max_capacity
+            .try_into() // Convert to u32.
+            .unwrap_or(u32::MAX)
+            .max(128);
         let frequency_sketch = FrequencySketch::with_capacity(skt_capacity);
         Self {
             max_capacity,


### PR DESCRIPTION
This PR fixes the issue #25, `usize` multiply overflow on big cache capacity.

## Changes

- Removed the multiply operation (`max_capacity * 32`) when setting the capacity of the popularity estimator `FrequencySketch`.
    - The implementation of the estimator was replaced in an older version of Moka and the multiply operation was not really needed since then.
- Added code to ensure that the capacity of the popularity estimator always fits within a range of `128u32..=u32::MAX`.
- Changed the type of the internal fields of the estimator from `usize` to `u32` so that the estimator will work consistency on any platform with different pointer width.

## Verification

- Added unit tests to `sync::base_cache` and `unsync::cache` modules to ensure overflows should not happen and sizes of the population estimators are correct:
    - Before applying the fix, ran the tests with the debug profile and confirmed they panicked as expected:
      ```
      ---- sync::base_cache::tests::test_skt_capacity_will_not_overflow stdout ----
      thread 'sync::base_cache::tests::test_skt_capacity_will_not_overflow' panicked at
      'attempt to multiply with overflow', src/sync/base_cache.rs:395:39
      ```
    - After applying the fix, ran the tests again and verified they passed. **PASSED**
- Ran some mokabench workloads on Moka before/after the fix and verified that hit rates and run-time durations did not change. **PASSED**

----
Fixes #25 