### PR TITLE
Replace some `std::sync::Arc` with `triomphe::Arc` to reduce memory utilization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,7 @@
         "Tatsuya",
         "thiserror",
         "toolchain",
+        "triomphe",
         "trybuild",
         "Uninit",
         "unsync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ quanta = "0.9.3"
 scheduled-thread-pool = "0.2"
 smallvec = "1.6"
 thiserror = "1.0"
+triomphe = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 # Optional dependencies

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -676,7 +676,11 @@ where
         self.cache.get(key)
     }
 
-    fn remove_key_value_if<F>(&self, key: &Arc<K>, condition: F) -> Option<TrioArc<ValueEntry<K, V>>>
+    fn remove_key_value_if<F>(
+        &self,
+        key: &Arc<K>,
+        condition: F,
+    ) -> Option<TrioArc<ValueEntry<K, V>>>
     where
         F: FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool,
     {

--- a/src/sync/deques.rs
+++ b/src/sync/deques.rs
@@ -1,8 +1,8 @@
 use super::{KeyDate, KeyHashDate, ValueEntry};
 use crate::common::deque::{CacheRegion, DeqNode, Deque};
 
-use std::{ptr::NonNull, sync::Arc};
-
+use std::ptr::NonNull;
+use triomphe::Arc as TrioArc;
 pub(crate) struct Deques<K> {
     pub(crate) window: Deque<KeyHashDate<K>>, //    Not used yet.
     pub(crate) probation: Deque<KeyHashDate<K>>,
@@ -34,7 +34,7 @@ impl<K> Deques<K> {
         &mut self,
         region: CacheRegion,
         khd: KeyHashDate<K>,
-        entry: &Arc<ValueEntry<K, V>>,
+        entry: &TrioArc<ValueEntry<K, V>>,
     ) {
         use CacheRegion::*;
         let node = Box::new(DeqNode::new(region, khd));
@@ -47,13 +47,13 @@ impl<K> Deques<K> {
         entry.set_access_order_q_node(Some(node));
     }
 
-    pub(crate) fn push_back_wo<V>(&mut self, kd: KeyDate<K>, entry: &Arc<ValueEntry<K, V>>) {
+    pub(crate) fn push_back_wo<V>(&mut self, kd: KeyDate<K>, entry: &TrioArc<ValueEntry<K, V>>) {
         let node = Box::new(DeqNode::new(CacheRegion::WriteOrder, kd));
         let node = self.write_order.push_back(node);
         entry.set_write_order_q_node(Some(node));
     }
 
-    pub(crate) fn move_to_back_ao<V>(&mut self, entry: &Arc<ValueEntry<K, V>>) {
+    pub(crate) fn move_to_back_ao<V>(&mut self, entry: &TrioArc<ValueEntry<K, V>>) {
         use CacheRegion::*;
         if let Some(node) = entry.access_order_q_node() {
             let p = unsafe { node.as_ref() };
@@ -73,7 +73,7 @@ impl<K> Deques<K> {
     pub(crate) fn move_to_back_ao_in_deque<V>(
         deq_name: &str,
         deq: &mut Deque<KeyHashDate<K>>,
-        entry: &Arc<ValueEntry<K, V>>,
+        entry: &TrioArc<ValueEntry<K, V>>,
     ) {
         if let Some(node) = entry.access_order_q_node() {
             let p = unsafe { node.as_ref() };
@@ -90,7 +90,7 @@ impl<K> Deques<K> {
         }
     }
 
-    pub(crate) fn move_to_back_wo<V>(&mut self, entry: &Arc<ValueEntry<K, V>>) {
+    pub(crate) fn move_to_back_wo<V>(&mut self, entry: &TrioArc<ValueEntry<K, V>>) {
         use CacheRegion::*;
         if let Some(node) = entry.write_order_q_node() {
             let p = unsafe { node.as_ref() };
@@ -103,7 +103,7 @@ impl<K> Deques<K> {
 
     pub(crate) fn move_to_back_wo_in_deque<V>(
         deq: &mut Deque<KeyDate<K>>,
-        entry: &Arc<ValueEntry<K, V>>,
+        entry: &TrioArc<ValueEntry<K, V>>,
     ) {
         if let Some(node) = entry.write_order_q_node() {
             let p = unsafe { node.as_ref() };
@@ -120,7 +120,7 @@ impl<K> Deques<K> {
         }
     }
 
-    pub(crate) fn unlink_ao<V>(&mut self, entry: &Arc<ValueEntry<K, V>>) {
+    pub(crate) fn unlink_ao<V>(&mut self, entry: &TrioArc<ValueEntry<K, V>>) {
         if let Some(node) = entry.take_access_order_q_node() {
             self.unlink_node_ao(node);
         }
@@ -129,14 +129,14 @@ impl<K> Deques<K> {
     pub(crate) fn unlink_ao_from_deque<V>(
         deq_name: &str,
         deq: &mut Deque<KeyHashDate<K>>,
-        entry: &Arc<ValueEntry<K, V>>,
+        entry: &TrioArc<ValueEntry<K, V>>,
     ) {
         if let Some(node) = entry.take_access_order_q_node() {
             unsafe { Self::unlink_node_ao_from_deque(deq_name, deq, node) };
         }
     }
 
-    pub(crate) fn unlink_wo<V>(deq: &mut Deque<KeyDate<K>>, entry: &Arc<ValueEntry<K, V>>) {
+    pub(crate) fn unlink_wo<V>(deq: &mut Deque<KeyDate<K>>, entry: &TrioArc<ValueEntry<K, V>>) {
         if let Some(node) = entry.take_write_order_q_node() {
             Self::unlink_node_wo(deq, node);
         }

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 
+use super::{base_cache::Inner, AccessTime, KvEntry, PredicateId, PredicateIdStr, ValueEntry};
 use crate::{
     common::{
         thread_pool::{PoolName, ThreadPool, ThreadPoolRegistry},
@@ -8,7 +9,6 @@ use crate::{
     },
     PredicateError,
 };
-use super::{base_cache::Inner, AccessTime, KvEntry, PredicateId, PredicateIdStr, ValueEntry};
 
 use parking_lot::{Mutex, RwLock};
 use std::{
@@ -29,7 +29,11 @@ pub(crate) type PredicateFun<K, V> = Arc<dyn Fn(&K, &V) -> bool + Send + Sync + 
 pub(crate) trait GetOrRemoveEntry<K, V> {
     fn get_value_entry(&self, key: &Arc<K>) -> Option<TrioArc<ValueEntry<K, V>>>;
 
-    fn remove_key_value_if<F>(&self, key: &Arc<K>, condition: F) -> Option<TrioArc<ValueEntry<K, V>>>
+    fn remove_key_value_if<F>(
+        &self,
+        key: &Arc<K>,
+        condition: F,
+    ) -> Option<TrioArc<ValueEntry<K, V>>>
     where
         F: FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool;
 }

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     PredicateError,
 };
-
 use super::{base_cache::Inner, AccessTime, KvEntry, PredicateId, PredicateIdStr, ValueEntry};
 
 use parking_lot::{Mutex, RwLock};
@@ -22,16 +21,17 @@ use std::{
     },
     time::Duration,
 };
+use triomphe::Arc as TrioArc;
 use uuid::Uuid;
 
 pub(crate) type PredicateFun<K, V> = Arc<dyn Fn(&K, &V) -> bool + Send + Sync + 'static>;
 
 pub(crate) trait GetOrRemoveEntry<K, V> {
-    fn get_value_entry(&self, key: &Arc<K>) -> Option<Arc<ValueEntry<K, V>>>;
+    fn get_value_entry(&self, key: &Arc<K>) -> Option<TrioArc<ValueEntry<K, V>>>;
 
-    fn remove_key_value_if<F>(&self, key: &Arc<K>, condition: F) -> Option<Arc<ValueEntry<K, V>>>
+    fn remove_key_value_if<F>(&self, key: &Arc<K>, condition: F) -> Option<TrioArc<ValueEntry<K, V>>>
     where
-        F: FnMut(&Arc<K>, &Arc<ValueEntry<K, V>>) -> bool;
+        F: FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool;
 }
 
 pub(crate) struct KeyDateLite<K> {
@@ -161,7 +161,7 @@ impl<K, V, S> Invalidator<K, V, S> {
 
     // This method will be called by the get method of Cache.
     #[inline]
-    pub(crate) fn apply_predicates(&self, key: &Arc<K>, entry: &Arc<ValueEntry<K, V>>) -> bool {
+    pub(crate) fn apply_predicates(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>) -> bool {
         if self.is_empty() {
             false
         } else if let Some(ts) = entry.last_modified() {
@@ -434,7 +434,7 @@ where
         false
     }
 
-    fn invalidate<C>(cache: &Arc<C>, key: &Arc<K>, ts: Instant) -> Option<Arc<ValueEntry<K, V>>>
+    fn invalidate<C>(cache: &Arc<C>, key: &Arc<K>, ts: Instant) -> Option<TrioArc<ValueEntry<K, V>>>
     where
         Arc<C>: GetOrRemoveEntry<K, V>,
     {


### PR DESCRIPTION
- Replace `Arc` for `Arc<ValueEntry>`, `Arc<EntryInfo>` and `Arc<value_initializer::Waiter>`.
- Add `triomphe` to the dependencies.

Note: Did not replace `Arc` for `Arc<K>` as this change leaks to the public APIs. e.g. `get(&Q)`.

* * *
Relates to #72.