### PR TITLE
Import cht source files for better integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
         "Ohad",
         "peekable",
         "preds",
+        "repr",
         "reqwest",
         "runtimes",
         "rustdoc",
@@ -41,6 +42,7 @@
         "thiserror",
         "toolchain",
         "trybuild",
+        "Uninit",
         "unsync",
         "Upsert",
         "usize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ atomic64 = []
 # borrow violations found by Miri.
 # https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-channel/CHANGELOG.md#version-052
 crossbeam-channel = "0.5.2"
+crossbeam-epoch = "0.8.2"
 crossbeam-utils = "0.8"
-moka-cht = "0.4.2"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.11"

--- a/README.md
+++ b/README.md
@@ -492,6 +492,20 @@ This name would imply the following facts and hopes:
 [moka-pot-wikipedia]: https://en.wikipedia.org/wiki/Moka_pot
 
 
+## Credits
+
+### cht
+
+The source files of the concurrent hash table under `moka::cht` module were copied
+from the [cht v0.4.1][cht-v041] and modified by us. We did so for better integration
+between Moka and cht.
+
+The cht is authored by Gregory Meyer and its v0.4.1 and earlier versions are licensed
+under the MIT license.
+
+[cht-v041]: https://github.com/Gregory-Meyer/cht/tree/v0.4.1
+
+
 ## License
 
 Moka is distributed under either of
@@ -504,18 +518,6 @@ at your option.
 See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE) for details.
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_large)
-
-
-## Credits
-
-The source files of the concurrent hash table under `moka::cht` module were copied
-from the [cht v0.4.1][cht-v041] and modified by us. We did so for better integration
-between Moka and cht.
-
-The cht is authored by Gregory Meyer and its v0.4.1 and earlier versions are licensed
-under the MIT license.
-
-[cht-v041]: https://github.com/Gregory-Meyer/cht/tree/v0.4.1
 
 <!--
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,18 @@ See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE) for details.
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_large)
 
+
+## Credits
+
+The source files of the concurrent hash table under `moka::cht` module were copied
+from the [cht v0.4.1][cht-v041] and modified by us. We did so for better integration
+between Moka and cht.
+
+The cht is authored by Gregory Meyer and its v0.4.1 and earlier versions are licensed
+under the MIT license.
+
+[cht-v041]: https://github.com/Gregory-Meyer/cht/tree/v0.4.1
+
 <!--
 
 MEMO:

--- a/src/cht.rs
+++ b/src/cht.rs
@@ -1,0 +1,81 @@
+//! Lock-free hash tables.
+//!
+//! The hash tables in this crate are, at their core, open addressing hash
+//! tables implemented using open addressing and boxed buckets. The core of
+//! these hash tables are bucket arrays, which consist of a vector of atomic
+//! pointers to buckets, an atomic pointer to the next bucket array, and an
+//! epoch number. In the context of this crate, an atomic pointer is a nullable
+//! pointer that is accessed and manipulated using atomic memory operations.
+//! Each bucket consists of a key and a possibly-uninitialized value.
+//!
+//! The key insight into making the hash table resizable is to incrementally
+//! copy buckets from the old bucket array to the new bucket array. As buckets
+//! are copied between bucket arrays, their pointers in the old bucket array are
+//! CAS'd with a null pointer that has a sentinel bit set. If the CAS fails,
+//! that thread must read the bucket pointer again and retry copying it into the
+//! new bucket array. If at any time a thread reads a bucket pointer with the
+//! sentinel bit set, that thread knows that a new (larger) bucket array has
+//! been allocated. That thread will then immediately attempt to copy all
+//! buckets to the new bucket array. It is possible to implement an algorithm in
+//! which a subset of buckets are relocated per-thread; such an algorithm has
+//! not been implemented for the sake of simplicity.
+//!
+//! Bucket pointers that have been copied from an old bucket array into a new
+//! bucket array are marked with a borrowed bit. If a thread copies a bucket
+//! from an old bucket array into a new bucket array, fails to CAS the bucket
+//! pointer in the old bucket array, it attempts to CAS the bucket pointer in
+//! the new bucket array that it previously inserted to. If the bucket pointer
+//! in the new bucket array does *not* have the borrowed tag bit set, that
+//! thread knows that the value in the new bucket array was modified more
+//! recently than the value in the old bucket array. To avoid discarding updates
+//! to the new bucket array, a thread will never replace a bucket pointer that
+//! has the borrowed tag bit set with one that does not. To see why this is
+//! necessary, consider the case where a bucket pointer is copied into the new
+//! array, removed from the new array by a second thread, then copied into the
+//! new array again by a third thread.
+//!
+//! Mutating operations are, at their core, an atomic compare-and-swap (CAS) on
+//! a bucket pointer. Insertions CAS null pointers and bucket pointers with
+//! matching keys, modifications CAS bucket pointers with matching keys, and
+//! removals CAS non-tombstone bucket pointers. Tombstone bucket pointers are
+//! bucket pointers with a tombstone bit set as part of a removal; this
+//! indicates that the bucket's value has been moved from and will be destroyed
+//! if it has not been already.
+//!
+//! As previously mentioned, removing an entry from the hash table results in
+//! that bucket pointer having a tombstone bit set. Insertions cannot
+//! displace a tombstone bucket unless their key compares equal, so once an
+//! entry is inserted into the hash table, the specific index it is assigned to
+//! will only ever hold entries whose keys compare equal. Without this
+//! restriction, resizing operations could result in the old and new bucket
+//! arrays being temporarily inconsistent. Consider the case where one thread,
+//! as part of a resizing operation, copies a bucket into a new bucket array
+//! while another thread removes and replaces that bucket from the old bucket
+//! array. If the new bucket has a non-matching key, what happens to the bucket
+//! that was just copied into the new bucket array?
+//!
+//! Tombstone bucket pointers are typically not copied into new bucket arrays.
+//! The exception is the case where a bucket pointer was copied to the new
+//! bucket array, then CAS on the old bucket array fails because that bucket has
+//! been replaced with a tombstone. In this case, the tombstone bucket pointer
+//! will be copied over to reflect the update without displacing a key from its
+//! bucket.
+//!
+//! This hash table algorithm was inspired by [a blog post by Jeff Phreshing]
+//! that describes the implementation of the Linear hash table in [Junction], a
+//! C++ library of concurrent data structures. Additional inspiration was drawn
+//! from the lock-free hash table described by Cliff Click in [a tech talk] given
+//! at Google in 2007.
+//!
+//! [a blog post by Jeff Phreshing]: https://preshing.com/20160222/a-resizable-concurrent-map/
+//! [Junction]: https://github.com/preshing/junction
+//! [a tech talk]: https://youtu.be/HJ-719EGIts
+
+pub(crate) mod map;
+pub(crate) mod segment;
+
+// #[cfg(test)]
+// #[macro_use]
+// pub(crate) mod test_util;
+
+pub(crate) use segment::HashMap as SegmentedHashMap;

--- a/src/cht/map.rs
+++ b/src/cht/map.rs
@@ -1,0 +1,10 @@
+//! A lock-free hash map implemented with bucket pointer arrays, open addressing,
+//! and linear probing.
+
+pub(crate) mod bucket;
+pub(crate) mod bucket_array_ref;
+
+use std::collections::hash_map::RandomState;
+
+/// Default hasher for `HashMap`.
+pub type DefaultHashBuilder = RandomState;

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -1,0 +1,696 @@
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, Hash, Hasher},
+    mem::{self, MaybeUninit},
+    ptr,
+    sync::atomic::{self, AtomicU64, Ordering},
+};
+
+use crossbeam_epoch::{Atomic, CompareAndSetError, Guard, Owned, Shared};
+use once_cell::sync::Lazy;
+
+pub(crate) static BUCKET_COUNTERS: Lazy<Counters> = Lazy::new(|| Counters::default());
+
+#[derive(Default)]
+pub(crate) struct Counters {
+    pub(crate) bucket_array_creation_count: AtomicU64,
+    pub(crate) bucket_array_allocation_bytes: AtomicU64,
+    pub(crate) bucket_array_drop_count: AtomicU64,
+    pub(crate) bucket_array_release_bytes: AtomicU64,
+    pub(crate) bucket_creation_count: AtomicU64,
+    pub(crate) bucket_drop_count: AtomicU64,
+}
+
+pub(crate) struct BucketArray<K, V> {
+    pub(crate) buckets: Box<[Atomic<Bucket<K, V>>]>,
+    pub(crate) next: Atomic<BucketArray<K, V>>,
+    pub(crate) epoch: usize,
+}
+
+impl<K, V> BucketArray<K, V> {
+    pub(crate) fn with_length(epoch: usize, length: usize) -> Self {
+        assert!(length.is_power_of_two());
+        let mut buckets = Vec::with_capacity(length);
+
+        unsafe {
+            ptr::write_bytes(buckets.as_mut_ptr(), 0, length);
+            buckets.set_len(length);
+        }
+
+        let buckets = buckets.into_boxed_slice();
+
+        let size = (buckets.len() * std::mem::size_of::<Atomic<Bucket<K, V>>>()) as u64;
+        BUCKET_COUNTERS
+            .bucket_array_creation_count
+            .fetch_add(1, Ordering::AcqRel);
+        BUCKET_COUNTERS
+            .bucket_array_allocation_bytes
+            .fetch_add(size, Ordering::AcqRel);
+
+        Self {
+            buckets,
+            next: Atomic::null(),
+            epoch,
+        }
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        assert!(self.buckets.len().is_power_of_two());
+
+        self.buckets.len() / 2
+    }
+}
+
+impl<K, V> Drop for BucketArray<K, V> {
+    fn drop(&mut self) {
+        let size = (self.buckets.len() * std::mem::size_of::<Atomic<Bucket<K, V>>>()) as u64;
+        BUCKET_COUNTERS
+            .bucket_array_drop_count
+            .fetch_add(1, Ordering::AcqRel);
+        BUCKET_COUNTERS
+            .bucket_array_release_bytes
+            .fetch_add(size, Ordering::AcqRel);
+    }
+}
+
+impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
+    pub(crate) fn get<Q: ?Sized + Eq>(
+        &self,
+        guard: &'g Guard,
+        hash: u64,
+        key: &Q,
+    ) -> Result<Shared<'g, Bucket<K, V>>, RelocatedError>
+    where
+        K: Borrow<Q>,
+    {
+        let loop_result = self.probe_loop(guard, hash, |_, _, this_bucket_ptr| {
+            let this_bucket_ref = if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() }
+            {
+                this_bucket_ref
+            } else {
+                return ProbeLoopAction::Return(Shared::null());
+            };
+
+            let this_key = &this_bucket_ref.key;
+
+            if this_key.borrow() != key {
+                return ProbeLoopAction::Continue;
+            }
+
+            let result_ptr = if this_bucket_ptr.tag() & TOMBSTONE_TAG == 0 {
+                this_bucket_ptr
+            } else {
+                Shared::null()
+            };
+
+            ProbeLoopAction::Return(result_ptr)
+        });
+
+        match loop_result {
+            ProbeLoopResult::Returned(t) => Ok(t),
+            ProbeLoopResult::LoopEnded => Ok(Shared::null()),
+            ProbeLoopResult::FoundSentinelTag => Err(RelocatedError),
+        }
+    }
+
+    pub(crate) fn remove_if<Q: ?Sized + Eq, F: FnMut(&K, &V) -> bool>(
+        &self,
+        guard: &'g Guard,
+        hash: u64,
+        key: &Q,
+        mut condition: F,
+    ) -> Result<Shared<'g, Bucket<K, V>>, F>
+    where
+        K: Borrow<Q>,
+    {
+        let loop_result = self.probe_loop(guard, hash, |_, this_bucket, this_bucket_ptr| {
+            let this_bucket_ref = if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() }
+            {
+                this_bucket_ref
+            } else {
+                return ProbeLoopAction::Return(Shared::null());
+            };
+
+            let this_key = &this_bucket_ref.key;
+
+            if this_key.borrow() != key {
+                return ProbeLoopAction::Continue;
+            } else if this_bucket_ptr.tag() & TOMBSTONE_TAG != 0 {
+                return ProbeLoopAction::Return(Shared::null());
+            }
+
+            let this_value = unsafe { &*this_bucket_ref.maybe_value.as_ptr() };
+
+            if !condition(this_key, this_value) {
+                return ProbeLoopAction::Return(Shared::null());
+            }
+
+            let new_bucket_ptr = this_bucket_ptr.with_tag(TOMBSTONE_TAG);
+
+            match this_bucket.compare_and_set_weak(
+                this_bucket_ptr,
+                new_bucket_ptr,
+                (Ordering::Release, Ordering::Relaxed),
+                guard,
+            ) {
+                Ok(_) => ProbeLoopAction::Return(new_bucket_ptr),
+                Err(_) => ProbeLoopAction::Reload,
+            }
+        });
+
+        match loop_result {
+            ProbeLoopResult::Returned(t) => Ok(t),
+            ProbeLoopResult::LoopEnded => Ok(Shared::null()),
+            ProbeLoopResult::FoundSentinelTag => Err(condition),
+        }
+    }
+
+    // https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn insert_or_modify<F: FnOnce() -> V, G: FnMut(&K, &V) -> V>(
+        &self,
+        guard: &'g Guard,
+        hash: u64,
+        state: InsertOrModifyState<K, V, F>,
+        mut modifier: G,
+    ) -> Result<Shared<'g, Bucket<K, V>>, (InsertOrModifyState<K, V, F>, G)> {
+        let mut maybe_state = Some(state);
+
+        let loop_result = self.probe_loop(guard, hash, |_, this_bucket, this_bucket_ptr| {
+            let state = maybe_state.take().unwrap();
+
+            let (new_bucket, maybe_insert_value) =
+                if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() } {
+                    let this_key = &this_bucket_ref.key;
+
+                    if this_key != state.key() {
+                        maybe_state = Some(state);
+
+                        return ProbeLoopAction::Continue;
+                    }
+
+                    if this_bucket_ptr.tag() & TOMBSTONE_TAG == 0 {
+                        let this_value = unsafe { &*this_bucket_ref.maybe_value.as_ptr() };
+                        let new_value = modifier(this_key, this_value);
+
+                        let (new_bucket, insert_value) = state.into_modify_bucket(new_value);
+
+                        (new_bucket, Some(insert_value))
+                    } else {
+                        (state.into_insert_bucket(), None)
+                    }
+                } else {
+                    (state.into_insert_bucket(), None)
+                };
+
+            if let Err(CompareAndSetError { new, .. }) = this_bucket.compare_and_set_weak(
+                this_bucket_ptr,
+                new_bucket,
+                (Ordering::Release, Ordering::Relaxed),
+                guard,
+            ) {
+                maybe_state = Some(InsertOrModifyState::from_bucket_value(
+                    new,
+                    maybe_insert_value,
+                ));
+
+                ProbeLoopAction::Reload
+            } else {
+                ProbeLoopAction::Return(this_bucket_ptr)
+            }
+        });
+
+        loop_result
+            .returned()
+            .ok_or_else(|| (maybe_state.unwrap(), modifier))
+    }
+
+    fn insert_for_grow(
+        &self,
+        guard: &'g Guard,
+        hash: u64,
+        bucket_ptr: Shared<'g, Bucket<K, V>>,
+    ) -> Option<usize> {
+        assert!(!bucket_ptr.is_null());
+        assert_eq!(bucket_ptr.tag() & SENTINEL_TAG, 0);
+        assert_ne!(bucket_ptr.tag() & BORROWED_TAG, 0);
+
+        let key = &unsafe { bucket_ptr.deref() }.key;
+
+        let loop_result = self.probe_loop(guard, hash, |i, this_bucket, this_bucket_ptr| {
+            if let Some(Bucket { key: this_key, .. }) = unsafe { this_bucket_ptr.as_ref() } {
+                if this_bucket_ptr == bucket_ptr {
+                    return ProbeLoopAction::Return(None);
+                } else if this_key != key {
+                    return ProbeLoopAction::Continue;
+                } else if this_bucket_ptr.tag() & BORROWED_TAG == 0 {
+                    return ProbeLoopAction::Return(None);
+                }
+            }
+
+            if this_bucket_ptr.is_null() && bucket_ptr.tag() & TOMBSTONE_TAG != 0 {
+                ProbeLoopAction::Return(None)
+            } else if this_bucket
+                .compare_and_set_weak(
+                    this_bucket_ptr,
+                    bucket_ptr,
+                    (Ordering::Release, Ordering::Relaxed),
+                    guard,
+                )
+                .is_ok()
+            {
+                ProbeLoopAction::Return(Some(i))
+            } else {
+                ProbeLoopAction::Reload
+            }
+        });
+
+        loop_result.returned().flatten()
+    }
+}
+
+impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
+    fn probe_loop<
+        F: FnMut(usize, &Atomic<Bucket<K, V>>, Shared<'g, Bucket<K, V>>) -> ProbeLoopAction<T>,
+        T,
+    >(
+        &self,
+        guard: &'g Guard,
+        hash: u64,
+        mut f: F,
+    ) -> ProbeLoopResult<T> {
+        let offset = hash as usize & (self.buckets.len() - 1);
+
+        for i in
+            (0..self.buckets.len()).map(|i| (i.wrapping_add(offset)) & (self.buckets.len() - 1))
+        {
+            let this_bucket = &self.buckets[i];
+
+            loop {
+                let this_bucket_ptr = this_bucket.load_consume(guard);
+
+                if this_bucket_ptr.tag() & SENTINEL_TAG != 0 {
+                    return ProbeLoopResult::FoundSentinelTag;
+                }
+
+                match f(i, this_bucket, this_bucket_ptr) {
+                    ProbeLoopAction::Continue => break,
+                    ProbeLoopAction::Reload => (),
+                    ProbeLoopAction::Return(t) => return ProbeLoopResult::Returned(t),
+                }
+            }
+        }
+
+        ProbeLoopResult::LoopEnded
+    }
+
+    pub(crate) fn rehash<H: BuildHasher>(
+        &self,
+        guard: &'g Guard,
+        build_hasher: &H,
+    ) -> &'g BucketArray<K, V>
+    where
+        K: Hash + Eq,
+    {
+        let next_array = self.next_array(guard);
+        assert!(self.buckets.len() <= next_array.buckets.len());
+
+        for this_bucket in self.buckets.iter() {
+            let mut maybe_state: Option<(usize, Shared<'g, Bucket<K, V>>)> = None;
+
+            loop {
+                let this_bucket_ptr = this_bucket.load_consume(guard);
+
+                if this_bucket_ptr.tag() & SENTINEL_TAG != 0 {
+                    break;
+                }
+
+                let to_put_ptr = this_bucket_ptr.with_tag(this_bucket_ptr.tag() | BORROWED_TAG);
+
+                if let Some((index, mut next_bucket_ptr)) = maybe_state {
+                    assert!(!this_bucket_ptr.is_null());
+
+                    let next_bucket = &next_array.buckets[index];
+
+                    while next_bucket_ptr.tag() & BORROWED_TAG != 0
+                        && next_bucket
+                            .compare_and_set_weak(
+                                next_bucket_ptr,
+                                to_put_ptr,
+                                (Ordering::Release, Ordering::Relaxed),
+                                guard,
+                            )
+                            .is_err()
+                    {
+                        next_bucket_ptr = next_bucket.load_consume(guard);
+                    }
+                } else if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() } {
+                    let key = &this_bucket_ref.key;
+                    let hash = hash(build_hasher, key);
+
+                    if let Some(index) = next_array.insert_for_grow(guard, hash, to_put_ptr) {
+                        maybe_state = Some((index, to_put_ptr));
+                    }
+                }
+
+                if this_bucket
+                    .compare_and_set_weak(
+                        this_bucket_ptr,
+                        Shared::null().with_tag(SENTINEL_TAG),
+                        (Ordering::Release, Ordering::Relaxed),
+                        guard,
+                    )
+                    .is_ok()
+                {
+                    if !this_bucket_ptr.is_null()
+                        && this_bucket_ptr.tag() & TOMBSTONE_TAG != 0
+                        && maybe_state.is_none()
+                    {
+                        unsafe { defer_destroy_bucket(guard, this_bucket_ptr) };
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        next_array
+    }
+
+    fn next_array(&self, guard: &'g Guard) -> &'g BucketArray<K, V> {
+        let mut maybe_new_next = None;
+
+        loop {
+            let next_ptr = self.next.load_consume(guard);
+
+            if let Some(next_ref) = unsafe { next_ptr.as_ref() } {
+                return next_ref;
+            }
+
+            let new_next = maybe_new_next.unwrap_or_else(|| {
+                Owned::new(BucketArray::with_length(
+                    self.epoch + 1,
+                    self.buckets.len() * 2,
+                ))
+            });
+
+            match self.next.compare_and_set_weak(
+                Shared::null(),
+                new_next,
+                (Ordering::Release, Ordering::Relaxed),
+                guard,
+            ) {
+                Ok(p) => return unsafe { p.deref() },
+                Err(CompareAndSetError { new, .. }) => {
+                    maybe_new_next = Some(new);
+                }
+            }
+        }
+    }
+}
+
+#[repr(align(8))]
+#[derive(Debug)]
+pub(crate) struct Bucket<K, V> {
+    pub(crate) key: K,
+    pub(crate) maybe_value: MaybeUninit<V>,
+}
+
+impl<K, V> Bucket<K, V> {
+    pub(crate) fn new(key: K, value: V) -> Bucket<K, V> {
+        let b = Bucket {
+            key,
+            maybe_value: MaybeUninit::new(value),
+        };
+        BUCKET_COUNTERS
+            .bucket_creation_count
+            .fetch_add(1, Ordering::AcqRel);
+        b
+    }
+}
+
+impl<K, V> Drop for Bucket<K, V> {
+    fn drop(&mut self) {
+        BUCKET_COUNTERS
+            .bucket_drop_count
+            .fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct RelocatedError;
+
+pub(crate) enum InsertOrModifyState<K, V, F: FnOnce() -> V> {
+    New(K, F),
+    AttemptedInsertion(Owned<Bucket<K, V>>),
+    AttemptedModification(Owned<Bucket<K, V>>, ValueOrFunction<V, F>),
+}
+
+impl<K, V, F: FnOnce() -> V> InsertOrModifyState<K, V, F> {
+    fn from_bucket_value(
+        bucket: Owned<Bucket<K, V>>,
+        value_or_function: Option<ValueOrFunction<V, F>>,
+    ) -> Self {
+        if let Some(value_or_function) = value_or_function {
+            Self::AttemptedModification(bucket, value_or_function)
+        } else {
+            Self::AttemptedInsertion(bucket)
+        }
+    }
+
+    fn key(&self) -> &K {
+        match self {
+            InsertOrModifyState::New(k, _) => k,
+            InsertOrModifyState::AttemptedInsertion(b)
+            | InsertOrModifyState::AttemptedModification(b, _) => &b.key,
+        }
+    }
+
+    fn into_insert_bucket(self) -> Owned<Bucket<K, V>> {
+        match self {
+            InsertOrModifyState::New(k, f) => Owned::new(Bucket::new(k, f())),
+            InsertOrModifyState::AttemptedInsertion(b) => b,
+            InsertOrModifyState::AttemptedModification(mut b, v_or_f) => {
+                unsafe {
+                    mem::drop(
+                        mem::replace(&mut b.maybe_value, MaybeUninit::new(v_or_f.into_value()))
+                            .assume_init(),
+                    )
+                };
+
+                b
+            }
+        }
+    }
+
+    fn into_modify_bucket(self, value: V) -> (Owned<Bucket<K, V>>, ValueOrFunction<V, F>) {
+        match self {
+            InsertOrModifyState::New(k, f) => (
+                Owned::new(Bucket::new(k, value)),
+                ValueOrFunction::Function(f),
+            ),
+            InsertOrModifyState::AttemptedInsertion(mut b) => {
+                let insert_value = unsafe {
+                    mem::replace(&mut b.maybe_value, MaybeUninit::new(value)).assume_init()
+                };
+
+                (b, ValueOrFunction::Value(insert_value))
+            }
+            InsertOrModifyState::AttemptedModification(mut b, v_or_f) => {
+                unsafe {
+                    mem::drop(
+                        mem::replace(&mut b.maybe_value, MaybeUninit::new(value)).assume_init(),
+                    )
+                };
+
+                (b, v_or_f)
+            }
+        }
+    }
+}
+
+pub(crate) enum ValueOrFunction<V, F: FnOnce() -> V> {
+    Value(V),
+    Function(F),
+}
+
+impl<V, F: FnOnce() -> V> ValueOrFunction<V, F> {
+    fn into_value(self) -> V {
+        match self {
+            ValueOrFunction::Value(v) => v,
+            ValueOrFunction::Function(f) => f(),
+        }
+    }
+}
+
+pub(crate) fn hash<K: ?Sized + Hash, H: BuildHasher>(build_hasher: &H, key: &K) -> u64 {
+    let mut hasher = build_hasher.build_hasher();
+    key.hash(&mut hasher);
+
+    hasher.finish()
+}
+
+enum ProbeLoopAction<T> {
+    Continue,
+    Reload,
+    Return(T),
+}
+
+enum ProbeLoopResult<T> {
+    LoopEnded,
+    FoundSentinelTag,
+    Returned(T),
+}
+
+impl<T> ProbeLoopResult<T> {
+    fn returned(self) -> Option<T> {
+        match self {
+            Self::Returned(t) => Some(t),
+            Self::LoopEnded | Self::FoundSentinelTag => None,
+        }
+    }
+}
+
+pub(crate) unsafe fn defer_destroy_bucket<'g, K, V>(
+    guard: &'g Guard,
+    mut ptr: Shared<'g, Bucket<K, V>>,
+) {
+    assert!(!ptr.is_null());
+
+    guard.defer_unchecked(move || {
+        atomic::fence(Ordering::Acquire);
+
+        if ptr.tag() & TOMBSTONE_TAG == 0 {
+            ptr::drop_in_place(ptr.deref_mut().maybe_value.as_mut_ptr());
+        }
+
+        mem::drop(ptr.into_owned());
+    });
+}
+
+pub(crate) unsafe fn defer_destroy_tombstone<'g, K, V>(
+    guard: &'g Guard,
+    mut ptr: Shared<'g, Bucket<K, V>>,
+) {
+    assert!(!ptr.is_null());
+    assert_ne!(ptr.tag() & TOMBSTONE_TAG, 0);
+
+    atomic::fence(Ordering::Acquire);
+    // read the value now, but defer its destruction for later
+    let value = ptr::read(ptr.deref_mut().maybe_value.as_ptr());
+
+    // to be entirely honest, i don't know what order deferred functions are
+    // called in crossbeam-epoch. in the case that the deferred functions are
+    // called out of order, this prevents that from being an issue.
+    guard.defer_unchecked(move || mem::drop(value));
+}
+
+pub(crate) unsafe fn defer_acquire_destroy<'g, T>(guard: &'g Guard, ptr: Shared<'g, T>) {
+    assert!(!ptr.is_null());
+
+    guard.defer_unchecked(move || {
+        atomic::fence(Ordering::Acquire);
+        mem::drop(ptr.into_owned());
+    });
+}
+
+pub(crate) const SENTINEL_TAG: usize = 0b001; // set on old table buckets when copied into a new table
+pub(crate) const TOMBSTONE_TAG: usize = 0b010; // set when the value has been destroyed
+pub(crate) const BORROWED_TAG: usize = 0b100; // set on new table buckets when copied from an old table
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     use std::collections::hash_map::RandomState;
+
+//     #[test]
+//     fn get_insert_remove() {
+//         let build_hasher = RandomState::new();
+//         let buckets = BucketArray::with_length(0, 16);
+//         let guard = unsafe { &crossbeam_epoch::unprotected() };
+
+//         let k1 = "foo";
+//         let h1 = hash(&build_hasher, k1);
+//         let v1 = 5;
+
+//         let k2 = "bar";
+//         let h2 = hash(&build_hasher, k2);
+//         let v2 = 10;
+
+//         let k3 = "baz";
+//         let h3 = hash(&build_hasher, k3);
+//         let v3 = 15;
+
+//         assert_eq!(buckets.get(guard, h1, k1), Ok(Shared::null()));
+//         assert_eq!(buckets.get(guard, h2, k2), Ok(Shared::null()));
+//         assert_eq!(buckets.get(guard, h3, k3), Ok(Shared::null()));
+
+//         let b1 = Owned::new(Bucket::new(k1, v1)).into_shared(guard);
+//         assert!(is_ok_null(
+//             buckets.insert(guard, h1, unsafe { b1.into_owned() })
+//         ));
+
+//         assert_eq!(buckets.get(guard, h1, k1), Ok(b1));
+//         assert_eq!(buckets.get(guard, h2, k2), Ok(Shared::null()));
+//         assert_eq!(buckets.get(guard, h3, k3), Ok(Shared::null()));
+
+//         let b2 = Owned::new(Bucket::new(k2, v2)).into_shared(guard);
+//         assert!(is_ok_null(
+//             buckets.insert(guard, h2, unsafe { b2.into_owned() })
+//         ));
+
+//         assert_eq!(buckets.get(guard, h1, k1), Ok(b1));
+//         assert_eq!(buckets.get(guard, h2, k2), Ok(b2));
+//         assert_eq!(buckets.get(guard, h3, k3), Ok(Shared::null()));
+
+//         let b3 = Owned::new(Bucket::new(k3, v3)).into_shared(guard);
+//         assert!(is_ok_null(
+//             buckets.insert(guard, h3, unsafe { b3.into_owned() })
+//         ));
+
+//         assert_eq!(buckets.get(guard, h1, k1), Ok(b1));
+//         assert_eq!(buckets.get(guard, h2, k2), Ok(b2));
+//         assert_eq!(buckets.get(guard, h3, k3), Ok(b3));
+
+//         assert_eq!(
+//             buckets.remove_if(guard, h1, k1, |_, _| true).ok().unwrap(),
+//             b1.with_tag(TOMBSTONE_TAG)
+//         );
+//         unsafe { defer_destroy_tombstone(guard, b1.with_tag(TOMBSTONE_TAG)) };
+//         assert_eq!(
+//             buckets.remove_if(guard, h2, k2, |_, _| true).ok().unwrap(),
+//             b2.with_tag(TOMBSTONE_TAG)
+//         );
+//         unsafe { defer_destroy_tombstone(guard, b2.with_tag(TOMBSTONE_TAG)) };
+//         assert_eq!(
+//             buckets.remove_if(guard, h3, k3, |_, _| true).ok().unwrap(),
+//             b3.with_tag(TOMBSTONE_TAG)
+//         );
+//         unsafe { defer_destroy_tombstone(guard, b3.with_tag(TOMBSTONE_TAG)) };
+
+//         assert_eq!(buckets.get(guard, h1, k1), Ok(Shared::null()));
+//         assert_eq!(buckets.get(guard, h2, k2), Ok(Shared::null()));
+//         assert_eq!(buckets.get(guard, h3, k3), Ok(Shared::null()));
+
+//         for this_bucket in buckets.buckets.iter() {
+//             let this_bucket_ptr = this_bucket.swap(Shared::null(), Ordering::Relaxed, guard);
+
+//             if this_bucket_ptr.is_null() {
+//                 continue;
+//             }
+
+//             unsafe {
+//                 defer_destroy_bucket(guard, this_bucket_ptr);
+//             }
+//         }
+//     }
+
+//     fn is_ok_null<'g, K, V, E>(maybe_bucket_ptr: Result<Shared<'g, Bucket<K, V>>, E>) -> bool {
+//         if let Ok(bucket_ptr) = maybe_bucket_ptr {
+//             bucket_ptr.is_null()
+//         } else {
+//             false
+//         }
+//     }
+// }

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -9,7 +9,7 @@ use std::{
 use crossbeam_epoch::{Atomic, CompareAndSetError, Guard, Owned, Shared};
 use once_cell::sync::Lazy;
 
-pub(crate) static BUCKET_COUNTERS: Lazy<Counters> = Lazy::new(|| Counters::default());
+pub(crate) static BUCKET_COUNTERS: Lazy<Counters> = Lazy::new(Counters::default);
 
 #[derive(Default)]
 pub(crate) struct Counters {

--- a/src/cht/map/bucket_array_ref.rs
+++ b/src/cht/map/bucket_array_ref.rs
@@ -1,0 +1,235 @@
+use super::bucket::{self, Bucket, BucketArray, InsertOrModifyState};
+
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, Hash},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crossbeam_epoch::{Atomic, CompareAndSetError, Guard, Owned, Shared};
+
+pub(crate) struct BucketArrayRef<'a, K, V, S> {
+    pub(crate) bucket_array: &'a Atomic<BucketArray<K, V>>,
+    pub(crate) build_hasher: &'a S,
+    pub(crate) len: &'a AtomicUsize,
+}
+
+impl<'a, K: Hash + Eq, V, S: BuildHasher> BucketArrayRef<'a, K, V, S> {
+    pub(crate) fn get_key_value_and<Q: Hash + Eq + ?Sized, F: FnOnce(&K, &V) -> T, T>(
+        &self,
+        key: &Q,
+        hash: u64,
+        with_entry: F,
+    ) -> Option<T>
+    where
+        K: Borrow<Q>,
+    {
+        let guard = &crossbeam_epoch::pin();
+        let current_ref = self.get(guard);
+        let mut bucket_array_ref = current_ref;
+
+        let result;
+
+        loop {
+            match bucket_array_ref
+                .get(guard, hash, key)
+                .map(|p| unsafe { p.as_ref() })
+            {
+                Ok(Some(Bucket {
+                    key,
+                    maybe_value: value,
+                })) => {
+                    result = Some(with_entry(key, unsafe { &*value.as_ptr() }));
+
+                    break;
+                }
+                Ok(None) => {
+                    result = None;
+
+                    break;
+                }
+                Err(_) => {
+                    bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher);
+                }
+            }
+        }
+
+        self.swing(guard, current_ref, bucket_array_ref);
+
+        result
+    }
+
+    pub(crate) fn remove_entry_if_and<
+        Q: Hash + Eq + ?Sized,
+        F: FnMut(&K, &V) -> bool,
+        G: FnOnce(&K, &V) -> T,
+        T,
+    >(
+        &self,
+        key: &Q,
+        hash: u64,
+        mut condition: F,
+        with_previous_entry: G,
+    ) -> Option<T>
+    where
+        K: Borrow<Q>,
+    {
+        let guard = &crossbeam_epoch::pin();
+        let current_ref = self.get(guard);
+        let mut bucket_array_ref = current_ref;
+
+        let result;
+
+        loop {
+            match bucket_array_ref.remove_if(guard, hash, key, condition) {
+                Ok(previous_bucket_ptr) => {
+                    if let Some(previous_bucket_ref) = unsafe { previous_bucket_ptr.as_ref() } {
+                        let Bucket {
+                            key,
+                            maybe_value: value,
+                        } = previous_bucket_ref;
+                        self.len.fetch_sub(1, Ordering::Relaxed);
+                        result = Some(with_previous_entry(key, unsafe { &*value.as_ptr() }));
+
+                        unsafe { bucket::defer_destroy_tombstone(guard, previous_bucket_ptr) };
+                    } else {
+                        result = None;
+                    }
+
+                    break;
+                }
+                Err(c) => {
+                    condition = c;
+                    bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher);
+                }
+            }
+        }
+
+        self.swing(guard, current_ref, bucket_array_ref);
+
+        result
+    }
+
+    pub(crate) fn insert_with_or_modify_entry_and<
+        F: FnOnce() -> V,
+        G: FnMut(&K, &V) -> V,
+        H: FnOnce(&K, &V) -> T,
+        T,
+    >(
+        &self,
+        key: K,
+        hash: u64,
+        on_insert: F,
+        mut on_modify: G,
+        with_old_entry: H,
+    ) -> Option<T> {
+        let guard = &crossbeam_epoch::pin();
+        let current_ref = self.get(guard);
+        let mut bucket_array_ref = current_ref;
+        let mut state = InsertOrModifyState::New(key, on_insert);
+
+        let result;
+
+        loop {
+            while self.len.load(Ordering::Relaxed) > bucket_array_ref.capacity() {
+                bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher);
+            }
+
+            match bucket_array_ref.insert_or_modify(guard, hash, state, on_modify) {
+                Ok(previous_bucket_ptr) => {
+                    if let Some(previous_bucket_ref) = unsafe { previous_bucket_ptr.as_ref() } {
+                        if previous_bucket_ptr.tag() & bucket::TOMBSTONE_TAG != 0 {
+                            self.len.fetch_add(1, Ordering::Relaxed);
+                            result = None;
+                        } else {
+                            let Bucket {
+                                key,
+                                maybe_value: value,
+                            } = previous_bucket_ref;
+                            result = Some(with_old_entry(key, unsafe { &*value.as_ptr() }));
+                        }
+
+                        unsafe { bucket::defer_destroy_bucket(guard, previous_bucket_ptr) };
+                    } else {
+                        self.len.fetch_add(1, Ordering::Relaxed);
+                        result = None;
+                    }
+
+                    break;
+                }
+                Err((s, f)) => {
+                    state = s;
+                    on_modify = f;
+                    bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher);
+                }
+            }
+        }
+
+        self.swing(guard, current_ref, bucket_array_ref);
+
+        result
+    }
+}
+
+impl<'a, 'g, K, V, S> BucketArrayRef<'a, K, V, S> {
+    fn get(&self, guard: &'g Guard) -> &'g BucketArray<K, V> {
+        const DEFAULT_LENGTH: usize = 128;
+
+        let mut maybe_new_bucket_array = None;
+
+        loop {
+            let bucket_array_ptr = self.bucket_array.load_consume(guard);
+
+            if let Some(bucket_array_ref) = unsafe { bucket_array_ptr.as_ref() } {
+                return bucket_array_ref;
+            }
+
+            let new_bucket_array = maybe_new_bucket_array
+                .unwrap_or_else(|| Owned::new(BucketArray::with_length(0, DEFAULT_LENGTH)));
+
+            match self.bucket_array.compare_and_set_weak(
+                Shared::null(),
+                new_bucket_array,
+                (Ordering::Release, Ordering::Relaxed),
+                guard,
+            ) {
+                Ok(b) => return unsafe { b.as_ref() }.unwrap(),
+                Err(CompareAndSetError { new, .. }) => maybe_new_bucket_array = Some(new),
+            }
+        }
+    }
+
+    fn swing(
+        &self,
+        guard: &'g Guard,
+        mut current_ref: &'g BucketArray<K, V>,
+        min_ref: &'g BucketArray<K, V>,
+    ) {
+        let min_epoch = min_ref.epoch;
+
+        let mut current_ptr = (current_ref as *const BucketArray<K, V>).into();
+        let min_ptr: Shared<'g, _> = (min_ref as *const BucketArray<K, V>).into();
+
+        loop {
+            if current_ref.epoch >= min_epoch {
+                return;
+            }
+
+            match self.bucket_array.compare_and_set_weak(
+                current_ptr,
+                min_ptr,
+                (Ordering::Release, Ordering::Relaxed),
+                guard,
+            ) {
+                Ok(_) => unsafe { bucket::defer_acquire_destroy(guard, current_ptr) },
+                Err(_) => {
+                    let new_ptr = self.bucket_array.load_consume(guard);
+                    assert!(!new_ptr.is_null());
+
+                    current_ptr = new_ptr;
+                    current_ref = unsafe { new_ptr.as_ref() }.unwrap();
+                }
+            }
+        }
+    }
+}

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -1,0 +1,34 @@
+//! Segmented lock-free hash tables.
+//!
+//! Segmented hash tables divide their entries between a number of smaller
+//! logical hash tables, or segments. Each segment is entirely independent from
+//! the others, and entries are never relocated across segment boundaries.
+//!
+//! In the context of this crate, a segment refers specifically to an array of
+//! bucket pointers. The number of segments in a hash table is rounded up to the
+//! nearest power of two; this is so that selecting the segment for a key is no
+//! more than a right shift to select the most significant bits of a hashed key.
+//!
+//! Each segment is entirely independent from the others, all operations can be
+//! performed concurrently by multiple threads. Should a set of threads be
+//! operating on disjoint sets of segments, the only synchronization between
+//! them will be destructive interference as they access and update the bucket
+//! array pointer and length for each segment.
+//!
+//! Compared to the unsegmented hash tables in this crate, the segmented hash
+//! tables have higher concurrent write throughput for disjoint sets of keys.
+//! However, the segmented hash tables have slightly lower read and
+//! single-threaded write throughput. This is because the segmenting structure
+//! adds another layer of indirection between the hash table and its buckets.
+//!
+//! The idea for segmenting hash tables was inspired by the
+//! [`ConcurrentHashMap`] from OpenJDK 7, which consists of a number of
+//! separately-locked segments. OpenJDK 8 introduced a striped concurrent hash
+//! map that stripes a set of bucket locks across the set of buckets using the
+//! least significant bits of hashed keys.
+//!
+//! [`ConcurrentHashMap`]: https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/util/concurrent/ConcurrentHashMap.java
+
+pub mod map;
+
+pub use map::HashMap;

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -29,6 +29,6 @@
 //!
 //! [`ConcurrentHashMap`]: https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/util/concurrent/ConcurrentHashMap.java
 
-pub mod map;
+pub(crate) mod map;
 
-pub use map::HashMap;
+pub(crate) use map::HashMap;

--- a/src/cht/segment/map.rs
+++ b/src/cht/segment/map.rs
@@ -1,0 +1,670 @@
+//! A lock-free hash map implemented with segmented bucket pointer arrays, open
+//! addressing, and linear probing.
+
+use crate::cht::map::{
+    bucket::{self, BucketArray},
+    bucket_array_ref::BucketArrayRef,
+    DefaultHashBuilder,
+};
+
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, Hash},
+    ptr,
+    sync::atomic::{self, AtomicUsize, Ordering},
+};
+
+use crossbeam_epoch::Atomic;
+
+/// A lock-free hash map implemented with segmented bucket pointer arrays, open
+/// addressing, and linear probing.
+///
+/// By default, `Cache` uses a hashing algorithm selected to provide resistance
+/// against HashDoS attacks.
+///
+/// The default hashing algorithm is the one used by `std::collections::HashMap`,
+/// which is currently SipHash 1-3.
+///
+/// While its performance is very competitive for medium sized keys, other hashing
+/// algorithms will outperform it for small keys such as integers as well as large
+/// keys such as long strings. However those algorithms will typically not protect
+/// against attacks such as HashDoS.
+///
+/// The hashing algorithm can be replaced on a per-`HashMap` basis using the
+/// [`default`], [`with_hasher`], [`with_capacity_and_hasher`],
+/// [`with_num_segments_and_hasher`], and
+/// [`with_num_segments_capacity_and_hasher`] methods. Many alternative
+/// algorithms are available on crates.io, such as the [`aHash`] crate.
+///
+/// The number of segments can be specified on a per-`HashMap` basis using the
+/// [`with_num_segments`], [`with_num_segments_and_capacity`],
+/// [`with_num_segments_and_hasher`], and
+/// [`with_num_segments_capacity_and_hasher`] methods. By default, the
+/// `num-cpus` feature is enabled and [`new`], [`with_capacity`],
+/// [`with_hasher`], and [`with_capacity_and_hasher`] will create maps with
+/// twice as many segments as the system has CPUs.
+///
+/// It is required that the keys implement the [`Eq`] and [`Hash`] traits,
+/// although this can frequently be achieved by using
+/// `#[derive(PartialEq, Eq, Hash)]`. If you implement these yourself, it is
+/// important that the following property holds:
+///
+/// ```text
+/// k1 == k2 -> hash(k1) == hash(k2)
+/// ```
+///
+/// In other words, if two keys are equal, their hashes must be equal.
+///
+/// It is a logic error for a key to be modified in such a way that the key's
+/// hash, as determined by the [`Hash`] trait, or its equality, as determined by
+/// the [`Eq`] trait, changes while it is in the map. This is normally only
+/// possible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.
+///
+/// [`aHash`]: https://crates.io/crates/ahash
+/// [`default`]: #method.default
+/// [`with_hasher`]: #method.with_hasher
+/// [`with_capacity`]: #method.with_capacity
+/// [`with_capacity_and_hasher`]: #method.with_capacity_and_hasher
+/// [`with_num_segments_and_hasher`]: #method.with_num_segments_and_hasher
+/// [`with_num_segments_capacity_and_hasher`]: #method.with_num_segments_capacity_and_hasher
+/// [`with_num_segments`]: #method.with_num_segments
+/// [`with_num_segments_and_capacity`]: #method.with_num_segments_and_capacity
+/// [`new`]: #method.new
+/// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+/// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+/// [`Cell`]: https://doc.rust-lang.org/std/cell/struct.Ref.html
+/// [`RefCell`]: https://doc.rust-lang.org/std/cell/struct.RefCell.html
+pub struct HashMap<K, V, S = DefaultHashBuilder> {
+    segments: Box<[Segment<K, V>]>,
+    build_hasher: S,
+    len: AtomicUsize,
+    segment_shift: u32,
+}
+
+#[cfg(feature = "num-cpus")]
+impl<K, V> HashMap<K, V, DefaultHashBuilder> {
+    /// Creates an empty `HashMap`.
+    ///
+    /// The hash map is initially created with a capacity of 0, so it will not
+    /// allocate bucket pointer arrays until it is first inserted into. However,
+    /// it will always allocate memory for segment pointers and lengths.
+    ///
+    /// The `HashMap` will be created with at least twice as many segments as
+    /// the system has CPUs.
+    pub fn new() -> Self {
+        Self::with_num_segments_capacity_and_hasher(
+            default_num_segments(),
+            0,
+            DefaultHashBuilder::default(),
+        )
+    }
+
+    /// Creates an empty `HashMap` with the specified capacity.
+    ///
+    /// The hash map will be able to hold at least `capacity` elements without
+    /// reallocating any bucket pointer arrays. If `capacity` is 0, the hash map
+    /// will not allocate any bucket pointer arrays. However, it will always
+    /// allocate memory for segment pointers and lengths.
+    ///
+    /// The `HashMap` will be created with at least twice as many segments as
+    /// the system has CPUs.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_num_segments_capacity_and_hasher(
+            default_num_segments(),
+            capacity,
+            DefaultHashBuilder::default(),
+        )
+    }
+}
+
+#[cfg(feature = "num-cpus")]
+impl<K, V, S: BuildHasher> HashMap<K, V, S> {
+    /// Creates an empty `HashMap` which will use the given hash builder to hash
+    /// keys.
+    ///
+    /// The hash map is initially created with a capacity of 0, so it will not
+    /// allocate bucket pointer arrays until it is first inserted into. However,
+    /// it will always allocate memory for segment pointers and lengths.
+    ///
+    /// The `HashMap` will be created with at least twice as many segments as
+    /// the system has CPUs.
+    pub fn with_hasher(build_hasher: S) -> Self {
+        Self::with_num_segments_capacity_and_hasher(default_num_segments(), 0, build_hasher)
+    }
+
+    /// Creates an empty `HashMap` with the specified capacity, using
+    /// `build_hasher` to hash the keys.
+    ///
+    /// The hash map will be able to hold at least `capacity` elements without
+    /// reallocating any bucket pointer arrays. If `capacity` is 0, the hash map
+    /// will not allocate any bucket pointer arrays. However, it will always
+    /// allocate memory for segment pointers and lengths.
+    ///
+    /// The `HashMap` will be created with at least twice as many segments as
+    /// the system has CPUs.
+    pub fn with_capacity_and_hasher(capacity: usize, build_hasher: S) -> Self {
+        Self::with_num_segments_capacity_and_hasher(default_num_segments(), capacity, build_hasher)
+    }
+}
+
+impl<K, V> HashMap<K, V, DefaultHashBuilder> {
+    /// Creates an empty `HashMap` with the specified number of segments.
+    ///
+    /// The hash map is initially created with a capacity of 0, so it will not
+    /// allocate bucket pointer arrays until it is first inserted into. However,
+    /// it will always allocate memory for segment pointers and lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_segments` is 0.
+    pub fn with_num_segments(num_segments: usize) -> Self {
+        Self::with_num_segments_capacity_and_hasher(num_segments, 0, DefaultHashBuilder::default())
+    }
+
+    /// Creates an empty `HashMap` with the specified number of segments and
+    /// capacity.
+    ///
+    /// The hash map will be able to hold at least `capacity` elements without
+    /// reallocating any bucket pointer arrays. If `capacity` is 0, the hash map
+    /// will not allocate any bucket pointer arrays. However, it will always
+    /// allocate memory for segment pointers and lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_segments` is 0.
+    pub fn with_num_segments_and_capacity(num_segments: usize, capacity: usize) -> Self {
+        Self::with_num_segments_capacity_and_hasher(
+            num_segments,
+            capacity,
+            DefaultHashBuilder::default(),
+        )
+    }
+}
+
+impl<K, V, S> HashMap<K, V, S> {
+    /// Creates an empty `HashMap` with the specified number of segments, using
+    /// `build_hasher` to hash the keys.
+    ///
+    /// The hash map is initially created with a capacity of 0, so it will not
+    /// allocate bucket pointer arrays until it is first inserted into. However,
+    /// it will always allocate memory for segment pointers and lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_segments` is 0.
+    pub fn with_num_segments_and_hasher(num_segments: usize, build_hasher: S) -> Self {
+        Self::with_num_segments_capacity_and_hasher(num_segments, 0, build_hasher)
+    }
+
+    /// Creates an empty `HashMap` with the specified number of segments and
+    /// capacity, using `build_hasher` to hash the keys.
+    ///
+    /// The hash map will be able to hold at least `capacity` elements without
+    /// reallocating any bucket pointer arrays. If `capacity` is 0, the hash map
+    /// will not allocate any bucket pointer arrays. However, it will always
+    /// allocate memory for segment pointers and lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_segments` is 0.
+    pub fn with_num_segments_capacity_and_hasher(
+        num_segments: usize,
+        capacity: usize,
+        build_hasher: S,
+    ) -> Self {
+        assert!(num_segments > 0);
+
+        let actual_num_segments = num_segments.next_power_of_two();
+        let segment_shift = 64 - actual_num_segments.trailing_zeros();
+
+        let mut segments = Vec::with_capacity(actual_num_segments);
+
+        if capacity == 0 {
+            unsafe {
+                ptr::write_bytes(segments.as_mut_ptr(), 0, actual_num_segments);
+                segments.set_len(actual_num_segments);
+            }
+        } else {
+            let actual_capacity = (capacity * 2).next_power_of_two();
+
+            for _ in 0..actual_num_segments {
+                segments.push(Segment {
+                    bucket_array: Atomic::new(BucketArray::with_length(0, actual_capacity)),
+                    len: AtomicUsize::new(0),
+                });
+            }
+        }
+
+        let segments = segments.into_boxed_slice();
+
+        Self {
+            segments,
+            build_hasher,
+            len: AtomicUsize::new(0),
+            segment_shift,
+        }
+    }
+
+    /// Returns the number of elements in the map.
+    ///
+    /// # Safety
+    ///
+    /// This method on its own is safe, but other threads can add or remove
+    /// elements at any time.
+    pub fn len(&self) -> usize {
+        self.len.load(Ordering::Relaxed)
+    }
+
+    /// Returns `true` if the map contains no elements.
+    ///
+    /// # Safety
+    ///
+    /// This method on its own is safe, but other threads can add or remove
+    /// elements at any time.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of elements the map can hold without reallocating any
+    /// bucket pointer arrays.
+    ///
+    /// Note that all mutating operations except removal will result in a bucket
+    /// being allocated or reallocated.
+    ///
+    /// # Safety
+    ///
+    /// This method on its own is safe, but other threads can increase the
+    /// capacity of each segment at any time by adding elements.
+    pub fn capacity(&self) -> usize {
+        let guard = &crossbeam_epoch::pin();
+
+        self.segments
+            .iter()
+            .map(|s| s.bucket_array.load_consume(guard))
+            .map(|p| unsafe { p.as_ref() })
+            .map(|a| a.map(BucketArray::capacity).unwrap_or(0))
+            .sum::<usize>()
+    }
+
+    /// Returns the number of elements the `index`-th segment of the map can
+    /// hold without reallocating a bucket pointer array.
+    ///
+    /// Note that all mutating operations, with the exception of removing
+    /// elements, will result in an allocation for a new bucket.
+    ///
+    /// # Safety
+    ///
+    /// This method on its own is safe, but other threads can increase the
+    /// capacity of a segment at any time by adding elements.
+    pub fn segment_capacity(&self, index: usize) -> usize {
+        assert!(index < self.segments.len());
+
+        let guard = &crossbeam_epoch::pin();
+
+        unsafe {
+            self.segments[index]
+                .bucket_array
+                .load_consume(guard)
+                .as_ref()
+        }
+        .map(BucketArray::capacity)
+        .unwrap_or(0)
+    }
+
+    /// Returns the number of segments in the map.
+    pub fn num_segments(&self) -> usize {
+        self.segments.len()
+    }
+}
+
+impl<K, V, S: BuildHasher> HashMap<K, V, S> {
+    /// Returns the index of the segment that `key` would belong to if inserted
+    /// into the map.
+    pub fn segment_index<Q: Hash>(&self, key: &Q) -> usize
+    where
+        K: Borrow<Q>,
+    {
+        let hash = bucket::hash(&self.build_hasher, key);
+
+        self.segment_index_from_hash(hash)
+    }
+}
+
+impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
+    /// Returns a clone of the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    #[inline]
+    pub fn get<Q: Hash + Eq + ?Sized>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        V: Clone,
+    {
+        self.get_key_value_and(key, |_, v| v.clone())
+    }
+
+    /// Returns a clone of the the key-value pair corresponding to the supplied
+    /// key.
+    ///
+    /// The supplied key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for the key
+    /// type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    #[inline]
+    pub fn get_key_value<Q: Hash + Eq + ?Sized>(&self, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q> + Clone,
+        V: Clone,
+    {
+        self.get_key_value_and(key, |k, v| (k.clone(), v.clone()))
+    }
+
+    /// Returns the result of invoking a function with a reference to the
+    /// key-value pair corresponding to the supplied key.
+    ///
+    /// The supplied key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for the key
+    /// type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    #[inline]
+    pub fn get_key_value_and<Q: Hash + Eq + ?Sized, F: FnOnce(&K, &V) -> T, T>(
+        &self,
+        key: &Q,
+        with_entry: F,
+    ) -> Option<T>
+    where
+        K: Borrow<Q>,
+    {
+        let hash = bucket::hash(&self.build_hasher, &key);
+
+        self.bucket_array_ref(hash)
+            .get_key_value_and(key, hash, with_entry)
+    }
+
+    /// Removes a key from the map, returning a clone of the value previously
+    /// corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    #[inline]
+    pub fn remove<Q: Hash + Eq + ?Sized>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        V: Clone,
+    {
+        self.remove_entry_if_and(key, |_, _| true, |_, v| v.clone())
+    }
+
+    /// Removes a key from the map, returning a clone of the key-value pair
+    /// previously corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    #[inline]
+    pub fn remove_entry<Q: Hash + Eq + ?Sized>(&self, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q> + Clone,
+        V: Clone,
+    {
+        self.remove_entry_if_and(key, |_, _| true, |k, v| (k.clone(), v.clone()))
+    }
+
+    /// Removes a key from the map if a condition is met, returning a clone of
+    /// the value previously corresponding to the key.
+    ///
+    /// `condition` will be invoked at least once if [`Some`] is returned. It
+    /// may also be invoked one or more times if [`None`] is returned.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    pub fn remove_if<Q: Hash + Eq + ?Sized, F: FnMut(&K, &V) -> bool>(
+        &self,
+        key: &Q,
+        condition: F,
+    ) -> Option<V>
+    where
+        K: Borrow<Q>,
+        V: Clone,
+    {
+        self.remove_entry_if_and(key, condition, move |_, v| v.clone())
+    }
+
+    /// Removes a key from the map if a condition is met, returning the result
+    /// of invoking a function with a reference to the key-value pair previously
+    /// corresponding to the key.
+    ///
+    /// `condition` will be invoked at least once if [`Some`] is returned. It
+    /// may also be invoked one or more times if [`None`] is returned.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
+    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+    /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    #[inline]
+    pub fn remove_entry_if_and<
+        Q: Hash + Eq + ?Sized,
+        F: FnMut(&K, &V) -> bool,
+        G: FnOnce(&K, &V) -> T,
+        T,
+    >(
+        &self,
+        key: &Q,
+        condition: F,
+        with_previous_entry: G,
+    ) -> Option<T>
+    where
+        K: Borrow<Q>,
+    {
+        let hash = bucket::hash(&self.build_hasher, &key);
+
+        self.bucket_array_ref(hash)
+            .remove_entry_if_and(key, hash, condition, move |k, v| {
+                self.len.fetch_sub(1, Ordering::Relaxed);
+
+                with_previous_entry(k, v)
+            })
+    }
+
+    /// If no value corresponds to the key, invoke a default function to insert
+    /// a new key-value pair into the map. Otherwise, modify the existing value
+    /// and return a clone of the value previously corresponding to the key.
+    ///
+    /// `on_insert` may be invoked, even if [`None`] is returned.
+    ///
+    /// `on_modify` will be invoked at least once if [`Some`] is returned. It
+    /// may also be invoked one or more times if [`None`] is returned.
+    ///
+    /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// Moka
+    #[inline]
+    pub fn insert_with_or_modify<F: FnOnce() -> V, G: FnMut(&K, &V) -> V>(
+        &self,
+        key: K,
+        on_insert: F,
+        on_modify: G,
+    ) -> Option<V>
+    where
+        V: Clone,
+    {
+        self.insert_with_or_modify_entry_and(key, on_insert, on_modify, |_, v| v.clone())
+    }
+
+    /// If no value corresponds to the key, invoke a default function to insert
+    /// a new key-value pair into the map. Otherwise, modify the existing value
+    /// and return the result of invoking a function with a reference to the
+    /// key-value pair previously corresponding to the supplied key.
+    ///
+    /// `on_insert` may be invoked, even if [`None`] is returned.
+    ///
+    /// `on_modify` will be invoked at least once if [`Some`] is returned. It
+    /// may also be invoked one or more times if [`None`] is returned.
+    ///
+    /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    #[inline]
+    pub fn insert_with_or_modify_entry_and<
+        F: FnOnce() -> V,
+        G: FnMut(&K, &V) -> V,
+        H: FnOnce(&K, &V) -> T,
+        T,
+    >(
+        &self,
+        key: K,
+        on_insert: F,
+        on_modify: G,
+        with_old_entry: H,
+    ) -> Option<T> {
+        let hash = bucket::hash(&self.build_hasher, &key);
+
+        let result = self.bucket_array_ref(hash).insert_with_or_modify_entry_and(
+            key,
+            hash,
+            on_insert,
+            on_modify,
+            with_old_entry,
+        );
+
+        if result.is_none() {
+            self.len.fetch_add(1, Ordering::Relaxed);
+        }
+
+        result
+    }
+}
+
+#[cfg(feature = "num-cpus")]
+impl<K, V, S: Default> Default for HashMap<K, V, S> {
+    fn default() -> Self {
+        HashMap::with_num_segments_capacity_and_hasher(default_num_segments(), 0, S::default())
+    }
+}
+
+impl<K, V, S> Drop for HashMap<K, V, S> {
+    fn drop(&mut self) {
+        let guard = unsafe { &crossbeam_epoch::unprotected() };
+        atomic::fence(Ordering::Acquire);
+
+        for Segment {
+            bucket_array: this_bucket_array,
+            ..
+        } in self.segments.iter()
+        {
+            let mut current_ptr = this_bucket_array.load(Ordering::Relaxed, guard);
+
+            while let Some(current_ref) = unsafe { current_ptr.as_ref() } {
+                let next_ptr = current_ref.next.load(Ordering::Relaxed, guard);
+
+                for this_bucket_ptr in current_ref
+                    .buckets
+                    .iter()
+                    .map(|b| b.load(Ordering::Relaxed, guard))
+                    .filter(|p| !p.is_null())
+                    .filter(|p| next_ptr.is_null() || p.tag() & bucket::TOMBSTONE_TAG == 0)
+                {
+                    // only delete tombstones from the newest bucket array
+                    // the only way this becomes a memory leak is if there was a panic during a rehash,
+                    // in which case i'm going to say that running destructors and freeing memory is
+                    // best-effort, and my best effort is to not do it
+                    unsafe { bucket::defer_acquire_destroy(guard, this_bucket_ptr) };
+                }
+
+                unsafe { bucket::defer_acquire_destroy(guard, current_ptr) };
+
+                current_ptr = next_ptr;
+            }
+        }
+    }
+}
+
+impl<K, V, S> HashMap<K, V, S> {
+    #[inline]
+    fn bucket_array_ref(&'_ self, hash: u64) -> BucketArrayRef<'_, K, V, S> {
+        let index = self.segment_index_from_hash(hash);
+
+        let Segment {
+            ref bucket_array,
+            ref len,
+        } = self.segments[index];
+
+        BucketArrayRef {
+            bucket_array,
+            build_hasher: &self.build_hasher,
+            len,
+        }
+    }
+
+    #[inline]
+    fn segment_index_from_hash(&'_ self, hash: u64) -> usize {
+        if self.segment_shift == 64 {
+            0
+        } else {
+            (hash >> self.segment_shift) as usize
+        }
+    }
+}
+
+struct Segment<K, V> {
+    bucket_array: Atomic<BucketArray<K, V>>,
+    len: AtomicUsize,
+}
+
+#[cfg(feature = "num-cpus")]
+fn default_num_segments() -> usize {
+    num_cpus::get() * 2
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::write_test_cases_for_me;
+
+//     use super::*;
+
+//     write_test_cases_for_me!(HashMap);
+
+//     #[test]
+//     fn single_segment() {
+//         let map = HashMap::with_num_segments(1);
+
+//         assert!(map.is_empty());
+//         assert_eq!(map.len(), 0);
+
+//         assert_eq!(map.insert("foo", 5), None);
+//         assert_eq!(map.get("foo"), Some(5));
+
+//         assert!(!map.is_empty());
+//         assert_eq!(map.len(), 1);
+
+//         assert_eq!(map.remove("foo"), Some(5));
+//         assert!(map.is_empty());
+//         assert_eq!(map.len(), 0);
+//     }
+// }

--- a/src/cht/test_util.rs
+++ b/src/cht/test_util.rs
@@ -1,0 +1,117 @@
+#[macro_use]
+pub(crate) mod tests;
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use crossbeam_epoch::Owned;
+
+#[derive(Debug)]
+pub(crate) struct NoisyDropper<T: ?Sized> {
+    parent: Arc<DropNotifier>,
+    pub elem: T,
+}
+
+impl<T> NoisyDropper<T> {
+    pub(crate) fn new(parent: Arc<DropNotifier>, elem: T) -> Self {
+        Self { parent, elem }
+    }
+}
+
+impl<T: ?Sized> Drop for NoisyDropper<T> {
+    fn drop(&mut self) {
+        assert_eq!(self.parent.dropped.swap(true, Ordering::Relaxed), false);
+    }
+}
+
+impl<T: ?Sized + PartialEq> PartialEq for NoisyDropper<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.elem == other.elem
+    }
+}
+
+impl<T: ?Sized + PartialEq> PartialEq<T> for NoisyDropper<T> {
+    fn eq(&self, other: &T) -> bool {
+        &self.elem == other
+    }
+}
+
+impl<T: ?Sized + Eq> Eq for NoisyDropper<T> {}
+
+impl<T: ?Sized + Hash> Hash for NoisyDropper<T> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.elem.hash(hasher);
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for NoisyDropper<T> {
+    fn as_ref(&self) -> &T {
+        &self.elem
+    }
+}
+
+impl<T: ?Sized> AsMut<T> for NoisyDropper<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.elem
+    }
+}
+
+impl<T: ?Sized> Borrow<T> for NoisyDropper<T> {
+    fn borrow(&self) -> &T {
+        &self.elem
+    }
+}
+
+impl<T: ?Sized> BorrowMut<T> for NoisyDropper<T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        &mut self.elem
+    }
+}
+
+impl<T: ?Sized> Deref for NoisyDropper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.elem
+    }
+}
+
+impl<T: ?Sized> DerefMut for NoisyDropper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.elem
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct DropNotifier {
+    dropped: AtomicBool,
+}
+
+impl DropNotifier {
+    pub(crate) fn new() -> Self {
+        Self {
+            dropped: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn was_dropped(&self) -> bool {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+pub(crate) fn run_deferred() {
+    for _ in 0..65536 {
+        let guard = crossbeam_epoch::pin();
+
+        unsafe { guard.defer_destroy(Owned::new(0).into_shared(&guard)) };
+
+        guard.flush();
+    }
+}

--- a/src/cht/test_util/tests.rs
+++ b/src/cht/test_util/tests.rs
@@ -1,0 +1,967 @@
+#[macro_export]
+macro_rules! write_test_cases_for_me {
+    ($m:ident) => {
+        #[test]
+        fn insertion() {
+            const MAX_VALUE: i32 = 512;
+
+            let map = $m::with_capacity(MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.insert(i, i), None);
+
+                assert!(!map.is_empty());
+                assert_eq!(map.len(), (i + 1) as usize);
+
+                for j in 0..=i {
+                    assert_eq!(map.get(&j), Some(j));
+                    assert_eq!(map.insert(j, j), Some(j));
+                }
+
+                for k in i + 1..MAX_VALUE {
+                    assert_eq!(map.get(&k), None);
+                }
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn growth() {
+            const MAX_VALUE: i32 = 512;
+
+            let map = $m::new();
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.insert(i, i), None);
+
+                assert!(!map.is_empty());
+                assert_eq!(map.len(), (i + 1) as usize);
+
+                for j in 0..=i {
+                    assert_eq!(map.get(&j), Some(j));
+                    assert_eq!(map.insert(j, j), Some(j));
+                }
+
+                for k in i + 1..MAX_VALUE {
+                    assert_eq!(map.get(&k), None);
+                }
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_insertion() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+            const MAX_INSERTED_VALUE: i32 = (NUM_THREADS as i32) * MAX_VALUE;
+
+            let map = std::sync::Arc::new($m::with_capacity(MAX_INSERTED_VALUE as usize));
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
+                            assert_eq!(map.insert(j, j), None);
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), MAX_INSERTED_VALUE as usize);
+
+            for i in 0..MAX_INSERTED_VALUE {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_growth() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+            const MAX_INSERTED_VALUE: i32 = (NUM_THREADS as i32) * MAX_VALUE;
+
+            let map = std::sync::Arc::new($m::new());
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
+                            assert_eq!(map.insert(j, j), None);
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(|t| t.join()) {
+                assert!(result.is_ok());
+            }
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), MAX_INSERTED_VALUE as usize);
+
+            for i in 0..MAX_INSERTED_VALUE {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn removal() {
+            const MAX_VALUE: i32 = 512;
+
+            let map = $m::with_capacity(MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.insert(i, i), None);
+            }
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.remove(&i), Some(i));
+            }
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.get(&i), None);
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_removal() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+            const MAX_INSERTED_VALUE: i32 = (NUM_THREADS as i32) * MAX_VALUE;
+
+            let map = $m::with_capacity(MAX_INSERTED_VALUE as usize);
+
+            for i in 0..MAX_INSERTED_VALUE {
+                assert_eq!(map.insert(i, i), None);
+            }
+
+            let map = std::sync::Arc::new(map);
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
+                            assert_eq!(map.remove(&j), Some(j));
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(|t| t.join()) {
+                assert!(result.is_ok());
+            }
+
+            assert_eq!(map.len(), 0);
+
+            for i in 0..MAX_INSERTED_VALUE {
+                assert_eq!(map.get(&i), None);
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_insertion_and_removal() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+            const MAX_INSERTED_VALUE: i32 = (NUM_THREADS as i32) * MAX_VALUE * 2;
+            const INSERTED_MIDPOINT: i32 = MAX_INSERTED_VALUE / 2;
+
+            let map = $m::with_capacity(MAX_INSERTED_VALUE as usize);
+
+            for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
+                assert_eq!(map.insert(i, i), None);
+            }
+
+            let map = std::sync::Arc::new(map);
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS * 2));
+
+            let insert_threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
+                            assert_eq!(map.insert(j, j), None);
+                        }
+                    })
+                })
+                .collect();
+
+            let remove_threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in
+                            (0..MAX_VALUE).map(|j| INSERTED_MIDPOINT + j + (i as i32 * MAX_VALUE))
+                        {
+                            assert_eq!(map.remove(&j), Some(j));
+                        }
+                    })
+                })
+                .collect();
+
+            for result in insert_threads
+                .into_iter()
+                .chain(remove_threads.into_iter())
+                .map(|t| t.join())
+            {
+                assert!(result.is_ok());
+            }
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), INSERTED_MIDPOINT as usize);
+
+            for i in 0..INSERTED_MIDPOINT {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
+                assert_eq!(map.get(&i), None);
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_growth_and_removal() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+            const MAX_INSERTED_VALUE: i32 = (NUM_THREADS as i32) * MAX_VALUE * 2;
+            const INSERTED_MIDPOINT: i32 = MAX_INSERTED_VALUE / 2;
+
+            let map = $m::with_capacity(INSERTED_MIDPOINT as usize);
+
+            for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
+                assert_eq!(map.insert(i, i), None);
+            }
+
+            let map = std::sync::Arc::new(map);
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS * 2));
+
+            let insert_threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
+                            assert_eq!(map.insert(j, j), None);
+                        }
+                    })
+                })
+                .collect();
+
+            let remove_threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in
+                            (0..MAX_VALUE).map(|j| INSERTED_MIDPOINT + j + (i as i32 * MAX_VALUE))
+                        {
+                            assert_eq!(map.remove(&j), Some(j));
+                        }
+                    })
+                })
+                .collect();
+
+            for result in insert_threads
+                .into_iter()
+                .chain(remove_threads.into_iter())
+                .map(std::thread::JoinHandle::join)
+            {
+                assert!(result.is_ok());
+            }
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), INSERTED_MIDPOINT as usize);
+
+            for i in 0..INSERTED_MIDPOINT {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
+                assert_eq!(map.get(&i), None);
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn modify() {
+            let map = $m::new();
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            assert_eq!(map.modify("foo", |_, x| x * 2), None);
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            map.insert("foo", 1);
+            assert_eq!(map.modify("foo", |_, x| x * 2), Some(1));
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), 1);
+
+            map.remove("foo");
+            assert_eq!(map.modify("foo", |_, x| x * 2), None);
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_modification() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+            const MAX_INSERTED_VALUE: i32 = (NUM_THREADS as i32) * MAX_VALUE;
+
+            let map = $m::with_capacity(MAX_INSERTED_VALUE as usize);
+
+            for i in 0..MAX_INSERTED_VALUE {
+                map.insert(i, i);
+            }
+
+            let map = std::sync::Arc::new(map);
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|i| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in (i as i32 * MAX_VALUE)..((i as i32 + 1) * MAX_VALUE) {
+                            assert_eq!(map.modify(j, |_, x| x * 2), Some(j));
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), MAX_INSERTED_VALUE as usize);
+
+            for i in 0..MAX_INSERTED_VALUE {
+                assert_eq!(map.get(&i), Some(i * 2));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_overlapped_modification() {
+            const MAX_VALUE: i32 = 512;
+            const NUM_THREADS: usize = 64;
+
+            let map = $m::with_capacity(MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.insert(i, 0), None);
+            }
+
+            let map = std::sync::Arc::new(map);
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|_| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for i in 0..MAX_VALUE {
+                            assert!(map.modify(i, |_, x| x + 1).is_some());
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.get(&i), Some(NUM_THREADS as i32));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn insert_or_modify() {
+            let map = $m::new();
+
+            assert_eq!(map.insert_or_modify("foo", 1, |_, x| x + 1), None);
+            assert_eq!(map.get("foo"), Some(1));
+
+            assert_eq!(map.insert_or_modify("foo", 1, |_, x| x + 1), Some(1));
+            assert_eq!(map.get("foo"), Some(2));
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_insert_or_modify() {
+            const NUM_THREADS: usize = 64;
+            const MAX_VALUE: i32 = 512;
+
+            let map = std::sync::Arc::new($m::new());
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|_| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in 0..MAX_VALUE {
+                            map.insert_or_modify(j, 1, |_, x| x + 1);
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert_eq!(map.len(), MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.get(&i), Some(NUM_THREADS as i32));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_overlapped_insertion() {
+            const NUM_THREADS: usize = 64;
+            const MAX_VALUE: i32 = 512;
+
+            let map = std::sync::Arc::new($m::with_capacity(MAX_VALUE as usize));
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|_| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in 0..MAX_VALUE {
+                            map.insert(j, j);
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert_eq!(map.len(), MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_overlapped_growth() {
+            const NUM_THREADS: usize = 64;
+            const MAX_VALUE: i32 = 512;
+
+            let map = std::sync::Arc::new($m::with_capacity(1));
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|_| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in 0..MAX_VALUE {
+                            map.insert(j, j);
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert_eq!(map.len(), MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn concurrent_overlapped_removal() {
+            const NUM_THREADS: usize = 64;
+            const MAX_VALUE: i32 = 512;
+
+            let map = $m::with_capacity(MAX_VALUE as usize);
+
+            for i in 0..MAX_VALUE {
+                map.insert(i, i);
+            }
+
+            let map = std::sync::Arc::new(map);
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+            let threads: Vec<_> = (0..NUM_THREADS)
+                .map(|_| {
+                    let map = std::sync::Arc::clone(&map);
+                    let barrier = std::sync::Arc::clone(&barrier);
+
+                    std::thread::spawn(move || {
+                        barrier.wait();
+
+                        for j in 0..MAX_VALUE {
+                            let prev_value = map.remove(&j);
+
+                            if let Some(v) = prev_value {
+                                assert_eq!(v, j);
+                            }
+                        }
+                    })
+                })
+                .collect();
+
+            for result in threads.into_iter().map(std::thread::JoinHandle::join) {
+                assert!(result.is_ok());
+            }
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            for i in 0..MAX_VALUE {
+                assert_eq!(map.get(&i), None);
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn drop_value() {
+            let key_parent = std::sync::Arc::new($crate::test_util::DropNotifier::new());
+            let value_parent = std::sync::Arc::new($crate::test_util::DropNotifier::new());
+
+            {
+                let map = $m::new();
+
+                assert_eq!(
+                    map.insert_and(
+                        $crate::test_util::NoisyDropper::new(std::sync::Arc::clone(&key_parent), 0),
+                        $crate::test_util::NoisyDropper::new(
+                            std::sync::Arc::clone(&value_parent),
+                            0
+                        ),
+                        |_| ()
+                    ),
+                    None
+                );
+                assert!(!map.is_empty());
+                assert_eq!(map.len(), 1);
+                map.get_and(&0, |v| assert_eq!(v, &0));
+
+                map.remove_and(&0, |v| assert_eq!(v, &0));
+                assert!(map.is_empty());
+                assert_eq!(map.len(), 0);
+                assert_eq!(map.get_and(&0, |_| ()), None);
+
+                $crate::test_util::run_deferred();
+
+                assert!(!key_parent.was_dropped());
+                assert!(value_parent.was_dropped());
+            }
+
+            $crate::test_util::run_deferred();
+
+            assert!(key_parent.was_dropped());
+            assert!(value_parent.was_dropped());
+        }
+
+        #[test]
+        fn drop_many_values() {
+            const NUM_VALUES: usize = 1 << 16;
+
+            let key_parents: Vec<_> = std::iter::repeat_with(|| {
+                std::sync::Arc::new($crate::test_util::DropNotifier::new())
+            })
+            .take(NUM_VALUES)
+            .collect();
+            let value_parents: Vec<_> = std::iter::repeat_with(|| {
+                std::sync::Arc::new($crate::test_util::DropNotifier::new())
+            })
+            .take(NUM_VALUES)
+            .collect();
+
+            {
+                let map = $m::new();
+                assert!(map.is_empty());
+                assert_eq!(map.len(), 0);
+
+                for (i, (this_key_parent, this_value_parent)) in
+                    key_parents.iter().zip(value_parents.iter()).enumerate()
+                {
+                    assert_eq!(
+                        map.insert_and(
+                            $crate::test_util::NoisyDropper::new(
+                                std::sync::Arc::clone(&this_key_parent),
+                                i
+                            ),
+                            $crate::test_util::NoisyDropper::new(
+                                std::sync::Arc::clone(&this_value_parent),
+                                i
+                            ),
+                            |_| ()
+                        ),
+                        None
+                    );
+
+                    assert!(!map.is_empty());
+                    assert_eq!(map.len(), i + 1);
+                }
+
+                for i in 0..NUM_VALUES {
+                    assert_eq!(
+                        map.get_key_value_and(&i, |k, v| {
+                            assert_eq!(*k, i);
+                            assert_eq!(*v, i);
+                        }),
+                        Some(())
+                    );
+                }
+
+                for i in 0..NUM_VALUES {
+                    assert_eq!(
+                        map.remove_entry_and(&i, |k, v| {
+                            assert_eq!(*k, i);
+                            assert_eq!(*v, i);
+                        }),
+                        Some(())
+                    );
+                }
+
+                assert!(map.is_empty());
+                assert_eq!(map.len(), 0);
+
+                $crate::test_util::run_deferred();
+
+                for this_key_parent in key_parents.iter() {
+                    assert!(!this_key_parent.was_dropped());
+                }
+
+                for this_value_parent in value_parents.iter() {
+                    assert!(this_value_parent.was_dropped());
+                }
+
+                for i in 0..NUM_VALUES {
+                    assert_eq!(map.get_and(&i, |_| ()), None);
+                }
+            }
+
+            $crate::test_util::run_deferred();
+
+            for this_key_parent in key_parents.into_iter() {
+                assert!(this_key_parent.was_dropped());
+            }
+
+            for this_value_parent in value_parents.into_iter() {
+                assert!(this_value_parent.was_dropped());
+            }
+        }
+
+        #[test]
+        fn drop_many_values_concurrent() {
+            const NUM_THREADS: usize = 64;
+            const NUM_VALUES_PER_THREAD: usize = 512;
+            const NUM_VALUES: usize = NUM_THREADS * NUM_VALUES_PER_THREAD;
+
+            let key_parents: std::sync::Arc<Vec<_>> = std::sync::Arc::new(
+                std::iter::repeat_with(|| {
+                    std::sync::Arc::new($crate::test_util::DropNotifier::new())
+                })
+                .take(NUM_VALUES)
+                .collect(),
+            );
+            let value_parents: std::sync::Arc<Vec<_>> = std::sync::Arc::new(
+                std::iter::repeat_with(|| {
+                    std::sync::Arc::new($crate::test_util::DropNotifier::new())
+                })
+                .take(NUM_VALUES)
+                .collect(),
+            );
+
+            {
+                let map = std::sync::Arc::new($m::new());
+                assert!(map.is_empty());
+                assert_eq!(map.len(), 0);
+
+                let barrier = std::sync::Arc::new(std::sync::Barrier::new(NUM_THREADS));
+
+                let handles: Vec<_> = (0..NUM_THREADS)
+                    .map(|i| {
+                        let map = std::sync::Arc::clone(&map);
+                        let barrier = std::sync::Arc::clone(&barrier);
+                        let key_parents = std::sync::Arc::clone(&key_parents);
+                        let value_parents = std::sync::Arc::clone(&value_parents);
+
+                        std::thread::spawn(move || {
+                            barrier.wait();
+
+                            let these_key_parents = &key_parents
+                                [i * NUM_VALUES_PER_THREAD..(i + 1) * NUM_VALUES_PER_THREAD];
+                            let these_value_parents = &value_parents
+                                [i * NUM_VALUES_PER_THREAD..(i + 1) * NUM_VALUES_PER_THREAD];
+
+                            for (j, (this_key_parent, this_value_parent)) in these_key_parents
+                                .iter()
+                                .zip(these_value_parents.iter())
+                                .enumerate()
+                            {
+                                let key_value = i * NUM_VALUES_PER_THREAD + j;
+
+                                assert_eq!(
+                                    map.insert_and(
+                                        $crate::test_util::NoisyDropper::new(
+                                            std::sync::Arc::clone(&this_key_parent),
+                                            key_value as i32
+                                        ),
+                                        $crate::test_util::NoisyDropper::new(
+                                            std::sync::Arc::clone(&this_value_parent),
+                                            key_value as i32
+                                        ),
+                                        |_| ()
+                                    ),
+                                    None
+                                );
+                            }
+                        })
+                    })
+                    .collect();
+
+                for result in handles.into_iter().map(std::thread::JoinHandle::join) {
+                    assert!(result.is_ok());
+                }
+
+                assert!(!map.is_empty());
+                assert_eq!(map.len(), NUM_VALUES);
+
+                $crate::test_util::run_deferred();
+
+                for this_key_parent in key_parents.iter() {
+                    assert!(!this_key_parent.was_dropped());
+                }
+
+                for this_value_parent in value_parents.iter() {
+                    assert!(!this_value_parent.was_dropped());
+                }
+
+                for i in (0..NUM_VALUES).map(|i| i as i32) {
+                    assert_eq!(
+                        map.get_key_value_and(&i, |k, v| {
+                            assert_eq!(*k, i);
+                            assert_eq!(*v, i);
+                        }),
+                        Some(())
+                    );
+                }
+
+                let handles: Vec<_> = (0..NUM_THREADS)
+                    .map(|i| {
+                        let map = std::sync::Arc::clone(&map);
+                        let barrier = std::sync::Arc::clone(&barrier);
+
+                        std::thread::spawn(move || {
+                            barrier.wait();
+
+                            for j in 0..NUM_VALUES_PER_THREAD {
+                                let key_value = (i * NUM_VALUES_PER_THREAD + j) as i32;
+
+                                assert_eq!(
+                                    map.remove_entry_and(&key_value, |k, v| {
+                                        assert_eq!(*k, key_value);
+                                        assert_eq!(*v, key_value);
+                                    }),
+                                    Some(())
+                                );
+                            }
+                        })
+                    })
+                    .collect();
+
+                for result in handles.into_iter().map(std::thread::JoinHandle::join) {
+                    assert!(result.is_ok());
+                }
+
+                assert!(map.is_empty());
+                assert_eq!(map.len(), 0);
+
+                $crate::test_util::run_deferred();
+
+                for this_key_parent in key_parents.iter() {
+                    assert!(!this_key_parent.was_dropped());
+                }
+
+                for this_value_parent in value_parents.iter() {
+                    assert!(this_value_parent.was_dropped());
+                }
+
+                for i in (0..NUM_VALUES).map(|i| i as i32) {
+                    assert_eq!(map.get_and(&i, |_| ()), None);
+                }
+            }
+
+            $crate::test_util::run_deferred();
+
+            for this_key_parent in key_parents.iter() {
+                assert!(this_key_parent.was_dropped());
+            }
+
+            for this_value_parent in value_parents.iter() {
+                assert!(this_value_parent.was_dropped());
+            }
+        }
+
+        #[test]
+        fn remove_if() {
+            const NUM_VALUES: i32 = 512;
+
+            let is_even = |_: &i32, v: &i32| *v % 2 == 0;
+
+            let map = $m::new();
+
+            for i in 0..NUM_VALUES {
+                assert_eq!(map.insert(i, i), None);
+            }
+
+            for i in 0..NUM_VALUES {
+                if is_even(&i, &i) {
+                    assert_eq!(map.remove_if(&i, is_even), Some(i));
+                } else {
+                    assert_eq!(map.remove_if(&i, is_even), None);
+                }
+            }
+
+            for i in (0..NUM_VALUES).filter(|i| i % 2 == 0) {
+                assert_eq!(map.get(&i), None);
+            }
+
+            for i in (0..NUM_VALUES).filter(|i| i % 2 != 0) {
+                assert_eq!(map.get(&i), Some(i));
+            }
+
+            $crate::test_util::run_deferred();
+        }
+
+        #[test]
+        fn default() {
+            let map = $m::<_, _, $crate::map::DefaultHashBuilder>::default();
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            assert_eq!(map.insert("foo", 5), None);
+            assert_eq!(map.insert("bar", 10), None);
+            assert_eq!(map.insert("baz", 15), None);
+            assert_eq!(map.insert("qux", 20), None);
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), 4);
+
+            assert_eq!(map.insert("foo", 5), Some(5));
+            assert_eq!(map.insert("bar", 10), Some(10));
+            assert_eq!(map.insert("baz", 15), Some(15));
+            assert_eq!(map.insert("qux", 20), Some(20));
+
+            assert!(!map.is_empty());
+            assert_eq!(map.len(), 4);
+
+            assert_eq!(map.remove("foo"), Some(5));
+            assert_eq!(map.remove("bar"), Some(10));
+            assert_eq!(map.remove("baz"), Some(15));
+            assert_eq!(map.remove("qux"), Some(20));
+
+            assert!(map.is_empty());
+            assert_eq!(map.len(), 0);
+
+            $crate::test_util::run_deferred();
+        }
+    };
+}

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -90,7 +90,7 @@ pub(crate) struct ValueInitializer<K, V, S> {
     // try_init_or_read(). We use the type ID as a part of the key to ensure that
     // we can always downcast the trait object ErrorObject (in Waiter<V>) into
     // its concrete type.
-    waiters: moka_cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
+    waiters: crate::cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
@@ -101,7 +101,7 @@ where
 {
     pub(crate) fn with_hasher(hasher: S) -> Self {
         Self {
-            waiters: moka_cht::SegmentedHashMap::with_num_segments_and_hasher(16, hasher),
+            waiters: crate::cht::SegmentedHashMap::with_num_segments_and_hasher(16, hasher),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ pub mod future;
 pub mod sync;
 pub mod unsync;
 
+pub(crate) mod cht;
 pub(crate) mod common;
 
 pub use common::error::PredicateError;

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -457,7 +457,7 @@ enum AdmissionResult<K> {
     },
 }
 
-type CacheStore<K, V, S> = moka_cht::SegmentedHashMap<Arc<K>, Arc<ValueEntry<K, V>>, S>;
+type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<Arc<K>, Arc<ValueEntry<K, V>>, S>;
 
 type CacheEntry<K, V> = (Arc<K>, Arc<ValueEntry<K, V>>);
 
@@ -507,7 +507,7 @@ where
             .map(|cap| cap + WRITE_LOG_SIZE * 4)
             .unwrap_or_default();
         let num_segments = 64;
-        let cache = moka_cht::SegmentedHashMap::with_num_segments_capacity_and_hasher(
+        let cache = crate::cht::SegmentedHashMap::with_num_segments_capacity_and_hasher(
             num_segments,
             initial_capacity,
             build_hasher.clone(),

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -20,7 +20,7 @@ pub(crate) struct ValueInitializer<K, V, S> {
     // try_init_or_read(). We use the type ID as a part of the key to ensure that
     // we can always downcast the trait object ErrorObject (in Waiter<V>) into
     // its concrete type.
-    waiters: moka_cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
+    waiters: crate::cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
@@ -31,7 +31,7 @@ where
 {
     pub(crate) fn with_hasher(hasher: S) -> Self {
         Self {
-            waiters: moka_cht::SegmentedHashMap::with_num_segments_and_hasher(16, hasher),
+            waiters: crate::cht::SegmentedHashMap::with_num_segments_and_hasher(16, hasher),
         }
     }
 


### PR DESCRIPTION
This PR adds source files imported from moka-cht crate.

## Changes

-  Add source files (modules) used by Moka (as `moka::cht::*` modules).
- Remove moka-cht crate from the dependency.
- Add crossbeam-epoch v0.8.2 to the dependency.
- Update the existing `use` statement in Moka modules to refer to `moka::cht::SegmentedHashMap`.
- Change visibility of `moka::cht::*` modules from public to crate public.
- Remove unused feature `num_cpu` from `moka::cht::*` modules.
- Temporary disable unit tests for `cht::*` modules.


## Remaining Action Items

- Update and re-enable unit tests for `moka::cht::*` modules.
- Update the doc.