### PR TITLE
Downgrade crossbeam-epoch from v0.9.x to v0.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Downgrade crossbeam-epoch used in moka-cht from v0.9.x to v0.8.x as a
   possible workaround for segmentation faults on many-core CPU machines.
-  ([#33](gh-pull-0033))
+  ([#33][gh-pull-0033])
 
 
 ## Version 0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 - Add examples for `get_or_insert_with` and `get_or_try_insert_with`
   methods to the docs. ([#30][gh-pull-0030])
 
+### Changed
+
+- Downgrade crossbeam-epoch used in moka-cht from v0.9.x to v0.8.x as a
+  possible workaround for segmentation faults on many-core CPU machines.
+  ([#33](gh-pull-0033))
+
 
 ## Version 0.5.1
 
@@ -96,7 +102,8 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
-[gh-issue-0030]: https://github.com/moka-rs/moka/issues/30/
+[gh-pull-0033]: https://github.com/moka-rs/moka/pull/33/
+[gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 [gh-pull-0030]: https://github.com/moka-rs/moka/pull/30/
 [gh-pull-0028]: https://github.com/moka-rs/moka/pull/28/
 [gh-pull-0022]: https://github.com/moka-rs/moka/pull/22/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Fixed
 
-- Fix `get_or_insert_with` and `get_or_try_insert_with` methods in `future::Cache`
-  can lead undefined behavior as accepting `init` future that is not `Send` or
-  `'static`. ([#31][gh-issue-0031])
+- Fix a bug in `get_or_insert_with` and `get_or_try_insert_with` methods of
+  `future::Cache` by adding missing bounds `Send` and `'static` to the `init`
+  future. Without this fix, these methods will accept non-`Send` or
+  non-`'static` future and may cause undefined behavior.
+  ([#31][gh-issue-0031])
 - Fix `usize` overflow on big cache capacity. ([#28][gh-pull-0028])
 
 ### Added
@@ -16,8 +18,8 @@
 
 ### Changed
 
-- Downgrade crossbeam-epoch used in moka-cht from v0.9.x to v0.8.x as a
-  possible workaround for segmentation faults on many-core CPU machines.
+- Downgrade crossbeam-epoch used in moka-cht from v0.9.x to v0.8.x as a possible
+  workaround for segmentation faults on many-core CPU machines.
   ([#33][gh-pull-0033])
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ future = ["async-io", "async-lock"]
 
 [dependencies]
 crossbeam-channel = "0.5"
-moka-cht = "0.5"
+# moka-cht = "0.5"
+moka-cht = { git = "https://github.com/moka-rs/moka-cht", branch = "maint-0.4" }
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ future = ["async-io", "async-lock"]
 
 [dependencies]
 crossbeam-channel = "0.5"
-# moka-cht = "0.5"
-moka-cht = { git = "https://github.com/moka-rs/moka-cht", branch = "maint-0.4" }
+moka-cht = "0.4.2"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ To run all tests including `future` feature and doc tests on the README, use the
 following command:
 
 ```console
-$ RUSTFLAGS='--cfg skeptic -cfg trybuild' cargo test --all-features
+$ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test --all-features
 ```
 
 


### PR DESCRIPTION
Downgrade crossbeam-epoch crate used in moka-cht crate from v0.9.x to v0.8.0. I am hoping this would workaround #34.

- Changed moka-cht version from v0.5.0 to **v0.4.2**.
    - v0.5.0 has a dependency to crossbeam-epoch v0.9.x.
    - **v0.4.2** has a dependency to crossbeam-epoch **v0.8.x**.