### PR TITLE
Temporary disable Clippy on Rust 1.58 beta on CI

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -193,6 +193,8 @@ pub struct Cache<K, V, S = RandomState> {
     value_initializer: Arc<ValueInitializer<K, V, S>>,
 }
 
+// TODO: https://github.com/moka-rs/moka/issues/54
+#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<K, V, S> Send for Cache<K, V, S>
 where
     K: Send + Sync,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -165,6 +165,8 @@ pub struct Cache<K, V, S = RandomState> {
     value_initializer: Arc<ValueInitializer<K, V, S>>,
 }
 
+// TODO: https://github.com/moka-rs/moka/issues/54
+#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<K, V, S> Send for Cache<K, V, S>
 where
     K: Send + Sync,

--- a/src/sync/deques.rs
+++ b/src/sync/deques.rs
@@ -11,6 +11,8 @@ pub(crate) struct Deques<K> {
 }
 
 #[cfg(feature = "future")]
+// TODO: https://github.com/moka-rs/moka/issues/54
+#[allow(clippy::non_send_fields_in_send_ty)]
 // Multi-threaded async runtimes require base_cache::Inner to be Send, but it will
 // not be without this `unsafe impl`. This is because DeqNodes have NonNull
 // pointers.

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -24,6 +24,8 @@ pub struct SegmentedCache<K, V, S = RandomState> {
     inner: Arc<Inner<K, V, S>>,
 }
 
+// TODO: https://github.com/moka-rs/moka/issues/54
+#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<K, V, S> Send for SegmentedCache<K, V, S>
 where
     K: Send + Sync,


### PR DESCRIPTION
Disable Clippy on Rust 1.58 beta until we figure out what to do on the following lint:
https://rust-lang.github.io/rust-clippy/master/index.html#non_send_fields_in_send_ty

Relates to #54