### PR TITLE
Prevent `future::get_or_*_insert_with` to panic after inserting task was aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Moka &mdash; Change Log
 
+## Version 0.6.3
+
+### Fixed
+
+- Fix a bug in `get_or_insert_with` and `get_or_try_insert_with` methods of
+  `future::Cache`, which caused a panic if previously inserting task aborted.
+  ([#59][gh-issue-0059])
+
+
 ## Version 0.6.2
 
 ### Removed
@@ -160,6 +169,7 @@
 
 [resolving-error-on-32bit]: https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 
+[gh-issue-0059]: https://github.com/moka-rs/moka/issues/59/
 [gh-issue-0043]: https://github.com/moka-rs/moka/issues/43/
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1361,4 +1361,67 @@ mod tests {
             Ok(5)
         );
     }
+
+    #[tokio::test]
+    // https://github.com/moka-rs/moka/issues/59
+    async fn abort_get_or_insert_with() {
+        use tokio::time::{sleep, Duration};
+
+        let cache = Cache::new(16);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let handle;
+        {
+            let cache_ref = cache.clone();
+            let semaphore_ref = semaphore.clone();
+
+            handle = tokio::task::spawn(async move {
+                let _ = cache_ref
+                    .get_or_insert_with(1, async move {
+                        semaphore_ref.add_permits(1);
+                        sleep(Duration::from_millis(50)).await;
+                        unreachable!();
+                    })
+                    .await;
+            });
+        }
+
+        let _ = semaphore.acquire().await.expect("semaphore acquire failed");
+        handle.abort();
+
+        assert_eq!(cache.get_or_insert_with(1, async { 5 }).await, 5);
+    }
+
+    #[tokio::test]
+    // https://github.com/moka-rs/moka/issues/59
+    async fn abort_get_or_try_insert_with() {
+        use tokio::time::{sleep, Duration};
+
+        let cache = Cache::new(16);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let handle;
+        {
+            let cache_ref = cache.clone();
+            let semaphore_ref = semaphore.clone();
+
+            handle = tokio::task::spawn(async move {
+                let _ = cache_ref
+                    .get_or_try_insert_with(1, async move {
+                        semaphore_ref.add_permits(1);
+                        sleep(Duration::from_millis(50)).await;
+                        unreachable!();
+                    })
+                    .await as Result<_, Arc<Infallible>>;
+            });
+        }
+
+        let _ = semaphore.acquire().await.expect("semaphore acquire failed");
+        handle.abort();
+
+        assert_eq!(
+            cache.get_or_try_insert_with(1, async { Ok(5) }).await as Result<_, Arc<Infallible>>,
+            Ok(5)
+        );
+    }
 }

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -7,13 +7,82 @@ use std::{
 };
 
 type ErrorObject = Arc<dyn Any + Send + Sync + 'static>;
-type WaiterValue<V> = Option<Result<V, ErrorObject>>;
-type Waiter<V> = Arc<RwLock<WaiterValue<V>>>;
 
 pub(crate) enum InitResult<V, E> {
     Initialized(V),
     ReadExisting(V),
     InitErr(Arc<E>),
+}
+
+enum WaiterValue<V> {
+    Computing,
+    Ready(Result<V, ErrorObject>),
+    // https://github.com/moka-rs/moka/issues/43
+    InitFuturePanicked,
+    // https://github.com/moka-rs/moka/issues/59
+    EnclosingFutureAborted,
+}
+
+type Waiter<V> = Arc<RwLock<WaiterValue<V>>>;
+
+struct WaiterGuard<'a, K, V, S>
+// NOTE: We usually do not attach trait bounds to hera at the struct definition, but
+// the Drop trait requires these bounds here.
+where
+    Arc<K>: Eq + Hash,
+    V: Clone,
+    S: BuildHasher,
+{
+    is_waiter_value_set: bool,
+    key: &'a Arc<K>,
+    type_id: TypeId,
+    value_initializer: &'a ValueInitializer<K, V, S>,
+    write_lock: &'a mut WaiterValue<V>,
+}
+
+impl<'a, K, V, S> WaiterGuard<'a, K, V, S>
+where
+    Arc<K>: Eq + Hash,
+    V: Clone,
+    S: BuildHasher,
+{
+    fn new(
+        key: &'a Arc<K>,
+        type_id: TypeId,
+        value_initializer: &'a ValueInitializer<K, V, S>,
+        write_lock: &'a mut WaiterValue<V>,
+    ) -> Self {
+        Self {
+            is_waiter_value_set: false,
+            key,
+            type_id,
+            value_initializer,
+            write_lock,
+        }
+    }
+
+    fn set_waiter_value(&mut self, v: WaiterValue<V>) {
+        *self.write_lock = v;
+        self.is_waiter_value_set = true;
+    }
+}
+
+impl<'a, K, V, S> Drop for WaiterGuard<'a, K, V, S>
+where
+    Arc<K>: Eq + Hash,
+    V: Clone,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        if !self.is_waiter_value_set {
+            // Value is not set. This means the future containing
+            // `get_or_*_insert_with` has been aborted:
+            // https://github.com/moka-rs/moka/issues/59
+            *self.write_lock = WaiterValue::EnclosingFutureAborted;
+            self.value_initializer.remove_waiter(self.key, self.type_id);
+            self.is_waiter_value_set = true;
+        }
+    }
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
@@ -44,8 +113,8 @@ where
     {
         // This closure will be called after the init closure has returned a value.
         // It will convert the returned value (from init) into an InitResult.
-        let post_init = |_key, value: V, lock: &mut WaiterValue<V>| {
-            *lock = Some(Ok(value.clone()));
+        let post_init = |_key, value: V, mut guard: WaiterGuard<'_, K, V, S>| {
+            guard.set_waiter_value(WaiterValue::Ready(Ok(value.clone())));
             InitResult::Initialized(value)
         };
 
@@ -64,14 +133,15 @@ where
 
         // This closure will be called after the init closure has returned a value.
         // It will convert the returned value (from init) into an InitResult.
-        let post_init = |key, value: Result<V, E>, lock: &mut WaiterValue<V>| match value {
+        let post_init = |key, value: Result<V, E>, mut guard: WaiterGuard<'_, K, V, S>| match value
+        {
             Ok(value) => {
-                *lock = Some(Ok(value.clone()));
+                guard.set_waiter_value(WaiterValue::Ready(Ok(value.clone())));
                 InitResult::Initialized(value)
             }
             Err(e) => {
                 let err: ErrorObject = Arc::new(e);
-                *lock = Some(Err(Arc::clone(&err)));
+                guard.set_waiter_value(WaiterValue::Ready(Err(Arc::clone(&err))));
                 self.remove_waiter(key, type_id);
                 InitResult::InitErr(err.downcast().unwrap())
             }
@@ -91,7 +161,7 @@ where
     ) -> InitResult<V, E>
     where
         F: Future<Output = O>,
-        C: FnMut(&'a Arc<K>, O, &mut WaiterValue<V>) -> InitResult<V, E>,
+        C: FnMut(&'a Arc<K>, O, WaiterGuard<'_, K, V, S>) -> InitResult<V, E>,
         E: Send + Sync + 'static,
     {
         use futures_util::FutureExt;
@@ -102,19 +172,25 @@ where
         let mut retries = 0;
 
         loop {
-            let waiter = Arc::new(RwLock::new(None));
+            let waiter = Arc::new(RwLock::new(WaiterValue::Computing));
             let mut lock = waiter.write().await;
 
             match self.try_insert_waiter(key, type_id, &waiter) {
                 None => {
                     // Our waiter was inserted. Let's resolve the init future.
+
+                    // Create a guard. This will ensure to remove our waiter when the
+                    // enclosing future has been aborted:
+                    // https://github.com/moka-rs/moka/issues/59
+                    let mut waiter_guard = WaiterGuard::new(key, type_id, self, &mut lock);
+
                     // Catching panic is safe here as we do not try to resolve the future again.
                     match AssertUnwindSafe(init).catch_unwind().await {
                         // Resolved.
-                        Ok(value) => return post_init(key, value, &mut lock),
+                        Ok(value) => return post_init(key, value, waiter_guard),
                         // Panicked.
                         Err(payload) => {
-                            *lock = None;
+                            waiter_guard.set_waiter_value(WaiterValue::InitFuturePanicked);
                             // Remove the waiter so that others can retry.
                             self.remove_waiter(key, type_id);
                             resume_unwind(payload);
@@ -126,22 +202,30 @@ where
                     // for a read lock to become available.
                     std::mem::drop(lock);
                     match &*res.read().await {
-                        Some(Ok(value)) => return ReadExisting(value.clone()),
-                        Some(Err(e)) => return InitErr(Arc::clone(e).downcast().unwrap()),
-                        // None means somebody else's init future has been panicked.
-                        None => {
-                            retries += 1;
-                            if retries < MAX_RETRIES {
-                                // Retry from the beginning.
-                                continue;
-                            } else {
-                                panic!(
-                                    r#"Too many retries. Tried to read the return value from the `init` \
-                                future but failed {} times. Maybe the `init` kept panicking?"#,
-                                    retries
-                                );
-                            }
+                        WaiterValue::Ready(Ok(value)) => return ReadExisting(value.clone()),
+                        WaiterValue::Ready(Err(e)) => {
+                            return InitErr(Arc::clone(e).downcast().unwrap())
                         }
+                        // Somebody else's init future has been panicked.
+                        WaiterValue::InitFuturePanicked => {
+                            retries += 1;
+                            panic_if_retry_exhausted_for_panicking(retries, MAX_RETRIES);
+                            // Retry from the beginning.
+                            continue;
+                        }
+                        // Somebody else (a future containing `get_or_insert_with`/
+                        // `get_or_try_insert_with`) has been aborted.
+                        WaiterValue::EnclosingFutureAborted => {
+                            retries += 1;
+                            panic_if_retry_exhausted_for_aborting(retries, MAX_RETRIES);
+                            // Retry from the beginning.
+                            continue;
+                        }
+                        // Unexpected state.
+                        WaiterValue::Computing => panic!(
+                            "Got unexpected state `Computing` after resolving `init` future. \
+                        This might be a bug in Moka"
+                        ),
                     }
                 }
             }
@@ -166,5 +250,26 @@ where
 
         self.waiters
             .insert_with_or_modify((key, type_id), || waiter, |_, w| Arc::clone(w))
+    }
+}
+
+fn panic_if_retry_exhausted_for_panicking(retries: usize, max: usize) {
+    if retries >= max {
+        panic!(
+            "Too many retries. Tried to read the return value from the `init` future \
+    but failed {} times. Maybe the `init` kept panicking?",
+            retries
+        );
+    }
+}
+
+fn panic_if_retry_exhausted_for_aborting(retries: usize, max: usize) {
+    if retries >= max {
+        panic!(
+            "Too many retries. Tried to read the return value from the `init` future \
+    but failed {} times. Maybe the future containing `get_or_insert_with`/\
+    `get_or_try_insert_with` kept being aborted?",
+            retries
+        );
     }
 }

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -26,7 +26,7 @@ enum WaiterValue<V> {
 type Waiter<V> = Arc<RwLock<WaiterValue<V>>>;
 
 struct WaiterGuard<'a, K, V, S>
-// NOTE: We usually do not attach trait bounds to hera at the struct definition, but
+// NOTE: We usually do not attach trait bounds to here at the struct definition, but
 // the Drop trait requires these bounds here.
 where
     Arc<K>: Eq + Hash,
@@ -76,8 +76,8 @@ where
     fn drop(&mut self) {
         if !self.is_waiter_value_set {
             // Value is not set. This means the future containing
-            // `get_or_*_insert_with` has been aborted:
-            // https://github.com/moka-rs/moka/issues/59
+            // `get_or_*_insert_with` has been aborted. Remove our waiter to prevent
+            // the issue described in https://github.com/moka-rs/moka/issues/59
             *self.write_lock = WaiterValue::EnclosingFutureAborted;
             self.value_initializer.remove_waiter(self.key, self.type_id);
             self.is_waiter_value_set = true;

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -131,8 +131,8 @@ where
                                 continue;
                             } else {
                                 panic!(
-                                    r#"Too many retries. Tried to read the return value from the `init` \
-                                closure but failed {} times. Maybe the `init` kept panicking?"#,
+                                    "Too many retries. Tried to read the return value from the `init` \
+                                closure but failed {} times. Maybe the `init` kept panicking?",
                                     retries
                                 );
                             }


### PR DESCRIPTION
This PR addresses the issue described in #59. So `get_or_insert_with` and `get_or_try_insert_with` methods in `future::Cache` will no longer panic if previous inserting task was aborted.

## Changes

- Add `WaiterGuard` to the value initializer used by these methods and it will ensure to remove the waiter (a lock) when enclosing async task is aborted.
- Add unit test cases for the issue.

Fixes #59.