### PR TITLE
Fix memory leak when evicting or expiring an entry (v0.7.x)

### DIFF
--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -43,4 +43,5 @@ jobs:
       - name: Run Miri test (deque)
         uses: actions-rs/cargo@v1
         with:
-          command: miri test deque
+          command: miri
+          args: test deque

--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -1,0 +1,46 @@
+name: Miri tests
+
+on:
+  push:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+    - 'tests/**'
+  pull_request:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+    - 'tests/**'
+  schedule:
+    # Run against the last commit on the default branch on Friday at 9pm (UTC?)
+    - cron:  '0 21 * * 5'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Moka
+        uses: actions/checkout@v2
+
+      - name: Install Rust nightly toolchain with Miri
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: miri
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo clean
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+
+      - name: Run Miri test (deque)
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri test deque

--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: nightly
           override: true
           components: miri
 

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -504,11 +504,7 @@ mod tests {
         assert!(!deque.contains(node3_ref));
         assert!(node3_ref.next.is_none());
         assert!(node3_ref.next.is_none());
-
-        // This does not work as expected because NonNull implements Copy trait.
-        // See clippy(clippy::drop_copy) at
-        // https://rust-lang.github.io/rust-clippy/master/index.html#drop_copy
-        // std::mem::drop(node3_ptr);
+        std::mem::drop(unsafe { Box::from_raw(node3_ptr.as_ptr()) });
 
         // peek_front() -> node2
         let head_h = deque.peek_front().unwrap();
@@ -541,7 +537,7 @@ mod tests {
         assert!(!deque.contains(node2_ref));
         assert!(node2_ref.next.is_none());
         assert!(node2_ref.next.is_none());
-        // std::mem::drop(node2_ptr);
+        std::mem::drop(unsafe { Box::from_raw(node2_ptr.as_ptr()) });
 
         // peek_front() -> node1
         let head_g = deque.peek_front().unwrap();
@@ -568,7 +564,7 @@ mod tests {
         assert!(!deque.contains(node1_ref));
         assert!(node1_ref.next.is_none());
         assert!(node1_ref.next.is_none());
-        // std::mem::drop(node1_ptr);
+        std::mem::drop(unsafe { Box::from_raw(node1_ptr.as_ptr()) });
 
         // peek_front() -> node1
         let head_h = deque.peek_front();
@@ -630,6 +626,7 @@ mod tests {
         assert_eq!((&mut deque).next(), Some(&"a".into()));
         // Next will be "c", but we unlink it.
         unsafe { deque.unlink(node3_ptr) };
+        std::mem::drop(unsafe { Box::from_raw(node3_ptr.as_ptr()) });
         // Now, next should be "b".
         assert_eq!((&mut deque).next(), Some(&"b".into()));
         assert!((&mut deque).next().is_none());
@@ -692,6 +689,7 @@ mod tests {
         // Iterate after an unlink.
         // Unlink the second node "c". Now "a" -> "c".
         unsafe { deque.unlink(node3_ptr) };
+        std::mem::drop(unsafe { Box::from_raw(node3_ptr.as_ptr()) });
         let node1a = deque.peek_front().unwrap();
         assert_eq!(node1a.element, "a".to_string());
         let node2a = node1a.next_node().unwrap();

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -698,8 +698,7 @@ mod tests {
         // -------------------------------------------------------
         // Iterate after an unlink.
         // Unlink the second node "c". Now "a" -> "c".
-        unsafe { deque.unlink(node3_ptr) };
-        std::mem::drop(unsafe { Box::from_raw(node3_ptr.as_ptr()) });
+        unsafe { deque.unlink_and_drop(node3_ptr) };
         let node1a = deque.peek_front().unwrap();
         assert_eq!(node1a.element, "a".to_string());
         let node2a = node1a.next_node().unwrap();

--- a/src/sync/deques.rs
+++ b/src/sync/deques.rs
@@ -166,9 +166,8 @@ impl<K> Deques<K> {
         let p = node.as_ref();
         if &p.region == deq.region() {
             if deq.contains(p) {
-                deq.unlink(node);
                 // https://github.com/moka-rs/moka/issues/64
-                drop(Box::from_raw(node.as_ptr()));
+                deq.unlink_and_drop(node);
             }
         } else {
             panic!(
@@ -183,9 +182,8 @@ impl<K> Deques<K> {
             let p = node.as_ref();
             if &p.region == deq.region() {
                 if deq.contains(p) {
-                    deq.unlink(node);
                     // https://github.com/moka-rs/moka/issues/64
-                    drop(Box::from_raw(node.as_ptr()));
+                    deq.unlink_and_drop(node);
                 }
             } else {
                 panic!(

--- a/src/sync/deques.rs
+++ b/src/sync/deques.rs
@@ -167,6 +167,8 @@ impl<K> Deques<K> {
         if &p.region == deq.region() {
             if deq.contains(p) {
                 deq.unlink(node);
+                // https://github.com/moka-rs/moka/issues/64
+                drop(Box::from_raw(node.as_ptr()));
             }
         } else {
             panic!(
@@ -182,6 +184,8 @@ impl<K> Deques<K> {
             if &p.region == deq.region() {
                 if deq.contains(p) {
                     deq.unlink(node);
+                    // https://github.com/moka-rs/moka/issues/64
+                    drop(Box::from_raw(node.as_ptr()));
                 }
             } else {
                 panic!(

--- a/src/unsync/deques.rs
+++ b/src/unsync/deques.rs
@@ -123,6 +123,8 @@ impl<K> Deques<K> {
     ) {
         if deq.contains(node.as_ref()) {
             deq.unlink(node);
+            // https://github.com/moka-rs/moka/issues/64
+            drop(Box::from_raw(node.as_ptr()));
         } else {
             panic!(
                 "unlink_node - node is not a member of {} deque. {:?}",
@@ -139,6 +141,8 @@ impl<K> Deques<K> {
             debug_assert_eq!(&p.region, &WriteOrder);
             if deq.contains(p) {
                 deq.unlink(node);
+                // https://github.com/moka-rs/moka/issues/64
+                drop(Box::from_raw(node.as_ptr()));
             } else {
                 panic!(
                     "unlink_node - node is not a member of write_order deque. {:?}",

--- a/src/unsync/deques.rs
+++ b/src/unsync/deques.rs
@@ -122,9 +122,8 @@ impl<K> Deques<K> {
         node: NonNull<DeqNode<KeyHashDate<K>>>,
     ) {
         if deq.contains(node.as_ref()) {
-            deq.unlink(node);
             // https://github.com/moka-rs/moka/issues/64
-            drop(Box::from_raw(node.as_ptr()));
+            deq.unlink_and_drop(node);
         } else {
             panic!(
                 "unlink_node - node is not a member of {} deque. {:?}",
@@ -140,9 +139,8 @@ impl<K> Deques<K> {
             let p = node.as_ref();
             debug_assert_eq!(&p.region, &WriteOrder);
             if deq.contains(p) {
-                deq.unlink(node);
                 // https://github.com/moka-rs/moka/issues/64
-                drop(Box::from_raw(node.as_ptr()));
+                deq.unlink_and_drop(node);
             } else {
                 panic!(
                     "unlink_node - node is not a member of write_order deque. {:?}",


### PR DESCRIPTION
This PR addresses the memory leak issue reported by #64.

The memory leak happens when evicting/expiring an entry or manually invalidating an entry. It should not happen when dropping a cache.

The leaking data is the key of an entry, last modified timestamp (`u64`) and last accessed timestamp (`u64`). It does not include the value of an entry.

## How to reproduce

- This issue can be reproduced by the code in the description of #64.
- Or by running the following commands. [Miri](https://github.com/rust-lang/miri) will detect similar issue in `Deque`'s unit tests:

```console
$ rustup update nightly
$ rustup +nightly component add miri
$ cargo +nightly miri test deque
```

```
running 4 tests
test common::deque::tests::basics ... ok
test common::deque::tests::drop ... ok
test common::deque::tests::iter ... ok
test common::deque::tests::next_node ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 39 filtered out

The following memory was leaked: alloc92503 (Rust heap, size: 1, align: 1) {
    61                                              │ a
}
alloc92586 (Rust heap, size: 48, align: 8) {
    0x00 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
    0x10 │ ╾0x23b1f7[a92503]<untagged> (8 ptr bytes)╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
    0x20 │ 01 00 00 00 00 00 00 00 01 __ __ __ __ __ __ __ │ .........░░░░░░░
}
alloc93007 (Rust heap, size: 1, align: 1) { ... }
alloc93087 (Rust heap, size: 48, align: 8) { ... }
alloc93620 (Rust heap, size: 1, align: 1) { ... }
alloc93700 (Rust heap, size: 48, align: 8) { ... }
alloc105252 (Rust heap, size: 1, align: 1) { ... }
alloc105323 (Rust heap, size: 48, align: 8) { ... }
alloc114558 (Rust heap, size: 1, align: 1) { ... }
alloc114629 (Rust heap, size: 48, align: 8) { ... }

error: the evaluated program leaked memory
```

## Cause

The root cause is forgetting to drop an unlinked `DeqNode` after calling an unsafe method `moka::common::Deque::unlink`.

## Fixes

- Added unsafe `unlink_and_drop` method to `Deque` and updated the callers of `unlink` method to call `unlink_and_drop`. As the name implies, `unlink_and _drop` will unlink the `DeqNode` and then drop it.
- Added Miri test to the CI to detect similar programming errors in future.

This PR is for the master branch (v0.7.x). There is another PR #66 with the same fixes for the maint-06 branch (v0.6.x).

## Affected Versions

- v0.1.0 to v0.5.4
- v0.6.0 to v0.6.3. (Fixed in v0.6.4)
- v0.7.0. (Fixed in v0.7.1)

## Notes

We are not yanking the affected versions at crates.io although this issue will have impact to almost all Moka users, and may lead out of memory error in some use cases. This is because memory leak is not considered a memory safety issue and does not lead undefined behavior (UB).

Instead, we are doing patch releases v0.6.4 and v0.7.1 with the fixes, so that existing v0.6 and v0.7 users will automatically move to one of these fixed versions when `cargo update` is executed.

* * *
Fixes #64.