### PR TITLE
Handle panic in the `init` closure/future of `get_or_insert_with` and `get_or_try_insert_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix a bug in `get_or_insert_with` and `get_or_try_insert_with` methods of
   `future::Cache` and `sync::Cache`; a panic in the `init` future/closure
   causes subsequent calls on the same key to get "unreachable code" panics.
-  ([#41][gh-issue-0043])
+  ([#43][gh-issue-0043])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 0.6.0 (Unreleased)
 
+### Fixed
+
+- Fix a bug in `get_or_insert_with` and `get_or_try_insert_with` methods of
+  `future::Cache` and `sync::Cache`; a panic in the `init` future/closure
+  causes subsequent calls on the same key to get "unreachable code" panics.
+  ([#41][gh-issue-0043])
+
 ### Changed
 
 - Change `get_or_try_insert_with` to return a concrete error type rather
@@ -133,6 +140,7 @@
 
 [resolving-error-on-32bit]: https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 
+[gh-issue-0043]: https://github.com/moka-rs/moka/issues/43/
 [gh-pull-0042]: https://github.com/moka-rs/moka/pull/42/
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-pull-0037]: https://github.com/moka-rs/moka/pull/37/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Moka &mdash; Change Log
 
-## Version 0.6.0 (Unreleased)
+## Version 0.6.0
 
 ### Fixed
 
@@ -13,6 +13,7 @@
 
 - Change `get_or_try_insert_with` to return a concrete error type rather
   than a trait object. ([#23][gh-pull-0023], [#37][gh-pull-0037])
+
 
 ## Version 0.5.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ async-std = { version = "1", default-features = false, features = ["attributes"]
 getrandom = "0.2"
 reqwest = "0.11"
 skeptic = "0.13"
-tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time" ] }
 
 [target.'cfg(trybuild)'.dev-dependencies]
 trybuild = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = ["future"]
 default = ["atomic64"]
 
 # Enable this feature to use `moka::future::Cache`.
-future = ["async-io", "async-lock"]
+future = ["async-io", "async-lock", "futures"]
 
 # This feature is enabled by default. Disable it when the target platform does not
 # support `std::sync::atomic::AtomicU64`. (e.g. `armv5te-unknown-linux-musleabi`
@@ -45,12 +45,12 @@ uuid = { version = "0.8", features = ["v4"] }
 # Optional dependencies
 async-io = { version = "1.4", optional = true }
 async-lock = { version = "2.4", optional = true }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 actix-rt2 = { package = "actix-rt", version = "2", default-features = false }
 actix-rt1 = { package = "actix-rt", version = "1", default-features = false }
 async-std = { version = "1", default-features = false, features = ["attributes"] }
-futures = "0.3"
 getrandom = "0.2"
 reqwest = "0.11"
 skeptic = "0.13"

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1339,7 +1339,7 @@ mod tests {
             });
         }
         let _ = semaphore.acquire().await.expect("semaphore acquire failed");
-        assert_eq!(cache.get_or_insert_with(1, async move { 5 }).await, 5);
+        assert_eq!(cache.get_or_insert_with(1, async { 5 }).await, 5);
     }
 
     #[tokio::test]
@@ -1364,8 +1364,7 @@ mod tests {
         }
         let _ = semaphore.acquire().await.expect("semaphore acquire failed");
         assert_eq!(
-            cache.get_or_try_insert_with(1, async move { Ok(5) }).await
-                as Result<_, Arc<Infallible>>,
+            cache.get_or_try_insert_with(1, async { Ok(5) }).await as Result<_, Arc<Infallible>>,
             Ok(5)
         );
     }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -329,7 +329,7 @@ where
     ///
     /// **A Sample Result**
     ///
-    /// - The async black resolved exactly once by task 3.
+    /// - The `init` future (async black) was resolved exactly once by task 3.
     /// - Other tasks were blocked until task 3 inserted the value.
     ///
     /// ```console
@@ -343,6 +343,14 @@ where
     /// Task 1 got the value. (len: 10485760)
     /// Task 2 got the value. (len: 10485760)
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method panics when the `init` future has been panicked. When it happens,
+    /// only the caller whose `init` future panicked will get the panic (e.g. only
+    /// task 3 in the above sample). If there are other calls in progress (e.g. task
+    /// 0, 1 and 2 above), this method will restart and resolve one of the remaining
+    /// `init` futures.
     ///
     pub async fn get_or_insert_with<F>(&self, key: K, init: F) -> V
     where
@@ -420,7 +428,7 @@ where
     ///
     /// **A Sample Result**
     ///
-    /// - `get_html()` called exactly once by task 2.
+    /// - `get_html()` was called exactly once by task 2.
     /// - Other tasks were blocked until task 2 inserted the value.
     ///
     /// ```console
@@ -434,6 +442,14 @@ where
     /// Task 0 got the value. (len: 19419)
     /// Task 3 got the value. (len: 19419)
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method panics when the `init` future has been panicked. When it happens,
+    /// only the caller whose `init` future panicked will get the panic (e.g. only
+    /// task 2 in the above sample). If there are other calls in progress (e.g. task
+    /// 0, 1 and 3 above), this method will restart and resolve one of the remaining
+    /// `init` futures.
     ///
     pub async fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
@@ -750,7 +766,7 @@ mod tests {
     use crate::{common::time::Clock, future::CacheBuilder};
 
     use async_io::Timer;
-    use std::time::Duration;
+    use std::{convert::Infallible, sync::Arc, time::Duration};
 
     #[tokio::test]
     async fn basic_single_async_task() {
@@ -1300,5 +1316,57 @@ mod tests {
         };
 
         futures::join!(task1, task2, task3, task4, task5, task6, task7, task8);
+    }
+
+    #[tokio::test]
+    // https://github.com/moka-rs/moka/issues/43
+    async fn handle_panic_in_get_or_insert_with() {
+        use tokio::time::{sleep, Duration};
+
+        let cache = Cache::new(16);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+        {
+            let cache_ref = cache.clone();
+            let semaphore_ref = semaphore.clone();
+            tokio::task::spawn(async move {
+                let _ = cache_ref
+                    .get_or_insert_with(1, async move {
+                        semaphore_ref.add_permits(1);
+                        sleep(Duration::from_millis(50)).await;
+                        panic!("Panic during get_or_try_insert_with");
+                    })
+                    .await;
+            });
+        }
+        let _ = semaphore.acquire().await.expect("semaphore acquire failed");
+        assert_eq!(cache.get_or_insert_with(1, async move { 5 }).await, 5);
+    }
+
+    #[tokio::test]
+    // https://github.com/moka-rs/moka/issues/43
+    async fn handle_panic_in_get_or_try_insert_with() {
+        use tokio::time::{sleep, Duration};
+
+        let cache = Cache::new(16);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+        {
+            let cache_ref = cache.clone();
+            let semaphore_ref = semaphore.clone();
+            tokio::task::spawn(async move {
+                let _ = cache_ref
+                    .get_or_try_insert_with(1, async move {
+                        semaphore_ref.add_permits(1);
+                        sleep(Duration::from_millis(50)).await;
+                        panic!("Panic during get_or_try_insert_with");
+                    })
+                    .await as Result<_, Arc<Infallible>>;
+            });
+        }
+        let _ = semaphore.acquire().await.expect("semaphore acquire failed");
+        assert_eq!(
+            cache.get_or_try_insert_with(1, async move { Ok(5) }).await
+                as Result<_, Arc<Infallible>>,
+            Ok(5)
+        );
     }
 }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -316,6 +316,14 @@ where
     /// Thread 3 got the value. (len: 10485760)
     /// ```
     ///
+    /// # Panics
+    ///
+    /// This method panics when the `init` closure has been panicked. When it
+    /// happens, only the caller whose `init` closure panicked will get the panic
+    /// (e.g. only thread 1 in the above sample). If there are other calls in
+    /// progress (e.g. thread 0, 2 and 3 above), this method will restart and resolve
+    /// one of the remaining `init` closure.
+    ///
     pub fn get_or_insert_with(&self, key: K, init: impl FnOnce() -> V) -> V {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
@@ -418,6 +426,14 @@ where
     /// Thread 1 got the value. (len: 1466)
     /// Thread 3 got the value. (len: 1466)
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method panics when the `init` closure has been panicked. When it
+    /// happens, only the caller whose `init` closure panicked will get the panic
+    /// (e.g. only thread 1 in the above sample). If there are other calls in
+    /// progress (e.g. thread 0, 2 and 3 above), this method will restart and resolve
+    /// one of the remaining `init` closure.
     ///
     pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
@@ -648,7 +664,7 @@ mod tests {
     use super::{Cache, ConcurrentCacheExt};
     use crate::{common::time::Clock, sync::CacheBuilder};
 
-    use std::time::Duration;
+    use std::{convert::Infallible, sync::Arc, time::Duration};
 
     #[test]
     fn basic_single_thread() {
@@ -1137,5 +1153,54 @@ mod tests {
         ] {
             t.join().expect("Failed to join");
         }
+    }
+
+    #[test]
+    // https://github.com/moka-rs/moka/issues/43
+    fn handle_panic_in_get_or_insert_with() {
+        use std::{sync::Barrier, thread};
+
+        let cache = Cache::new(16);
+        let barrier = Arc::new(Barrier::new(2));
+        {
+            let cache_ref = cache.clone();
+            let barrier_ref = barrier.clone();
+            thread::spawn(move || {
+                let _ = cache_ref.get_or_insert_with(1, || {
+                    barrier_ref.wait();
+                    thread::sleep(Duration::from_millis(50));
+                    panic!("Panic during get_or_try_insert_with");
+                });
+            });
+        }
+
+        barrier.wait();
+        assert_eq!(cache.get_or_insert_with(1, || 5), 5);
+    }
+
+    #[test]
+    // https://github.com/moka-rs/moka/issues/43
+    fn handle_panic_in_get_or_try_insert_with() {
+        use std::{sync::Barrier, thread};
+
+        let cache = Cache::new(16);
+        let barrier = Arc::new(Barrier::new(2));
+        {
+            let cache_ref = cache.clone();
+            let barrier_ref = barrier.clone();
+            thread::spawn(move || {
+                let _ = cache_ref.get_or_try_insert_with(1, || {
+                    barrier_ref.wait();
+                    thread::sleep(Duration::from_millis(50));
+                    panic!("Panic during get_or_try_insert_with");
+                }) as Result<_, Arc<Infallible>>;
+            });
+        }
+
+        barrier.wait();
+        assert_eq!(
+            cache.get_or_try_insert_with(1, || Ok(5)) as Result<_, Arc<Infallible>>,
+            Ok(5)
+        );
     }
 }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -301,7 +301,7 @@ where
     ///
     /// **Result**
     ///
-    /// - The `init` closure called exactly once by thread 1.
+    /// - The `init` closure was called exactly once by thread 1.
     /// - Other threads were blocked until thread 1 inserted the value.
     ///
     /// ```console
@@ -412,7 +412,7 @@ where
     ///
     /// **Result**
     ///
-    /// - `get_file_size()` called exactly once by thread 1.
+    /// - `get_file_size()` was called exactly once by thread 1.
     /// - Other threads were blocked until thread 1 inserted the value.
     ///
     /// ```console

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 type ErrorObject = Arc<dyn Any + Send + Sync + 'static>;
-type Waiter<V> = Arc<RwLock<Option<Result<V, ErrorObject>>>>;
+type WaiterValue<V> = Option<Result<V, ErrorObject>>;
+type Waiter<V> = Arc<RwLock<WaiterValue<V>>>;
 
 pub(crate) enum InitResult<V, E> {
     Initialized(V),
@@ -34,66 +35,95 @@ where
         }
     }
 
+    /// # Panics
+    /// Panics if the `init` future has been panicked.
     pub(crate) fn init_or_read(&self, key: Arc<K>, init: impl FnOnce() -> V) -> InitResult<V, ()> {
-        use InitResult::*;
+        // This closure will be called after the init closure has returned a value.
+        // It will convert the returned value (from init) into an InitResult.
+        let post_init = |_key, value: V, lock: &mut WaiterValue<V>| {
+            *lock = Some(Ok(value.clone()));
+            InitResult::Initialized(value)
+        };
 
-        let waiter = Arc::new(RwLock::new(None));
-        let mut lock = waiter.write();
-
-        match self.try_insert_waiter(&key, TypeId::of::<()>(), &waiter) {
-            None => {
-                // Our waiter was inserted. Let's resolve the init closure.
-                let value = init();
-                *lock = Some(Ok(value.clone()));
-                Initialized(value)
-            }
-            Some(res) => {
-                // Somebody else's waiter already exists. Drop our write lock and wait
-                // for a read lock to become available.
-                std::mem::drop(lock);
-                match &*res.read() {
-                    Some(Ok(value)) => ReadExisting(value.clone()),
-                    Some(Err(_)) | None => unreachable!(),
-                }
-            }
-        }
+        let type_id = TypeId::of::<()>();
+        self.do_try_init(&key, type_id, init, post_init)
     }
 
+    /// # Panics
+    /// Panics if the `init` future has been panicked.
     pub(crate) fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
     where
         F: FnOnce() -> Result<V, E>,
         E: Send + Sync + 'static,
     {
+        let type_id = TypeId::of::<E>();
+
+        // This closure will be called after the init closure has returned a value.
+        // It will convert the returned value (from init) into an InitResult.
+        let post_init = |key, value: Result<V, E>, lock: &mut WaiterValue<V>| match value {
+            Ok(value) => {
+                *lock = Some(Ok(value.clone()));
+                InitResult::Initialized(value)
+            }
+            Err(e) => {
+                let err: ErrorObject = Arc::new(e);
+                *lock = Some(Err(Arc::clone(&err)));
+                self.remove_waiter(key, type_id);
+                InitResult::InitErr(err.downcast().unwrap())
+            }
+        };
+
+        self.do_try_init(&key, type_id, init, post_init)
+    }
+
+    /// # Panics
+    /// Panics if the `init` future has been panicked.
+    fn do_try_init<'a, F, O, C, E>(
+        &self,
+        key: &'a Arc<K>,
+        type_id: TypeId,
+        init: F,
+        mut post_init: C,
+    ) -> InitResult<V, E>
+    where
+        F: FnOnce() -> O,
+        C: FnMut(&'a Arc<K>, O, &mut WaiterValue<V>) -> InitResult<V, E>,
+        E: Send + Sync + 'static,
+    {
+        use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
         use InitResult::*;
 
-        let type_id = TypeId::of::<E>();
-        let waiter = Arc::new(RwLock::new(None));
-        let mut lock = waiter.write();
+        loop {
+            let waiter = Arc::new(RwLock::new(None));
+            let mut lock = waiter.write();
 
-        match self.try_insert_waiter(&key, type_id, &waiter) {
-            None => {
-                // Our waiter was inserted. Let's resolve the init closure.
-                match init() {
-                    Ok(value) => {
-                        *lock = Some(Ok(value.clone()));
-                        Initialized(value)
-                    }
-                    Err(e) => {
-                        let err: ErrorObject = Arc::new(e);
-                        *lock = Some(Err(Arc::clone(&err)));
-                        self.remove_waiter(&key, type_id);
-                        InitErr(err.downcast().unwrap())
+            match self.try_insert_waiter(key, type_id, &waiter) {
+                None => {
+                    // Our waiter was inserted. Let's resolve the init future.
+                    // Catching panic is safe here as we do not try to resolve the future again.
+                    match catch_unwind(AssertUnwindSafe(init)) {
+                        // Resolved.
+                        Ok(value) => return post_init(key, value, &mut lock),
+                        // Panicked.
+                        Err(payload) => {
+                            *lock = None;
+                            // Remove the waiter so that others can retry.
+                            self.remove_waiter(key, type_id);
+                            resume_unwind(payload);
+                        } // The lock will be unlock here.
                     }
                 }
-            }
-            Some(res) => {
-                // Somebody else's waiter already exists. Drop our write lock and wait
-                // for a read lock to become available.
-                std::mem::drop(lock);
-                match &*res.read() {
-                    Some(Ok(value)) => ReadExisting(value.clone()),
-                    Some(Err(e)) => InitErr(Arc::clone(e).downcast().unwrap()),
-                    None => unreachable!(),
+                Some(res) => {
+                    // Somebody else's waiter already exists. Drop our write lock and wait
+                    // for a read lock to become available.
+                    std::mem::drop(lock);
+                    match &*res.read() {
+                        Some(Ok(value)) => return ReadExisting(value.clone()),
+                        Some(Err(e)) => return InitErr(Arc::clone(e).downcast().unwrap()),
+                        // None means somebody else's init future has been panicked.
+                        // Retry from the beginning.
+                        None => continue,
+                    }
                 }
             }
         }
@@ -105,6 +135,7 @@ where
         self.waiters.remove(&(key, type_id));
     }
 
+    #[inline]
     fn try_insert_waiter(
         &self,
         key: &Arc<K>,


### PR DESCRIPTION
This PR addresses the issue reported by #43.

## Changes

When the user-provided `init` future/closure for `get_or_insert_with` or `get_or_try_insert_with` method has panicked, it will catch the panic, remove the waiter for the key, and resume the panic. It also restarts other in-progress (actually blocked) method calls on the same key.

- Add `futures` crate for Moka's `future` feature.
- Update `future::Cache` to handle panic in the `init` future of `get_or_insert_with` and `get_or_try_insert_with`.
- Update `sync::Cache` to handle panic in the `init` future of `get_or_insert_with` and `get_or_try_insert_with`.
- Add unit tests.

----
Fixes #43