### PR TITLE
CI: Add cross-compile tests for some Linux targets

### DIFF
--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -1,0 +1,73 @@
+name: Linux cross compile tests
+
+on:
+  push:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+    - 'tests/**'
+  pull_request:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+    - 'tests/**'
+  schedule:
+    # Run against the last commit on the default branch on Friday at 9pm (UTC?)
+    - cron:  '0 21 * * 5'
+
+jobs:
+  linux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: aarch64-unknown-linux-musl
+          - target: i686-unknown-linux-musl
+          - target: armv7-unknown-linux-musleabihf
+          # Platforms without AtomicU64 support.
+          - target: armv5te-unknown-linux-musleabi
+            cargo-opts: "--no-default-features"  # Disable atomic64 feature.
+          - target: mips-unknown-linux-musl
+            cargo-opts: "--no-default-features"  # Disable atomic64 feature.
+          - target: mipsel-unknown-linux-musl
+            cargo-opts: "--no-default-features"  # Disable atomic64 feature.
+
+    steps:
+      - name: Checkout Moka
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.platform.target }}
+          override: true
+
+      - name: Remove integration tests
+        run: |
+          rm -rf tests
+          sed -i '/(actix-rt|async-std|reqwest|skeptic)/d' Cargo.toml
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo clean
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+
+      - name: Run tests (no features)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --release --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+
+      - name: Run tests (future feature)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --release --features future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Remove integration tests
         run: |
           rm -rf tests
-          sed -i '/(actix-rt|async-std|reqwest|skeptic)/d' Cargo.toml
+          sed -i '/actix-rt\|async-std\|reqwest\|skeptic/d' Cargo.toml
+          cat Cargo.toml
 
       - uses: Swatinem/rust-cache@v1
 

--- a/src/common/thread_pool.rs
+++ b/src/common/thread_pool.rs
@@ -55,7 +55,7 @@ impl ThreadPoolRegistry {
                 pools.entry(name).or_insert_with(|| {
                     // Some platforms may return 0. In that case, use 1.
                     // https://github.com/moka-rs/moka/pull/39#issuecomment-916888859
-                    // https://github.com/rust-lang/futures-rs/pull/1835
+                    // https://github.com/seanmonstar/num_cpus/issues/69
                     let num_threads = num_cpus::get().max(1);
                     let pool =
                         ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);


### PR DESCRIPTION
Add a CI (GitHub Actions) using [rust-embedded/cross](https://github.com/rust-embedded/cross). It does the followings:

1. Cross-compile Moka to a specified Linux target.
2. Run `cross test`(similar to `cargo test` but without integration tests) using QEMU user space emulation.

Currently, the following targets are tested:

- `aarch64-unknown-linux-musl`
- `i686-unknown-linux-musl`
- `armv7-unknown-linux-musleabihf`
- `armv5te-unknown-linux-musleabi`
- `mips-unknown-linux-musl`
- `mipsel-unknown-linux-musl`

There is one concern though. [The README of cross](https://github.com/rust-embedded/cross#supported-targets) says: 

> `cross test` runs units tests sequentially because QEMU gets upset when you spawn multiple threads. This means that, if one of your unit tests spawns threads, then it's more likely to fail or, worst, never terminate.

Moka _does_ spawn threads but it seems QEMU is working fine. So it is OK for now. If such a problem happens in the future, we will have to disable the `cross test` step.