### PR TITLE
Lazily initialize and enable the LFU filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.7.0
 
+- **Breaking change**: The type of the `max_capacity` has been changed from `usize`
+  to `u64`. This was necessary to have the weight-based cache management consistent
+  across different CPU architectures.
+
 ### Added
 
 - Add support for weight-based (size aware) cache management.

--- a/README.md
+++ b/README.md
@@ -458,13 +458,13 @@ $ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test \
 - [x] `async` optimized caches. (`v0.2.0`)
 - [x] Bounding a cache with weighted size of entry.
       (`v0.7.0` via [#24](https://github.com/moka-rs/moka/pull/24))
-- [ ] API stabilization. (Smaller core API, shorter names for frequently used
-      methods)
+- [ ] API stabilization. (Smaller core cache API, shorter names for frequently
+      used methods)
     - e.g.
-    - `get(&Q)` → `get_if_present(&Q)`
     - `get_or_insert_with(K, F)` → `get(K, F)`
     - `get_or_try_insert_with(K, F)` → `try_get(K, F)`
-    - `blocking_insert(K, V)` → `blocking().insert(K, V)`.
+    - `get(&Q)` → `get_if_present(&Q)`
+    - `blocking_insert(K, V)` → `blocking().insert(K, V)`
     - `time_to_live()` → `config().time_to_live()`
 - [ ] Cache statistics. (Hit rate, etc.)
 - [ ] Notifications on eviction, etc.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 pub(crate) mod builder_utils;
 pub(crate) mod deque;
 pub(crate) mod error;
@@ -14,3 +16,8 @@ pub(crate) mod unsafe_weak_pointer;
 pub(crate) mod atomic_time;
 
 pub(crate) mod time;
+
+// Ensures the value fits in a range of `128u32..=u32::MAX`.
+pub(crate) fn sketch_capacity(max_capacity: u64) -> u32 {
+    max_capacity.try_into().unwrap_or(u32::MAX).max(128)
+}

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -50,7 +50,7 @@ use std::{
 /// ```
 ///
 pub struct CacheBuilder<K, V, C> {
-    max_capacity: Option<usize>,
+    max_capacity: Option<u64>,
     initial_capacity: Option<usize>,
     weigher: Option<Weigher<K, V>>,
     time_to_live: Option<Duration>,
@@ -84,7 +84,7 @@ where
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
     /// up to `max_capacity` entries.
-    pub fn new(max_capacity: usize) -> Self {
+    pub fn new(max_capacity: u64) -> Self {
         Self {
             max_capacity: Some(max_capacity),
             ..Default::default()
@@ -138,7 +138,7 @@ where
 
 impl<K, V, C> CacheBuilder<K, V, C> {
     /// Sets the max capacity of the cache.
-    pub fn max_capacity(self, max_capacity: usize) -> Self {
+    pub fn max_capacity(self, max_capacity: u64) -> Self {
         Self {
             max_capacity: Some(max_capacity),
             ..self

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -315,7 +315,7 @@ where
     /// `time_to_live`, use the [`CacheBuilder`][builder-struct].
     ///
     /// [builder-struct]: ./struct.CacheBuilder.html
-    pub fn new(max_capacity: usize) -> Self {
+    pub fn new(max_capacity: u64) -> Self {
         let build_hasher = RandomState::default();
         Self::with_everything(
             Some(max_capacity),
@@ -344,7 +344,7 @@ where
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn with_everything(
-        max_capacity: Option<usize>,
+        max_capacity: Option<u64>,
         initial_capacity: Option<usize>,
         build_hasher: S,
         weigher: Option<Weigher<K, V>>,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -706,7 +706,7 @@ where
     }
 
     #[cfg(test)]
-    pub(crate) fn weighted_size(&self) -> u64 {
+    fn weighted_size(&self) -> u64 {
         self.base.weighted_size()
     }
 }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -212,6 +212,16 @@ where
     pub(crate) fn time_to_idle(&self) -> Option<Duration> {
         self.inner.time_to_idle()
     }
+
+    #[cfg(test)]
+    pub(crate) fn estimated_entry_count(&self) -> u64 {
+        self.inner.estimated_entry_count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.inner.weighted_size()
+    }
 }
 
 //
@@ -357,13 +367,9 @@ where
 impl<K, V, S> BaseCache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
-    pub(crate) fn table_size(&self) -> usize {
-        self.inner.len()
-    }
-
     pub(crate) fn invalidation_predicate_count(&self) -> usize {
         self.inner.invalidation_predicate_count()
     }
@@ -582,6 +588,18 @@ where
     #[inline]
     fn time_to_idle(&self) -> Option<Duration> {
         self.time_to_idle
+    }
+
+    #[cfg(test)]
+    #[inline]
+    fn estimated_entry_count(&self) -> u64 {
+        self.entry_count.load()
+    }
+
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.weighted_size.load()
     }
 
     #[inline]
@@ -1343,10 +1361,6 @@ where
     K: Hash + Eq,
     S: BuildHasher + Clone,
 {
-    fn len(&self) -> usize {
-        self.cache.len()
-    }
-
     fn invalidation_predicate_count(&self) -> usize {
         self.invalidator
             .read()

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -42,7 +42,7 @@ use std::{
 /// ```
 ///
 pub struct CacheBuilder<K, V, C> {
-    max_capacity: Option<usize>,
+    max_capacity: Option<u64>,
     initial_capacity: Option<usize>,
     num_segments: Option<usize>,
     weigher: Option<Weigher<K, V>>,
@@ -78,7 +78,7 @@ where
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
     /// `SegmentedCache` holding up to `max_capacity` entries.
-    pub fn new(max_capacity: usize) -> Self {
+    pub fn new(max_capacity: u64) -> Self {
         Self {
             max_capacity: Some(max_capacity),
             ..Default::default()
@@ -219,7 +219,7 @@ where
 
 impl<K, V, C> CacheBuilder<K, V, C> {
     /// Sets the max capacity of the cache.
-    pub fn max_capacity(self, max_capacity: usize) -> Self {
+    pub fn max_capacity(self, max_capacity: u64) -> Self {
         Self {
             max_capacity: Some(max_capacity),
             ..self

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -675,6 +675,16 @@ where
     pub fn num_segments(&self) -> usize {
         1
     }
+
+    #[cfg(test)]
+    pub(crate) fn estimated_entry_count(&self) -> u64 {
+        self.base.estimated_entry_count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.base.weighted_size()
+    }
 }
 
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
@@ -727,15 +737,11 @@ where
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
-    V: Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn is_table_empty(&self) -> bool {
-        self.table_size() == 0
-    }
-
-    pub(crate) fn table_size(&self) -> usize {
-        self.base.table_size()
+        self.estimated_entry_count() == 0
     }
 
     pub(crate) fn invalidation_predicate_count(&self) -> usize {
@@ -867,11 +873,23 @@ mod tests {
         assert_eq!(cache.get(&"c"), None);
         assert_eq!(cache.get(&"d"), Some(dennis));
 
-        // Update "b" with "bill" (w: 20). This should evict "d" (w: 15).
+        // Update "b" with "bill" (w: 15 -> 20). This should evict "d" (w: 15).
         cache.insert("b", bill);
         cache.sync();
         assert_eq!(cache.get(&"b"), Some(bill));
         assert_eq!(cache.get(&"d"), None);
+
+        // Re-add "a" (w: 10) and update "b" with "bob" (w: 20 -> 15).
+        cache.insert("a", alice);
+        cache.insert("b", bob);
+        cache.sync();
+        assert_eq!(cache.get(&"a"), Some(alice));
+        assert_eq!(cache.get(&"b"), Some(bob));
+        assert_eq!(cache.get(&"d"), None);
+
+        // Verify the sizes.
+        assert_eq!(cache.estimated_entry_count(), 2);
+        assert_eq!(cache.weighted_size(), 25);
     }
 
     #[test]
@@ -971,7 +989,7 @@ mod tests {
         assert_eq!(cache.get(&1), Some("bob"));
         // This should survive as it was inserted after calling invalidate_entries_if.
         assert_eq!(cache.get(&3), Some("alice"));
-        assert_eq!(cache.table_size(), 2);
+        assert_eq!(cache.estimated_entry_count(), 2);
         assert_eq!(cache.invalidation_predicate_count(), 0);
 
         mock.increment(Duration::from_secs(5)); // 15 secs from the start.
@@ -988,7 +1006,7 @@ mod tests {
 
         assert!(cache.get(&1).is_none());
         assert!(cache.get(&3).is_none());
-        assert_eq!(cache.table_size(), 0);
+        assert_eq!(cache.estimated_entry_count(), 0);
         assert_eq!(cache.invalidation_predicate_count(), 0);
 
         Ok(())
@@ -1025,13 +1043,13 @@ mod tests {
         cache.insert("b", "bob");
         cache.sync();
 
-        assert_eq!(cache.table_size(), 1);
+        assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(5)); // 15 secs.
         cache.sync();
 
         assert_eq!(cache.get(&"b"), Some("bob"));
-        assert_eq!(cache.table_size(), 1);
+        assert_eq!(cache.estimated_entry_count(), 1);
 
         cache.insert("b", "bill");
         cache.sync();
@@ -1040,7 +1058,7 @@ mod tests {
         cache.sync();
 
         assert_eq!(cache.get(&"b"), Some("bill"));
-        assert_eq!(cache.table_size(), 1);
+        assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(5)); // 25 secs
         cache.sync();
@@ -1078,14 +1096,14 @@ mod tests {
         cache.insert("b", "bob");
         cache.sync();
 
-        assert_eq!(cache.table_size(), 2);
+        assert_eq!(cache.estimated_entry_count(), 2);
 
         mock.increment(Duration::from_secs(5)); // 15 secs.
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), Some("bob"));
-        assert_eq!(cache.table_size(), 1);
+        assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(10)); // 25 secs
         cache.sync();

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -267,7 +267,7 @@ where
     /// `time_to_live`, use the [`CacheBuilder`][builder-struct].
     ///
     /// [builder-struct]: ./struct.CacheBuilder.html
-    pub fn new(max_capacity: usize) -> Self {
+    pub fn new(max_capacity: u64) -> Self {
         let build_hasher = RandomState::default();
         Self::with_everything(
             Some(max_capacity),
@@ -296,7 +296,7 @@ where
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
     pub(crate) fn with_everything(
-        max_capacity: Option<usize>,
+        max_capacity: Option<u64>,
         initial_capacity: Option<usize>,
         build_hasher: S,
         weigher: Option<Weigher<K, V>>,

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -70,7 +70,7 @@ where
     /// # Panics
     ///
     /// Panics if `num_segments` is 0.
-    pub fn new(max_capacity: usize, num_segments: usize) -> Self {
+    pub fn new(max_capacity: u64, num_segments: usize) -> Self {
         let build_hasher = RandomState::default();
         Self::with_everything(
             Some(max_capacity),
@@ -104,7 +104,7 @@ where
     /// Panics if `num_segments` is 0.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn with_everything(
-        max_capacity: Option<usize>,
+        max_capacity: Option<u64>,
         initial_capacity: Option<usize>,
         num_segments: usize,
         build_hasher: S,
@@ -256,7 +256,7 @@ where
     }
 
     /// Returns the `max_capacity` of this cache.
-    pub fn max_capacity(&self) -> Option<usize> {
+    pub fn max_capacity(&self) -> Option<u64> {
         self.inner.desired_capacity
     }
 
@@ -357,7 +357,7 @@ impl MockExpirationClock {
 }
 
 struct Inner<K, V, S> {
-    desired_capacity: Option<usize>,
+    desired_capacity: Option<u64>,
     segments: Box<[Cache<K, V, S>]>,
     build_hasher: S,
     segment_shift: u32,
@@ -374,7 +374,7 @@ where
     /// Panics if `num_segments` is 0.
     #[allow(clippy::too_many_arguments)]
     fn new(
-        max_capacity: Option<usize>,
+        max_capacity: Option<u64>,
         initial_capacity: Option<usize>,
         num_segments: usize,
         build_hasher: S,
@@ -388,7 +388,7 @@ where
         let actual_num_segments = num_segments.next_power_of_two();
         let segment_shift = 64 - actual_num_segments.trailing_zeros();
         // TODO: Round up.
-        let seg_max_capacity = max_capacity.map(|n| n / actual_num_segments);
+        let seg_max_capacity = max_capacity.map(|n| n / actual_num_segments as u64);
         let seg_init_capacity = initial_capacity.map(|cap| cap / actual_num_segments);
         // NOTE: We cannot initialize the segments as `vec![cache; actual_num_segments]`
         // because Cache::clone() does not clone its inner but shares the same inner.

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -39,7 +39,7 @@ use std::{
 /// ```
 ///
 pub struct CacheBuilder<K, V, C> {
-    max_capacity: Option<usize>,
+    max_capacity: Option<u64>,
     initial_capacity: Option<usize>,
     weigher: Option<Weigher<K, V>>,
     time_to_live: Option<Duration>,
@@ -69,7 +69,7 @@ where
 {
     /// Construct a new `CacheBuilder` that will be used to build a `Cache` holding
     /// up to `max_capacity` entries.
-    pub fn new(max_capacity: usize) -> Self {
+    pub fn new(max_capacity: u64) -> Self {
         Self {
             max_capacity: Some(max_capacity),
             ..Default::default()
@@ -121,7 +121,7 @@ where
 
 impl<K, V, C> CacheBuilder<K, V, C> {
     /// Sets the max capacity of the cache.
-    pub fn max_capacity(self, max_capacity: usize) -> Self {
+    pub fn max_capacity(self, max_capacity: u64) -> Self {
         Self {
             max_capacity: Some(max_capacity),
             ..self

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -959,10 +959,21 @@ mod tests {
         assert_eq!(cache.get(&"c"), None);
         assert_eq!(cache.get(&"d"), Some(&dennis));
 
-        // Update "b" with "bill" (w: 20). This should evict "d" (w: 15).
+        // Update "b" with "bill" (w: 15 -> 20). This should evict "d" (w: 15).
         cache.insert("b", bill);
         assert_eq!(cache.get(&"b"), Some(&bill));
         assert_eq!(cache.get(&"d"), None);
+
+        // Re-add "a" (w: 10) and update "b" with "bob" (w: 20 -> 15).
+        cache.insert("a", alice);
+        cache.insert("b", bob);
+        assert_eq!(cache.get(&"a"), Some(&alice));
+        assert_eq!(cache.get(&"b"), Some(&bob));
+        assert_eq!(cache.get(&"d"), None);
+
+        // Verify the sizes.
+        assert_eq!(cache.entry_count, 2);
+        assert_eq!(cache.weighted_size, 25);
     }
 
     #[test]


### PR DESCRIPTION
This is a follow-up PR for #24.

This PR makes these caches not to initialize the LFU filter (`FrequencySketch`) at the cache creation time, but initialize and enable it once the cache is half full (based on the weighted size).

The size of the `FrequencySketch` is determined by the followings:
- If the `weigher` is set, use the current number of the entries in the cache.
- If not, use the `max_capacity` of the cache, which is equals to the max number of entries.

This PR also changes the `max_capacity` from `usize` to `u64`.