### PR TITLE
Support Linux on MIPS and ARMv5TE

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           RUSTFLAGS: '--cfg skeptic'
 
-      - name: Run tests (future, without quanta)
+      - name: Run tests (future, without atomic64)
         uses: actions-rs/cargo@v1
         if: ${{ matrix.rust != '1.45.2' }}
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,6 +68,15 @@ jobs:
         env:
           RUSTFLAGS: '--cfg skeptic'
 
+      - name: Run tests (future, without quanta)
+        uses: actions-rs/cargo@v1
+        if: ${{ matrix.rust != '1.45.2' }}
+        with:
+          command: test
+          args: --release --no-default-features --features future
+        env:
+          RUSTFLAGS: '--cfg skeptic'
+
       - name: Run UI tests (future, trybuild)
         uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'stable' }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,13 @@
 {
     "rust-analyzer.cargo.features": ["future"],
     "cSpell.words": [
+        "aarch",
         "actix",
         "ahash",
         "benmanes",
         "CLFU",
         "clippy",
+        "compat",
         "cpus",
         "deqs",
         "Deque",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Add support for some 32-bit platforms where `std::sync::atomic::AtomicU64` is not
-  provided. (e.g. `armv5te-unknown-linux-musleabi`, `mips-unknown-linux-musl`)
+  provided. (e.g. `armv5te-unknown-linux-musleabi` or `mips-unknown-linux-musl`)
     - On these platforms, you will need to disable the default features of Moka.
       See [the relevant section][resolving-error-on-32bit] of the README.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Moka &mdash; Change Log
 
+## Version 0.5.3
+
+### Added
+
+- Add support for some 32-bit platforms where `std::sync::atomic::AtomicU64` is not
+  provided. (e.g. `armv5te-unknown-linux-musleabi`, `mips-unknown-linux-musl`)
+    - On these platforms, you will need to disable the default features of Moka.
+      See [the relevant section][resolving-error-on-32bit] of the README.
+
+
 ## Version 0.5.2
 
 ### Fixed
@@ -104,6 +114,9 @@
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 
+[resolving-error-on-32bit]: https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
+
+[gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-pull-0033]: https://github.com/moka-rs/moka/pull/33/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 [gh-pull-0030]: https://github.com/moka-rs/moka/pull/30/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ build = "build.rs"
 features = ["future"]
 
 [features]
-default = []
+default = ["quanta"]
 future = ["async-io", "async-lock"]
 
 [dependencies]
@@ -29,7 +29,6 @@ moka-cht = "0.4.2"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"
-quanta = "0.9"
 scheduled-thread-pool = "0.2"
 thiserror = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
@@ -37,6 +36,7 @@ uuid = { version = "0.8", features = ["v4"] }
 # Optional dependencies
 async-io = { version = "1.4", optional = true }
 async-lock = { version = "2.4", optional = true }
+quanta = { version = "0.9", optional = true }
 
 [dev-dependencies]
 actix-rt2 = { package = "actix-rt", version = "2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,16 @@ build = "build.rs"
 features = ["future"]
 
 [features]
-default = ["quanta"]
+default = ["atomic64"]
+
+# Enable this feature to use `moka::future::Cache`.
 future = ["async-io", "async-lock"]
+
+# This feature is enabled by default. Disable it when the target platform does not
+# support `std::sync::atomic::AtomicU64`. (e.g. `armv5te-unknown-linux-musleabi`
+# or `mips-unknown-linux-musl`)
+# https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
+atomic64 = ["quanta"]
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -317,15 +317,15 @@ available on crates.io, such as the [aHash][ahash-crate] crate.
 
 This crate's minimum supported Rust versions (MSRV) are the followings:
 
-| Enabled Feature      | MSRV        |
-|:---------------------|:------------|
-| no feature           | Rust 1.45.2 |
-| `quanta`   (default) | Rust 1.45.2 |
-| `future`             | Rust 1.46.0 |
+| Feature    | Enabled by default? | MSRV        |
+|:-----------|:-------------------:|:-----------:|
+| no feature |                     | Rust 1.45.2 |
+| `atomic64` |       yes           | Rust 1.45.2 |
+| `future`   |                     | Rust 1.46.0 |
 
-If only the default features are enabled, MSRV will be updated conservatively. When using other
-features, like `future`, MSRV might be updated more frequently, up to the latest
-stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
+If only the default features are enabled, MSRV will be updated conservatively. When
+using other features, like `future`, MSRV might be updated more frequently, up to the
+latest stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
 change.
 
 <!--

--- a/README.md
+++ b/README.md
@@ -319,10 +319,11 @@ This crate's minimum supported Rust versions (MSRV) are the followings:
 
 | Enabled Feature      | MSRV        |
 |:---------------------|:------------|
-| no feature (default) | Rust 1.45.2 |
+| no feature           | Rust 1.45.2 |
+| `quanta`   (default) | Rust 1.45.2 |
 | `future`             | Rust 1.46.0 |
 
-If no feature is enabled, MSRV will be updated conservatively. When using other
+If only the default features are enabled, MSRV will be updated conservatively. When using other
 features, like `future`, MSRV might be updated more frequently, up to the latest
 stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
 change.
@@ -332,6 +333,50 @@ change.
 - quanta requires 1.45.
 - moka-cht requires 1.41.
 -->
+
+
+## Resolving Compile Errors on Some 32-bit Platforms
+
+On some 32-bit target platforms including the followings, you may encounter compile
+errors in quanta crate and Moka itself.
+
+- `armv5te-unknown-linux-musleabi`
+- `mips-unknown-linux-musl`
+- `mipsel-unknown-linux-musl`
+
+```console
+error[E0599]: no method named `fetch_add` found for struct `Arc<AtomicCell<u64>>` in the current scope
+  --> ... /quanta-0.9.2/src/mock.rs:48:21
+   |
+48 |         self.offset.fetch_add(amount.into_nanos());
+   |                     ^^^^^^^^^ method not found in `Arc<AtomicCell<u64>>`
+```
+
+```console
+error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
+  --> ... /moka-0.5.3/src/sync.rs:10:30
+   |
+10 |         atomic::{AtomicBool, AtomicU64, Ordering},
+   |                              ^^^^^^^^^
+   |                              |
+   |                              no `AtomicU64` in `sync::atomic`
+```
+
+These errors occur because `std::sync::atomic::AtomicU64` type is not provided on
+these platforms but both quanta and Moka use it.
+
+You can resolve the errors by disabling the default features of Moka. Edit your
+Cargo.toml to add `default-features = false` option to the dependency declaration.
+
+```toml:Cargo.toml
+[dependencies]
+moka = { version = "0.5", default-feautures = false }
+# Or
+moka = { version = "0.5", default-feautures = false, features = ["future"] }
+```
+
+This will remove quanta from the dependencies and enable a fall-back implementation
+in Moka, so it will compile.
 
 
 ## Developing Moka

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,8 +8,8 @@ pub(crate) mod unsafe_weak_pointer;
 // https://github.com/rust-lang/rust/issues/32976
 // #[cfg_attr(target_has_atomic = "64", path = "common/time_quanta.rs")]
 
-#[cfg_attr(feature = "quanta", path = "common/time_quanta.rs")]
-#[cfg_attr(not(feature = "quanta"), path = "common/time_compat.rs")]
+#[cfg_attr(feature = "atomic64", path = "common/time_quanta.rs")]
+#[cfg_attr(not(feature = "atomic64"), path = "common/time_compat.rs")]
 pub(crate) mod time;
 
 use time::Instant;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,3 @@
-// use quanta::Instant;
-
 pub(crate) mod deque;
 pub(crate) mod error;
 pub(crate) mod frequency_sketch;
@@ -10,8 +8,14 @@ pub(crate) mod unsafe_weak_pointer;
 // https://github.com/rust-lang/rust/issues/32976
 // #[cfg_attr(target_has_atomic = "64", path = "common/time_quanta.rs")]
 
-#[cfg_attr(all(feature = "quanta", not(target_arch = "mips")), path = "common/time_quanta.rs")]
-#[cfg_attr(any(not(feature = "quanta"), target_arch = "mips"), path = "common/time_compat.rs")]
+#[cfg_attr(
+    all(feature = "quanta", not(target_arch = "mips")),
+    path = "common/time_quanta.rs"
+)]
+#[cfg_attr(
+    any(not(feature = "quanta"), target_arch = "mips"),
+    path = "common/time_compat.rs"
+)]
 pub(crate) mod time;
 
 use time::Instant;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,4 @@
-use quanta::Instant;
+// use quanta::Instant;
 
 pub(crate) mod deque;
 pub(crate) mod error;
@@ -6,17 +6,19 @@ pub(crate) mod frequency_sketch;
 pub(crate) mod thread_pool;
 pub(crate) mod unsafe_weak_pointer;
 
+// targe_has_atomic is more convenient but yet unstable (Rust 1.55)
+// https://github.com/rust-lang/rust/issues/32976
+// #[cfg_attr(target_has_atomic = "64", path = "common/time_quanta.rs")]
+
+#[cfg_attr(all(feature = "quanta", not(target_arch = "mips")), path = "common/time_quanta.rs")]
+#[cfg_attr(any(not(feature = "quanta"), target_arch = "mips"), path = "common/time_compat.rs")]
+pub(crate) mod time;
+
+use time::Instant;
+
 pub(crate) trait AccessTime {
     fn last_accessed(&self) -> Option<Instant>;
     fn set_last_accessed(&mut self, timestamp: Instant);
     fn last_modified(&self) -> Option<Instant>;
     fn set_last_modified(&mut self, timestamp: Instant);
-}
-
-pub(crate) fn u64_to_instant(ts: u64) -> Option<Instant> {
-    if ts == u64::MAX {
-        None
-    } else {
-        Some(unsafe { std::mem::transmute(ts) })
-    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,14 +8,8 @@ pub(crate) mod unsafe_weak_pointer;
 // https://github.com/rust-lang/rust/issues/32976
 // #[cfg_attr(target_has_atomic = "64", path = "common/time_quanta.rs")]
 
-#[cfg_attr(
-    all(feature = "quanta", not(target_arch = "mips")),
-    path = "common/time_quanta.rs"
-)]
-#[cfg_attr(
-    any(not(feature = "quanta"), target_arch = "mips"),
-    path = "common/time_compat.rs"
-)]
+#[cfg_attr(feature = "quanta", path = "common/time_quanta.rs")]
+#[cfg_attr(not(feature = "quanta"), path = "common/time_compat.rs")]
 pub(crate) mod time;
 
 use time::Instant;

--- a/src/common/thread_pool.rs
+++ b/src/common/thread_pool.rs
@@ -53,7 +53,10 @@ impl ThreadPoolRegistry {
                 // and insert a new pool.
                 let mut pools = REGISTRY.pools.write();
                 pools.entry(name).or_insert_with(|| {
-                    let num_threads = num_cpus::get();
+                    // Some platforms may return 0. In that case, use 1.
+                    // https://github.com/moka-rs/moka/pull/39#issuecomment-916888859
+                    // https://github.com/rust-lang/futures-rs/pull/1835
+                    let num_threads = num_cpus::get().max(1);
                     let pool =
                         ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);
                     let t_pool = ThreadPool {

--- a/src/common/time_compat.rs
+++ b/src/common/time_compat.rs
@@ -1,0 +1,105 @@
+use std::{
+    cmp::Ordering,
+    ops::Add,
+    sync::Arc,
+    time::{Duration, Instant as StdInstant},
+};
+
+use parking_lot::RwLock;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Instant(StdInstant);
+
+impl Instant {
+    pub(crate) fn now() -> Self {
+        Self(StdInstant::now())
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    fn add(self, other: Duration) -> Self::Output {
+        let instant = self
+            .0
+            .checked_add(other)
+            .expect("overflow when adding duration to instant");
+        Self(instant)
+    }
+}
+
+impl PartialOrd for Instant {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Instant {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+pub(crate) struct AtomicInstant {
+    instant: RwLock<Option<Instant>>,
+}
+
+impl Default for AtomicInstant {
+    fn default() -> Self {
+        Self {
+            instant: RwLock::new(None),
+        }
+    }
+}
+
+impl AtomicInstant {
+    pub(crate) fn reset(&self) {
+        *self.instant.write() = None;
+    }
+
+    pub(crate) fn is_set(&self) -> bool {
+        self.instant.read().is_some()
+    }
+
+    pub(crate) fn instant(&self) -> Option<Instant> {
+        *self.instant.read()
+    }
+
+    pub(crate) fn set_instant(&self, instant: Instant) {
+        *self.instant.write() = Some(instant);
+    }
+}
+
+pub(crate) struct Clock(Arc<Mock>);
+
+impl Clock {
+    #[cfg(test)]
+    pub(crate) fn mock() -> (Clock, Arc<Mock>) {
+        let mock = Arc::new(Mock::default());
+        let clock = Clock(Arc::clone(&mock));
+        (clock, mock)
+    }
+
+    pub(crate) fn now(&self) -> Instant {
+        Instant(*self.0.now.read())
+    }
+}
+
+pub(crate) struct Mock {
+    now: RwLock<StdInstant>,
+}
+
+impl Default for Mock {
+    fn default() -> Self {
+        Self {
+            now: RwLock::new(StdInstant::now()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Mock {
+    pub(crate) fn increment(&self, amount: Duration) {
+        *self.now.write() += amount;
+    }
+}

--- a/src/common/time_quanta.rs
+++ b/src/common/time_quanta.rs
@@ -1,0 +1,42 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub(crate) type Instant = quanta::Instant;
+pub(crate) type Clock = quanta::Clock;
+
+#[cfg(test)]
+pub(crate) type Mock = quanta::Mock;
+
+pub(crate) struct AtomicInstant {
+    instant: AtomicU64,
+}
+
+impl Default for AtomicInstant {
+    fn default() -> Self {
+        Self {
+            instant: AtomicU64::new(std::u64::MAX),
+        }
+    }
+}
+
+impl AtomicInstant {
+    pub(crate) fn reset(&self) {
+        self.instant.store(std::u64::MAX, Ordering::Release);
+    }
+
+    pub(crate) fn is_set(&self) -> bool {
+        self.instant.load(Ordering::Acquire) != u64::MAX
+    }
+
+    pub(crate) fn instant(&self) -> Option<Instant> {
+        let ts = self.instant.load(Ordering::Acquire);
+        if ts == u64::MAX {
+            None
+        } else {
+            Some(unsafe { std::mem::transmute(ts) })
+        }
+    }
+
+    pub(crate) fn set_instant(&self, instant: Instant) {
+        self.instant.store(instant.as_u64(), Ordering::Release);
+    }
+}

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -749,7 +749,7 @@ where
         self.base.reconfigure_for_testing();
     }
 
-    fn set_expiration_clock(&self, clock: Option<quanta::Clock>) {
+    fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
 }
@@ -758,10 +758,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Cache, ConcurrentCacheExt};
-    use crate::future::CacheBuilder;
+    use crate::{common::time::Clock, future::CacheBuilder};
 
     use async_io::Timer;
-    use quanta::Clock;
     use std::time::Duration;
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,16 @@
 //!
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
-//! | Enabled Feature      | MSRV        |
-//! |:---------------------|:------------|
-//! | no feature (default) | Rust 1.45.2 |
-//! | `future`             | Rust 1.46.0 |
+//! | Feature    | Enabled by default? | MSRV        |
+//! |:-----------|:-------------------:|:-----------:|
+//! | no feature |                     | Rust 1.45.2 |
+//! | `atomic64` |       yes           | Rust 1.45.2 |
+//! | `future`   |                     | Rust 1.46.0 |
 //!
-//! If no crate feature is enabled, MSRV will be updated conservatively. When using
-//! features like `future`, MSRV might be updated more frequently, up to the latest
-//! stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
-//! change.
+//! If only the default features are enabled, MSRV will be updated conservatively.
+//! When using other features, like `future`, MSRV might be updated more frequently,
+//! up to the latest stable. In both cases, increasing MSRV is _not_ considered a
+//! semver-breaking change.
 //!
 //! # Implementation Details
 //!

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -479,21 +479,16 @@ where
 
     #[inline]
     fn valid_after(&self) -> Option<Instant> {
-        // let ts = self.valid_after.load(Ordering::Acquire);
-        // unsafe { std::mem::transmute(ts) }
         self.valid_after.instant()
     }
 
     #[inline]
     fn set_valid_after(&self, timestamp: Instant) {
-        // self.valid_after
-        //     .store(timestamp.as_u64(), Ordering::Release);
         self.valid_after.set_instant(timestamp);
     }
 
     #[inline]
     fn has_valid_after(&self) -> bool {
-        // self.valid_after.load(Ordering::Acquire) > 0
         self.valid_after.is_set()
     }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -648,7 +648,7 @@ where
         self.base.reconfigure_for_testing();
     }
 
-    pub(crate) fn set_expiration_clock(&self, clock: Option<quanta::Clock>) {
+    pub(crate) fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
 }
@@ -657,9 +657,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Cache, ConcurrentCacheExt};
-    use crate::sync::CacheBuilder;
+    use crate::{common::time::Clock, sync::CacheBuilder};
 
-    use quanta::Clock;
     use std::time::Duration;
 
     #[test]

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -3,6 +3,7 @@
 use crate::{
     common::{
         thread_pool::{PoolName, ThreadPool, ThreadPoolRegistry},
+        time::Instant,
         unsafe_weak_pointer::UnsafeWeakPointer,
         AccessTime,
     },
@@ -12,13 +13,12 @@ use crate::{
 use super::{base_cache::Inner, PredicateId, PredicateIdStr, ValueEntry};
 
 use parking_lot::{Mutex, RwLock};
-use quanta::Instant;
 use std::{
     collections::HashMap,
     hash::{BuildHasher, Hash},
     marker::PhantomData,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc, Weak,
     },
     time::Duration,

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -324,7 +324,7 @@ where
         let mut exp_clock = MockExpirationClock::default();
 
         for segment in self.inner.segments.iter() {
-            let (clock, mock) = quanta::Clock::mock();
+            let (clock, mock) = crate::common::time::Clock::mock();
             segment.set_expiration_clock(Some(clock));
             exp_clock.mocks.push(mock);
         }
@@ -337,7 +337,7 @@ where
 #[cfg(test)]
 #[derive(Default)]
 struct MockExpirationClock {
-    mocks: Vec<Arc<quanta::Mock>>,
+    mocks: Vec<Arc<crate::common::time::Mock>>,
 }
 
 #[cfg(test)]

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -8,9 +8,8 @@ use std::{ptr::NonNull, rc::Rc};
 
 pub use builder::CacheBuilder;
 pub use cache::Cache;
-use quanta::Instant;
 
-use crate::common::{deque::DeqNode, AccessTime};
+use crate::common::{deque::DeqNode, time::Instant, AccessTime};
 
 pub(crate) struct KeyDate<K> {
     pub(crate) key: Rc<K>,

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -2,10 +2,10 @@ use super::{deques::Deques, KeyDate, KeyHashDate, ValueEntry};
 use crate::common::{
     deque::{CacheRegion, DeqNode, Deque},
     frequency_sketch::FrequencySketch,
+    time::{Clock, Instant},
     AccessTime,
 };
 
-use quanta::{Clock, Instant};
 use std::{
     borrow::Borrow,
     collections::{hash_map::RandomState, HashMap},
@@ -581,7 +581,7 @@ where
     K: Hash + Eq,
     S: BuildHasher + Clone,
 {
-    fn set_expiration_clock(&mut self, clock: Option<quanta::Clock>) {
+    fn set_expiration_clock(&mut self, clock: Option<crate::common::time::Clock>) {
         self.expiration_clock = clock;
     }
 }
@@ -590,9 +590,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Cache;
-    use crate::unsync::CacheBuilder;
+    use crate::{common::time::Clock, unsync::CacheBuilder};
 
-    use quanta::Clock;
     use std::time::Duration;
 
     #[test]


### PR DESCRIPTION
This pull request is for supporting Linux on 32-bit MIPS and ARMv5TE. These platforms does not provide `std::sync::atomic::AtomicU64` so currently both Moka and quanta will not compile.

~~After merging this PR, Moka will compile on 32-bit MIPS. For ARMv5TE, you need to add `default-features = false` to "moka" dependency in Cargo.toml and then Moka will compile.~~

After this PR is merged, you can resolve the errors by disabling the default features by adding `default-features = false` to the dependency declaration in Cargo.toml. This will remove quanta from the dependencies and enable a fall-back implementation in Moka.

## Changes

- Add a cargo feature ~~`quanta`~~ `atomic64` and make it a default feature.
- Add a module `common::time` and conditionally choose the source file from "time_quanta.rs" or "time_compat.rs".
    - time_quanta.rs file has type aliases to `quanta::{Instant, Clock, Mock}`. It also has `AtomicInstant` holding an `AtomicU64`.
    - time_compat.rs file has `Instant` based on `std::time::Instant` and quanta-like `Clock` and `Mock`. It also has `AtomicInstant` holding a `RwLock<Option<Instant>>`.
- Update Cache, etc. modules to use `common::time` instead of `quanta`.
- Add a step to GitHub Actions to test future feature without quanta/`AtomicU64`.

---
Fixes #38.