### PR TITLE
Fix Clippy 1.59 warnings for Moka v0.7.x

### DIFF
--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -49,6 +49,7 @@ use std::{
 /// }
 /// ```
 ///
+#[must_use]
 pub struct CacheBuilder<K, V, C> {
     max_capacity: Option<u64>,
     initial_capacity: Option<usize>,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -41,6 +41,7 @@ use std::{
 /// // after 30 minutes (TTL) from the insert().
 /// ```
 ///
+#[must_use]
 pub struct CacheBuilder<K, V, C> {
     max_capacity: Option<u64>,
     initial_capacity: Option<usize>,

--- a/src/sync/housekeeper.rs
+++ b/src/sync/housekeeper.rs
@@ -60,7 +60,11 @@ impl<T> Drop for Housekeeper<T> {
         }
 
         // Wait for the periodical sync job to finish.
-        let _ = self.periodical_sync_running.lock();
+        //
+        // NOTE: As suggested by Clippy 1.59, drop the lock explicitly rather
+        // than doing non-binding let to `_`.
+        // https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_lock
+        std::mem::drop(self.periodical_sync_running.lock());
 
         // Wait for the on-demand sync job to finish. (busy loop)
         while self.on_demand_sync_scheduled.load(Ordering::Acquire) {

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -38,6 +38,7 @@ use std::{
 /// // after 30 minutes (TTL) from the insert().
 /// ```
 ///
+#[must_use]
 pub struct CacheBuilder<K, V, C> {
     max_capacity: Option<u64>,
     initial_capacity: Option<usize>,


### PR DESCRIPTION
Fix Clippy warnings.

- clippy 0.1.59 (7c0b2509239 2022-01-13)
