### PR TITLE
Protect overflow when computing expiration (part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,13 @@ following command:
 $ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test --all-features
 ```
 
+**Running All Tests without Default Features**
+
+```console
+$ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test \
+    --no-default-features --features future
+```
+
 
 ## Road Map
 

--- a/README.md
+++ b/README.md
@@ -55,16 +55,18 @@ exceeded.
 
 ## Moka in Production
 
-Moka is powering production services as well as embedded devices. Here are some
-highlights:
+Moka is powering production services as well as embedded devices like home routers.
+Here are some highlights:
 
 - [crates.io](https://crates.io/): The official crate registry has been using Moka in
-  their API service to reduce the loads on PostgreSQL.
+  its API service to reduce the loads on PostgreSQL. Every time you download a crate
+  using Cargo, the API server will use the information cached in Moka. It is
+  maintaining cache hit rates of ~85% for the high-traffic download endpoints.
   ([discussions][gh-discussions-51]) (Moka used: Nov 2021 &mdash; present)
-- [aliyundrive-webdav][aliyundrive-webdav-git]: This WebDAV service for a cloud drive
-  is potentially running in hundreds of home WiFi routers with 32-bit ARMv5 or MIPS
-  based SoCs. Moka is used to cache the metadata of remote files. (Moka used: Aug
-  2021 &mdash; present)
+- [aliyundrive-webdav][aliyundrive-webdav-git]: This WebDAV gateway for a cloud drive
+  may have been deployed in hundreds of home WiFi routers, including inexpensive
+  models with 32-bit ARMv5TE or MIPS-based SoCs. Moka is used to cache the metadata
+  of remote files. (Moka used: Aug 2021 &mdash; present)
 
 [gh-discussions-51]: https://github.com/moka-rs/moka/discussions/51
 [aliyundrive-webdav-git]: https://github.com/messense/aliyundrive-webdav
@@ -308,8 +310,8 @@ fn main() {
 
 ### A note on expiration policies
 
-The cache builders will panic if configured with either time to live/ time to idle
-higher than 1000 years. This is done to protect against overflow when computing key
+The cache builders will panic if configured with either `time_to_live` or `time to idle`
+longer than 1000 years. This is done to protect against overflow when computing key
 expiration.
 
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@
 Moka is a fast, concurrent cache library for Rust. Moka is inspired by
 [Caffeine][caffeine-git] (Java).
 
-Moka provides cache implementations that support full concurrency of retrievals and
-a high expected concurrency for updates. Moka also provides a not thread-safe cache
-implementation for single thread applications.
+Moka provides cache implementations on top of hash maps. They support full
+concurrency of retrievals and a high expected concurrency for updates. Moka also
+provides a non-thread-safe cache implementation for single thread applications.
 
-All caches perform a best-effort bounding of a  hash map using an entry
-replacement algorithm to determine which entries to evict when the capacity is
-exceeded.
+All caches perform a best-effort bounding of a hash map using an entry replacement
+algorithm to determine which entries to evict when the capacity is exceeded.
 
 [gh-actions-badge]: https://github.com/moka-rs/moka/workflows/CI/badge.svg
 [release-badge]: https://img.shields.io/crates/v/moka.svg
@@ -40,7 +39,7 @@ exceeded.
 ## Features
 
 - Thread-safe, highly concurrent in-memory cache implementations:
-    - Blocking caches that can be shared across OS threads.
+    - Synchronous caches that can be shared across OS threads.
     - An asynchronous (futures aware) cache that can be accessed inside and outside
       of asynchronous contexts.
 - Caches are bounded by the maximum number of entries.
@@ -59,13 +58,12 @@ Moka is powering production services as well as embedded devices like home route
 Here are some highlights:
 
 - [crates.io](https://crates.io/): The official crate registry has been using Moka in
-  its API service to reduce the loads on PostgreSQL. Every time you download a crate
-  using Cargo, the API server will use the information cached in Moka. It is
-  maintaining cache hit rates of ~85% for the high-traffic download endpoints.
-  ([discussions][gh-discussions-51]) (Moka used: Nov 2021 &mdash; present)
+  its API service to reduce the loads on PostgreSQL. Moka is maintaining
+  [cache hit rates of ~85%][gh-discussions-51] for the high-traffic download endpoint.
+  (Moka used: Nov 2021 &mdash; present)
 - [aliyundrive-webdav][aliyundrive-webdav-git]: This WebDAV gateway for a cloud drive
   may have been deployed in hundreds of home WiFi routers, including inexpensive
-  models with 32-bit ARMv5TE or MIPS-based SoCs. Moka is used to cache the metadata
+  models with 32-bit MIPS or ARMv5TE-based SoCs. Moka is used to cache the metadata
   of remote files. (Moka used: Aug 2021 &mdash; present)
 
 [gh-discussions-51]: https://github.com/moka-rs/moka/discussions/51
@@ -91,7 +89,7 @@ moka = { version = "0.6", features = ["future"] }
 
 ## Example: Synchronous Cache
 
-The thread-safe, blocking caches are defined in the `sync` module.
+The thread-safe, synchronous caches are defined in the `sync` module.
 
 Cache entries are manually added using `insert` method, and are stored in the cache
 until either evicted or manually invalidated.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+pub(crate) mod builder_utils;
 pub(crate) mod deque;
 pub(crate) mod error;
 pub(crate) mod frequency_sketch;

--- a/src/common/builder_utils.rs
+++ b/src/common/builder_utils.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 const YEAR_SECONDS: u64 = 365 * 24 * 3600;
 
-pub(crate) fn ensure_expiration_config_or_panic(
+pub(crate) fn ensure_expirations_or_panic(
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
 ) {

--- a/src/common/builder_utils.rs
+++ b/src/common/builder_utils.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 const YEAR_SECONDS: u64 = 365 * 24 * 3600;
 
-pub(crate) fn check_ttl_and_tti(
+pub(crate) fn ensure_expiration_config_or_panic(
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
 ) {

--- a/src/common/builder_utils.rs
+++ b/src/common/builder_utils.rs
@@ -1,0 +1,16 @@
+use std::time::Duration;
+
+const YEAR_SECONDS: u64 = 365 * 24 * 3600;
+
+pub(crate) fn check_ttl_and_tti(
+    time_to_live: Option<Duration>,
+    time_to_idle: Option<Duration>,
+) {
+    let max_duration = Duration::from_secs(1_000 * YEAR_SECONDS);
+    if let Some(d) = time_to_live {
+        assert!(d <= max_duration, "time_to_live is longer than 1000 years");
+    }
+    if let Some(d) = time_to_idle {
+        assert!(d <= max_duration, "time_to_idle is longer than 1000 years");
+    }
+}

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -75,7 +75,7 @@ where
     /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -97,7 +97,7 @@ where
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -1,3 +1,4 @@
+use crate::common::builder_utils;
 use super::Cache;
 
 use std::{
@@ -6,8 +7,6 @@ use std::{
     marker::PhantomData,
     time::Duration,
 };
-
-const YEAR_SECONDS: u64 = 365 * 24 * 3600;
 
 /// Builds a [`Cache`][cache-struct] with various configuration knobs.
 ///
@@ -68,22 +67,15 @@ where
     }
 
     /// Builds a `Cache<K, V>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        self.time_to_live.map(|d| {
-            if Duration::from_secs(1_000 * YEAR_SECONDS) < d {
-                panic!("time_to_live is longer than 1000 years");
-            } else {
-                d
-            }
-        });
-        self.time_to_idle.map(|d| {
-            if Duration::from_secs(1_000 * YEAR_SECONDS) < d {
-                panic!("time_to_idle is longer than 1000 years");
-            } else {
-                d
-            }
-        });
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -95,10 +87,17 @@ where
     }
 
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -123,6 +122,12 @@ impl<C> CacheBuilder<C> {
     ///
     /// A cached entry will be expired after the specified duration past from
     /// `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn time_to_live(self, duration: Duration) -> Self {
         Self {
             time_to_live: Some(duration),
@@ -134,6 +139,12 @@ impl<C> CacheBuilder<C> {
     ///
     /// A cached entry will be expired after the specified duration past from `get`
     /// or `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -1,5 +1,5 @@
-use crate::common::builder_utils;
 use super::Cache;
+use crate::common::builder_utils;
 
 use std::{
     collections::hash_map::RandomState,
@@ -75,7 +75,7 @@ where
     /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -97,7 +97,7 @@ where
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,13 @@
 //! Moka is a fast, concurrent cache library for Rust. Moka is inspired by
 //! [Caffeine][caffeine-git] (Java).
 //!
-//! Moka provides in-memory concurrent cache implementations that support full
-//! concurrency of retrievals and a high expected concurrency for updates. <!-- , and multiple ways to bound the cache. -->
+//! Moka provides in-memory concurrent cache implementations on top of hash maps.
+//! They support full concurrency of retrievals and a high expected concurrency for
+//! updates. <!-- , and multiple ways to bound the cache. -->
 //! They utilize a lock-free concurrent hash table `SegmentedHashMap` from the
 //! [moka-cht][moka-cht-crate] crate for the central key-value storage.
 //!
-//! Moka also provides an in-memory, not thread-safe cache implementation for single
+//! Moka also provides an in-memory, non-thread-safe cache implementation for single
 //! thread applications.
 //!
 //! All cache implementations perform a best-effort bounding of the map using an
@@ -22,10 +23,9 @@
 //! # Features
 //!
 //! - Thread-safe, highly concurrent in-memory cache implementations:
-//!     - Blocking caches that can be shared across OS threads.
+//!     - Synchronous caches that can be shared across OS threads.
 //!     - An asynchronous (futures aware) cache that can be accessed inside and
 //!       outside of asynchronous contexts.
-//! - A not thread-safe, in-memory cache implementation for single thread applications.
 //! - Caches are bounded by the maximum number of entries.
 //! - Maintains good hit rate by using entry replacement algorithms inspired by
 //!   [Caffeine][caffeine-git]:
@@ -39,7 +39,7 @@
 //!
 //! See the following document:
 //!
-//! - Thread-safe, blocking caches:
+//! - Thread-safe, synchronous caches:
 //!     - [`sync::Cache`][sync-cache-struct] and
 //!       [`sync::SegmentedCache`][sync-seg-cache-struct].
 //! - An asynchronous (futures aware) cache:

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -99,7 +99,7 @@ where
     /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -124,7 +124,7 @@ where
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -153,7 +153,7 @@ where
     /// expiration.
     pub fn build(self) -> SegmentedCache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         SegmentedCache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -179,7 +179,7 @@ where
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         SegmentedCache::with_everything(
             self.max_capacity,
             self.initial_capacity,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -1,3 +1,4 @@
+use crate::common::builder_utils;
 use super::{Cache, SegmentedCache};
 
 use std::{
@@ -6,8 +7,6 @@ use std::{
     marker::PhantomData,
     time::Duration,
 };
-
-const YEAR_SECONDS: u64 = 365 * 24 * 3600;
 
 /// Builds a [`Cache`][cache-struct] or [`SegmentedCache`][seg-cache-struct]
 /// with various configuration knobs.
@@ -92,22 +91,15 @@ where
     ///
     /// If you want to build a `SegmentedCache<K, V>`, call `segments` method before
     /// calling this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        self.time_to_live.map(|d| {
-            if Duration::from_secs(1_000 * YEAR_SECONDS) < d {
-                panic!("time_to_live is longer than 1000 years");
-            } else {
-                d
-            }
-        });
-        self.time_to_idle.map(|d| {
-            if Duration::from_secs(1_000 * YEAR_SECONDS) < d {
-                panic!("time_to_idle is longer than 1000 years");
-            } else {
-                d
-            }
-        });
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -122,10 +114,17 @@ where
     ///
     /// If you want to build a `SegmentedCache<K, V>`, call `segments` method  before
     /// calling this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -146,8 +145,15 @@ where
     ///
     /// If you want to build a `Cache<K, V>`, do not call `segments` method before
     /// calling this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build(self) -> SegmentedCache<K, V, RandomState> {
         let build_hasher = RandomState::default();
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         SegmentedCache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -163,10 +169,17 @@ where
     ///
     /// If you want to build a `Cache<K, V>`, do not call `segments` method before
     /// calling this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build_with_hasher<S>(self, hasher: S) -> SegmentedCache<K, V, S>
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         SegmentedCache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -192,6 +205,12 @@ impl<C> CacheBuilder<C> {
     ///
     /// A cached entry will be expired after the specified duration past from
     /// `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn time_to_live(self, duration: Duration) -> Self {
         Self {
             time_to_live: Some(duration),
@@ -203,6 +222,12 @@ impl<C> CacheBuilder<C> {
     ///
     /// A cached entry will be expired after the specified duration past from `get`
     /// or `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),
@@ -287,9 +312,9 @@ mod tests {
         assert_eq!(cache.get(&'b'), Some("Bob"));
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "time_to_live is longer than 1000 years")]
-    async fn build_cache_too_long_ttl() {
+    fn build_cache_too_long_ttl() {
         let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
         let builder: CacheBuilder<Cache<char, String>> = CacheBuilder::new(100);
         let duration = Duration::from_secs(thousand_years_secs);
@@ -298,9 +323,9 @@ mod tests {
             .build();
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "time_to_idle is longer than 1000 years")]
-    async fn build_cache_too_long_tti() {
+    fn build_cache_too_long_tti() {
         let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
         let builder: CacheBuilder<Cache<char, String>> = CacheBuilder::new(100);
         let duration = Duration::from_secs(thousand_years_secs);

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -1,5 +1,5 @@
-use crate::common::builder_utils;
 use super::{Cache, SegmentedCache};
+use crate::common::builder_utils;
 
 use std::{
     collections::hash_map::RandomState,
@@ -99,7 +99,7 @@ where
     /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -124,7 +124,7 @@ where
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -153,7 +153,7 @@ where
     /// expiration.
     pub fn build(self) -> SegmentedCache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         SegmentedCache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -179,7 +179,7 @@ where
     where
         S: BuildHasher + Clone + Send + Sync + 'static,
     {
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         SegmentedCache::with_everything(
             self.max_capacity,
             self.initial_capacity,

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -70,7 +70,7 @@ where
     /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -91,7 +91,7 @@ where
     where
         S: BuildHasher + Clone,
     {
-        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -1,3 +1,4 @@
+use crate::common::builder_utils;
 use super::Cache;
 
 use std::{
@@ -6,8 +7,6 @@ use std::{
     marker::PhantomData,
     time::Duration,
 };
-
-const YEAR_SECONDS: u64 = 365 * 24 * 3600;
 
 /// Builds a [`Cache`][cache-struct] with various configuration knobs.
 ///
@@ -63,22 +62,15 @@ where
     }
 
     /// Builds a `Cache<K, V>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        self.time_to_live.map(|d| {
-            if Duration::from_secs(1_000 * YEAR_SECONDS) < d {
-                panic!("time_to_live is longer than 1000 years");
-            } else {
-                d
-            }
-        });
-        self.time_to_idle.map(|d| {
-            if Duration::from_secs(1_000 * YEAR_SECONDS) < d {
-                panic!("time_to_idle is longer than 1000 years");
-            } else {
-                d
-            }
-        });
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -89,10 +81,17 @@ where
     }
 
     /// Builds a `Cache<K, V, S>`, with the given `hasher`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
     where
         S: BuildHasher + Clone,
     {
+        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -116,6 +115,12 @@ impl<C> CacheBuilder<C> {
     ///
     /// A cached entry will be expired after the specified duration past from
     /// `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn time_to_live(self, duration: Duration) -> Self {
         Self {
             time_to_live: Some(duration),
@@ -127,6 +132,12 @@ impl<C> CacheBuilder<C> {
     ///
     /// A cached entry will be expired after the specified duration past from `get`
     /// or `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
     pub fn time_to_idle(self, duration: Duration) -> Self {
         Self {
             time_to_idle: Some(duration),
@@ -167,9 +178,9 @@ mod tests {
         assert_eq!(cache.get(&'a'), Some(&"Alice"));
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "time_to_live is longer than 1000 years")]
-    async fn build_cache_too_long_ttl() {
+    fn build_cache_too_long_ttl() {
         let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
         let builder: CacheBuilder<Cache<char, String>> = CacheBuilder::new(100);
         let duration = Duration::from_secs(thousand_years_secs);
@@ -178,9 +189,9 @@ mod tests {
             .build();
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "time_to_idle is longer than 1000 years")]
-    async fn build_cache_too_long_tti() {
+    fn build_cache_too_long_tti() {
         let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
         let builder: CacheBuilder<Cache<char, String>> = CacheBuilder::new(100);
         let duration = Duration::from_secs(thousand_years_secs);

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -1,5 +1,5 @@
-use crate::common::builder_utils;
 use super::Cache;
+use crate::common::builder_utils;
 
 use std::{
     collections::hash_map::RandomState,
@@ -70,7 +70,7 @@ where
     /// expiration.
     pub fn build(self) -> Cache<K, V, RandomState> {
         let build_hasher = RandomState::default();
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,
@@ -91,7 +91,7 @@ where
     where
         S: BuildHasher + Clone,
     {
-        builder_utils::check_ttl_and_tti(self.time_to_live, self.time_to_idle);
+        builder_utils::ensure_expiration_config_or_panic(self.time_to_live, self.time_to_idle);
         Cache::with_everything(
             self.max_capacity,
             self.initial_capacity,


### PR DESCRIPTION
This is a follow up PR for #56.

- Update `CacheBuilder::build_with_hasher` method to do the same duration checks to `build` methods.
- Update the API doc to explain panics.
- Not related to overflow checks but also tweaked the contents of the README.