### PR TITLE
Fix a wrong (oversized) initial capacity for the internal hash map

### DIFF
--- a/src/cht/segment/map.rs
+++ b/src/cht/segment/map.rs
@@ -159,7 +159,7 @@ impl<K, V, S> HashMap<K, V, S> {
                 segments.set_len(actual_num_segments);
             }
         } else {
-            let actual_capacity = (capacity * 2).next_power_of_two();
+            let actual_capacity = (capacity * 2 / actual_num_segments).next_power_of_two();
 
             for _ in 0..actual_num_segments {
                 segments.push(Segment {


### PR DESCRIPTION
I misunderstood what the initial capacity would do for `cht::SegmentedHashMap`.  I thought it was the initial capacity of the entire hash map, but the cht author meant it was the initial capacity of each segment in the hash map. Since Moka uses `SegmentedHashMap` with currently hard-coded number of segments `64`, setting the initial capacity using Moka's `CacheBuilder` results the hash map 64 times bigger than desired.

This PR changes the initial capacity of `moka::cht::SegmentedHashMap` to be the capacity of the entire hash map.