### PR TITLE
Remove the `Error` bound from `get_or_try_insert_with` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Change `get_or_try_insert_with` to return a concrete error type rather
-  than a trait object. ([#23][gh-pull-0023])
+  than a trait object. ([#23][gh-pull-0023], [#37][gh-pull-0037])
 
 
 ## Version 0.5.2
@@ -112,6 +112,7 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
+[gh-pull-0037]: https://github.com/moka-rs/moka/pull/37/
 [gh-pull-0033]: https://github.com/moka-rs/moka/pull/33/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 [gh-pull-0030]: https://github.com/moka-rs/moka/pull/30/

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -1,7 +1,6 @@
 use async_lock::RwLock;
 use std::{
     any::{Any, TypeId},
-    error::Error,
     future::Future,
     hash::{BuildHasher, Hash},
     sync::Arc,
@@ -68,7 +67,7 @@ where
     pub(crate) async fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
     where
         F: Future<Output = Result<V, E>>,
-        E: Error + Send + Sync + 'static,
+        E: Send + Sync + 'static,
     {
         use InitResult::*;
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -11,7 +11,6 @@ use std::{
     any::TypeId,
     borrow::Borrow,
     collections::hash_map::RandomState,
-    error::Error,
     hash::{BuildHasher, Hash},
     sync::Arc,
     time::Duration,
@@ -423,7 +422,7 @@ where
     pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
         F: FnOnce() -> Result<V, E>,
-        E: Error + Send + Sync + 'static,
+        E: Send + Sync + 'static,
     {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
@@ -438,7 +437,7 @@ where
     ) -> Result<V, Arc<E>>
     where
         F: FnOnce() -> Result<V, E>,
-        E: Error + Send + Sync + 'static,
+        E: Send + Sync + 'static,
     {
         if let Some(v) = self.get_with_hash(&key, hash) {
             return Ok(v);
@@ -1009,8 +1008,9 @@ mod tests {
             thread::{sleep, spawn},
         };
 
-        #[derive(thiserror::Error, Debug)]
-        #[error("{}", _0)]
+        // Note that MyError does not implement std::error::Error trait
+        // like anyhow::Error.
+        #[derive(Debug)]
         pub struct MyError(String);
 
         type MyResult<T> = Result<T, Arc<MyError>>;

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -1,7 +1,6 @@
 use parking_lot::RwLock;
 use std::{
     any::{Any, TypeId},
-    error::Error,
     hash::{BuildHasher, Hash},
     sync::Arc,
 };
@@ -63,7 +62,7 @@ where
     pub(crate) fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
     where
         F: FnOnce() -> Result<V, E>,
-        E: Error + Send + Sync + 'static,
+        E: Send + Sync + 'static,
     {
         use InitResult::*;
 


### PR DESCRIPTION
In #23, the trait bounds for `E` was changed from `Box<dyn Error + ...>` to `Error + ...`.

**Current**

```rust
use std::error::Error;

pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
where
    F: FnOnce() -> Result<V, E>,
    E: Error + Send + Sync + 'static,
```

This pull request removes the `Error` bound from `E`.

**After**

```rust
pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
where
    F: FnOnce() -> Result<V, E>,
    E: Send + Sync + 'static,
```

We are doing this because having `Error` is not necessary and too strict. For example, the following code will not compile with the current bounds, because `anyhow::Error` does not implement `std::error::Error` trait.

```rust
// Cargo.toml
// [dependencies]
// anyhow = "1"

use moka::sync::Cache;

fn main() -> anyhow::Result<()> {
    let cache: Cache<i32, i32> = Cache::new(1024);

    let _ = cache
        // The return type of the init closure is Result<i32, anyhow::Error>.
        // Note that anyhow::Error does not implement std::error::Error.
        .get_or_try_insert_with(0, || Err(anyhow::anyhow!("Always fail")))
        // Wrap Arc<anyhow::Error> with anyhow::Error.
        .map_err(|e| anyhow::anyhow!(e))?;
    Ok(())
}
```

```console
error[E0277]: the trait bound `anyhow::Error: std::error::Error` is not satisfied
  --> src/bin/main1.rs:13:10
   |
13 |         .get_or_try_insert_with(0, || Err(anyhow::anyhow!("Always fail")))
   |          ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `anyhow::Error`

error: aborting due to previous error
```

Removing the `Error` bound resolves the compile error.