### PR TITLE
Add unstable-debug-counters feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "rust-analyzer.cargo.features": ["future"],
+    "rust-analyzer.cargo.features": ["future", "unstable-debug-counters"],
     "rust-analyzer.server.extraEnv": {
         "CARGO_TARGET_DIR": "target/ra"
     },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ readme = "README.md"
 exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 build = "build.rs"
 
-# https://docs.rs/about/metadata
-[package.metadata.docs.rs]
-features = ["future"]
-
 [features]
 default = ["atomic64"]
 
@@ -30,6 +26,11 @@ future = ["async-io", "async-lock", "futures-util"]
 # or `mips-unknown-linux-musl`)
 # https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 atomic64 = []
+
+# This unstable feature adds `GlobalDebugCounters::current` function, which returns
+# counters of internal object construction and destruction`. It will have some
+# performance impacts and is intended for debugging perpose.
+unstable-debug-counters = ["future"]
 
 [dependencies]
 crossbeam-channel = "0.5.2"
@@ -64,6 +65,11 @@ trybuild = "1.0"
 
 [target.'cfg(skeptic)'.build-dependencies]
 skeptic = "0.13"
+
+# https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+# Build the doc with "future" feature enabled.
+features = ["future"]
 
 # ----------------------------------
 # RUSTSEC, etc.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ future = ["async-io", "async-lock", "futures-util"]
 atomic64 = []
 
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns
-# counters of internal object construction and destruction`. It will have some
+# counters of internal object construction and destruction. It will have some
 # performance impacts and is intended for debugging perpose.
 unstable-debug-counters = ["future"]
 

--- a/src/cht/segment/map.rs
+++ b/src/cht/segment/map.rs
@@ -199,26 +199,27 @@ impl<K, V, S> HashMap<K, V, S> {
     //     self.len() == 0
     // }
 
-    // /// Returns the number of elements the map can hold without reallocating any
-    // /// bucket pointer arrays.
-    // ///
-    // /// Note that all mutating operations except removal will result in a bucket
-    // /// being allocated or reallocated.
-    // ///
-    // /// # Safety
-    // ///
-    // /// This method on its own is safe, but other threads can increase the
-    // /// capacity of each segment at any time by adding elements.
-    // pub(crate) fn capacity(&self) -> usize {
-    //     let guard = &crossbeam_epoch::pin();
+    #[cfg(feature = "unstable-debug-counters")]
+    /// Returns the number of elements the map can hold without reallocating any
+    /// bucket pointer arrays.
+    ///
+    /// Note that all mutating operations except removal will result in a bucket
+    /// being allocated or reallocated.
+    ///
+    /// # Safety
+    ///
+    /// This method on its own is safe, but other threads can increase the
+    /// capacity of each segment at any time by adding elements.
+    pub(crate) fn capacity(&self) -> usize {
+        let guard = &crossbeam_epoch::pin();
 
-    //     self.segments
-    //         .iter()
-    //         .map(|s| s.bucket_array.load_consume(guard))
-    //         .map(|p| unsafe { p.as_ref() })
-    //         .map(|a| a.map(BucketArray::capacity).unwrap_or(0))
-    //         .sum::<usize>()
-    // }
+        self.segments
+            .iter()
+            .map(|s| s.bucket_array.load_consume(guard))
+            .map(|p| unsafe { p.as_ref() })
+            .map(|a| a.map(BucketArray::capacity).unwrap_or(0))
+            .sum::<usize>()
+    }
 
     // /// Returns the number of elements the `index`-th segment of the map can
     // /// hold without reallocating a bucket pointer array.

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -42,6 +42,9 @@ impl<T> std::fmt::Debug for DeqNode<T> {
 
 impl<T> DeqNode<T> {
     pub(crate) fn new(region: CacheRegion, element: T) -> Self {
+        #[cfg(feature = "unstable-debug-counters")]
+        crate::sync::debug_counters::InternalGlobalDebugCounters::deq_node_created();
+
         Self {
             region,
             next: None,
@@ -52,6 +55,13 @@ impl<T> DeqNode<T> {
 
     pub(crate) fn next_node(&self) -> Option<&DeqNode<T>> {
         self.next.as_ref().map(|node| unsafe { node.as_ref() })
+    }
+}
+
+#[cfg(feature = "unstable-debug-counters")]
+impl<T> Drop for DeqNode<T> {
+    fn drop(&mut self) {
+        crate::sync::debug_counters::InternalGlobalDebugCounters::deq_node_dropped();
     }
 }
 

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -183,6 +183,11 @@ impl FrequencySketch {
         hash += hash >> 32;
         (hash & self.table_mask) as usize
     }
+
+    #[cfg(feature = "unstable-debug-counters")]
+    pub(crate) fn table_size(&self) -> u64 {
+        (self.table.len() * std::mem::size_of::<u64>()) as u64
+    }
 }
 
 // Methods only available for testing.

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -11,6 +11,9 @@ use crate::{
     PredicateError,
 };
 
+#[cfg(feature = "unstable-debug-counters")]
+use crate::sync::debug_counters::CacheDebugStats;
+
 use crossbeam_channel::{Sender, TrySendError};
 use std::{
     any::TypeId,
@@ -693,6 +696,11 @@ where
     /// `Cache` always returns `1`.
     pub fn num_segments(&self) -> usize {
         1
+    }
+
+    #[cfg(feature = "unstable-debug-counters")]
+    pub fn debug_stats(&self) -> CacheDebugStats {
+        self.base.debug_stats()
     }
 
     #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@ pub(crate) mod common;
 
 pub use common::error::PredicateError;
 
+#[cfg(feature = "unstable-debug-counters")]
+pub use sync::debug_counters::GlobalDebugCounters;
+
 #[cfg(test)]
 mod tests {
     // #[cfg(trybuild)]

--- a/src/sync/debug_counters.rs
+++ b/src/sync/debug_counters.rs
@@ -1,0 +1,133 @@
+#![cfg(feature = "unstable-debug-counters")]
+
+use crossbeam_utils::atomic::AtomicCell;
+use once_cell::sync::Lazy;
+
+#[derive(Clone, Debug)]
+pub struct GlobalDebugCounters {
+    pub bucket_array_creation_count: u64,
+    pub bucket_array_allocation_bytes: u64,
+    pub bucket_array_drop_count: u64,
+    pub bucket_array_release_bytes: u64,
+    pub bucket_creation_count: u64,
+    pub bucket_drop_count: u64,
+    pub value_entry_creation_count: u64,
+    pub value_entry_drop_count: u64,
+    pub entry_info_creation_count: u64,
+    pub entry_info_drop_count: u64,
+    pub deq_node_creation_count: u64,
+    pub deq_node_drop_count: u64,
+}
+
+impl GlobalDebugCounters {
+    pub fn current() -> Self {
+        InternalGlobalDebugCounters::current()
+    }
+}
+
+static COUNTERS: Lazy<InternalGlobalDebugCounters> =
+    Lazy::new(InternalGlobalDebugCounters::default);
+
+#[derive(Default)]
+pub(crate) struct InternalGlobalDebugCounters {
+    bucket_array_creation_count: AtomicCell<u64>,
+    bucket_array_allocation_bytes: AtomicCell<u64>,
+    bucket_array_drop_count: AtomicCell<u64>,
+    bucket_array_release_bytes: AtomicCell<u64>,
+    bucket_creation_count: AtomicCell<u64>,
+    bucket_drop_count: AtomicCell<u64>,
+    value_entry_creation_count: AtomicCell<u64>,
+    value_entry_drop_count: AtomicCell<u64>,
+    entry_info_creation_count: AtomicCell<u64>,
+    entry_info_drop_count: AtomicCell<u64>,
+    deq_node_creation_count: AtomicCell<u64>,
+    deq_node_drop_count: AtomicCell<u64>,
+}
+
+impl InternalGlobalDebugCounters {
+    fn current() -> GlobalDebugCounters {
+        let c = &COUNTERS;
+        GlobalDebugCounters {
+            bucket_array_creation_count: c.bucket_array_creation_count.load(),
+            bucket_array_allocation_bytes: c.bucket_array_allocation_bytes.load(),
+            bucket_array_drop_count: c.bucket_array_drop_count.load(),
+            bucket_array_release_bytes: c.bucket_array_release_bytes.load(),
+            bucket_creation_count: c.bucket_creation_count.load(),
+            bucket_drop_count: c.bucket_drop_count.load(),
+            value_entry_creation_count: c.value_entry_creation_count.load(),
+            value_entry_drop_count: c.value_entry_drop_count.load(),
+            entry_info_creation_count: c.entry_info_creation_count.load(),
+            entry_info_drop_count: c.entry_info_drop_count.load(),
+            deq_node_creation_count: c.deq_node_creation_count.load(),
+            deq_node_drop_count: c.deq_node_drop_count.load(),
+        }
+    }
+
+    pub(crate) fn bucket_array_created(byte_size: u64) {
+        COUNTERS.bucket_array_creation_count.fetch_add(1);
+        COUNTERS.bucket_array_allocation_bytes.fetch_add(byte_size);
+    }
+
+    pub(crate) fn bucket_array_dropped(byte_size: u64) {
+        COUNTERS.bucket_array_drop_count.fetch_add(1);
+        COUNTERS.bucket_array_release_bytes.fetch_add(byte_size);
+    }
+
+    pub(crate) fn bucket_created() {
+        COUNTERS.bucket_creation_count.fetch_add(1);
+    }
+
+    pub(crate) fn bucket_dropped() {
+        COUNTERS.bucket_drop_count.fetch_add(1);
+    }
+
+    pub(crate) fn value_entry_created() {
+        COUNTERS.value_entry_creation_count.fetch_add(1);
+    }
+
+    pub(crate) fn value_entry_dropped() {
+        COUNTERS.value_entry_drop_count.fetch_add(1);
+    }
+
+    pub(crate) fn entry_info_created() {
+        COUNTERS.entry_info_creation_count.fetch_add(1);
+    }
+
+    pub(crate) fn entry_info_dropped() {
+        COUNTERS.entry_info_drop_count.fetch_add(1);
+    }
+
+    pub(crate) fn deq_node_created() {
+        COUNTERS.deq_node_creation_count.fetch_add(1);
+    }
+
+    pub(crate) fn deq_node_dropped() {
+        COUNTERS.deq_node_drop_count.fetch_add(1);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CacheDebugStats {
+    pub estimated_entry_count: u64,
+    pub weighted_size: u64,
+    // bytes
+    pub freq_sketch_size: u64,
+    // max entries
+    pub hashmap_capacity: u64,
+}
+
+impl CacheDebugStats {
+    pub(crate) fn new(
+        estimated_entry_count: u64,
+        weighted_size: u64,
+        hashmap_capacity: u64,
+        freq_sketch_size: u64,
+    ) -> Self {
+        Self {
+            estimated_entry_count,
+            weighted_size,
+            freq_sketch_size,
+            hashmap_capacity,
+        }
+    }
+}

--- a/src/sync/entry_info.rs
+++ b/src/sync/entry_info.rs
@@ -13,6 +13,9 @@ pub(crate) struct EntryInfo {
 impl EntryInfo {
     #[inline]
     pub(crate) fn new(policy_weight: u32) -> Self {
+        #[cfg(feature = "unstable-debug-counters")]
+        super::debug_counters::InternalGlobalDebugCounters::entry_info_created();
+
         Self {
             is_admitted: Default::default(),
             last_accessed: Default::default(),
@@ -44,6 +47,13 @@ impl EntryInfo {
 
     pub(crate) fn set_policy_weight(&self, size: u32) {
         self.policy_weight.store(size, Ordering::Release);
+    }
+}
+
+#[cfg(feature = "unstable-debug-counters")]
+impl Drop for EntryInfo {
+    fn drop(&mut self) {
+        super::debug_counters::InternalGlobalDebugCounters::entry_info_dropped();
     }
 }
 


### PR DESCRIPTION
When this feature is enabled:
- `moka::GlobalDebugCounters::current` function is provided.
- `moka::future::Cache::debug_stats` method is provided.
- The eviction batch size is changed to 10,000.

* * *
Relates to #72.