### PR TITLE
Update readme 2021 12

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,6 @@
         "peekable",
         "preds",
         "reqwest",
-        "Ristretto",
         "runtimes",
         "rustdoc",
         "RUSTFLAGS",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.2"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 
-description = "A fast and concurrent cache library inspired by Caffeine (Java) and Ristretto (Go)"
+description = "A fast and concurrent cache library inspired by Caffeine (Java)"
 license = "MIT OR Apache-2.0"
 # homepage = "https://"
 documentation = "https://docs.rs/moka/"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ exceeded.
 
 Moka is powering production services as well as embedded devices. Here are some highlights:
 
-- [crates.io](https://crates.io/) (Nov 2021 &mdash; present): The official crate registry has been using Moka in their API service to reduce the loads on PostgreSQL. ([discussions][gh-discussions-51])
-- [aliyundrive-webdav][aliyundrive-webdav-git] (Aug 2021 &mdash; present): This WebDAV service for a cloud drive is potentially running in hundreds of home WiFi routers with 32-bit ARMv5 or MIPS based SoCs. Moka is used to cache the metadata of remote files.
+- [crates.io](https://crates.io/) (Nov 2021 &mdash; present): The official crate
+  registry has been using Moka in their API service to reduce the loads on
+  PostgreSQL. ([discussions][gh-discussions-51])
+- [aliyundrive-webdav][aliyundrive-webdav-git] (Aug 2021 &mdash; present): This
+  WebDAV service for a cloud drive is potentially running in hundreds of home WiFi
+  routers with 32-bit ARMv5 or MIPS based SoCs. Moka is used to cache the metadata of
+  remote files.
 
 [gh-discussions-51]: https://github.com/moka-rs/moka/discussions/51
 [aliyundrive-webdav-git]: https://github.com/messense/aliyundrive-webdav

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ exceeded.
     - Blocking caches that can be shared across OS threads.
     - An asynchronous (futures aware) cache that can be accessed inside and outside
       of asynchronous contexts.
-- A not thread-safe, in-memory cache implementation for single thread applications.
 - Caches are bounded by the maximum number of entries.
 - Maintains good hit rate by using an entry replacement algorithms inspired by
   [Caffeine][caffeine-git]:
@@ -52,6 +51,17 @@ exceeded.
 - Supports expiration policies:
     - Time to live
     - Time to idle
+
+
+## Moka in Production
+
+Moka is powering production services as well as embedded devices. Here are some highlights:
+
+- [crates.io](https://crates.io/) (Nov 2021 &mdash; present): The official crate registry has been using Moka in their API service to reduce the loads on PostgreSQL. ([discussions][gh-discussions-51])
+- [aliyundrive-webdav][aliyundrive-webdav-git] (Aug 2021 &mdash; present): This WebDAV service for a cloud drive is potentially running in hundreds of home WiFi routers with 32-bit ARMv5 or MIPS based SoCs. Moka is used to cache the metadata of remote files.
+
+[gh-discussions-51]: https://github.com/moka-rs/moka/discussions/51
+[aliyundrive-webdav-git]: https://github.com/messense/aliyundrive-webdav
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield)
 
 Moka is a fast, concurrent cache library for Rust. Moka is inspired by
-[Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
+[Caffeine][caffeine-git] (Java).
 
 Moka provides cache implementations that support full concurrency of retrievals and
 a high expected concurrency for updates. Moka also provides a not thread-safe cache
@@ -35,7 +35,6 @@ exceeded.
 [fossa]: https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
-[ristretto-git]: https://github.com/dgraph-io/ristretto
 
 
 ## Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 
 //! Moka is a fast, concurrent cache library for Rust. Moka is inspired by
-//! [Caffeine][caffeine-git] (Java) and [Ristretto][ristretto-git] (Go).
+//! [Caffeine][caffeine-git] (Java).
 //!
 //! Moka provides in-memory concurrent cache implementations that support full
 //! concurrency of retrievals and a high expected concurrency for updates. <!-- , and multiple ways to bound the cache. -->
@@ -17,7 +17,6 @@
 //! is exceeded.
 //!
 //! [caffeine-git]: https://github.com/ben-manes/caffeine
-//! [ristretto-git]: https://github.com/dgraph-io/ristretto
 //! [moka-cht-crate]: https://crates.io/crates/moka-cht
 //!
 //! # Features


### PR DESCRIPTION
- Add "Moka in Production" section to the README.
- Remove references to Ristretto from the doc. It turned out Moka is mostly taking design idea from Caffeine and very little from Ristretto.