### PR TITLE
Embed CacheRegion value into a TagNonNull pointer 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,9 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          # - 1.46.0  # MSRV (future)
-          # - 1.45.2  # MSRV (no features)
-          - 1.49.0  # Temporary MSRV
+          - 1.51.0  # MSRV (for both no features and "future")
 
     steps:
       - name: Checkout Moka

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
         "semver",
         "smallvec",
         "structs",
+        "tagptr",
         "Tatsuya",
         "thiserror",
         "toolchain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ parking_lot = "0.12"
 quanta = "0.9.3"
 scheduled-thread-pool = "0.2"
 smallvec = "1.8"
+tagptr = "0.2"
 thiserror = "1.0"
 triomphe = "0.1"
 uuid = { version = "0.8", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "moka"
 version = "0.7.2"
 authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
+rust-version = "1.51"
 
 description = "A fast and concurrent cache library inspired by Caffeine (Java)"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -386,9 +386,9 @@ This crate's minimum supported Rust versions (MSRV) are the followings:
 
 | Feature    | Enabled by default? | MSRV        |
 |:-----------|:-------------------:|:-----------:|
-| no feature |                     | Rust 1.45.2 |
-| `atomic64` |       yes           | Rust 1.45.2 |
-| `future`   |                     | Rust 1.46.0 |
+| no feature |                     | Rust 1.51.0 |
+| `atomic64` |       yes           | Rust 1.51.0 |
+| `future`   |                     | Rust 1.51.0 |
 
 If only the default features are enabled, MSRV will be updated conservatively. When
 using other features, like `future`, MSRV might be updated more frequently, up to the
@@ -396,6 +396,7 @@ latest stable. In both cases, increasing MSRV is _not_ considered a semver-break
 change.
 
 <!--
+- tagptr 0.2.0 requires 1.51.
 - socket2 0.4.0 requires 1.46.
 - quanta requires 1.45.
 - moka-cht requires 1.41.

--- a/src/common.rs
+++ b/src/common.rs
@@ -17,6 +17,41 @@ pub(crate) mod atomic_time;
 
 pub(crate) mod time;
 
+// Note: `CacheRegion` cannot have more than four enum variants. This is because
+// `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`
+// pointer, where the 2-bit tag is `CacheRegion`.
+#[derive(Clone, Copy, Debug, Eq)]
+pub(crate) enum CacheRegion {
+    Window = 0,
+    MainProbation = 1,
+    MainProtected = 2,
+    Other = 3,
+}
+
+impl From<usize> for CacheRegion {
+    fn from(n: usize) -> Self {
+        match n {
+            0 => Self::Window,
+            1 => Self::MainProbation,
+            2 => Self::MainProtected,
+            3 => Self::Other,
+            _ => panic!("No such CacheRegion variant for {}", n),
+        }
+    }
+}
+
+impl PartialEq<Self> for CacheRegion {
+    fn eq(&self, other: &Self) -> bool {
+        core::mem::discriminant(self) == core::mem::discriminant(other)
+    }
+}
+
+impl PartialEq<usize> for CacheRegion {
+    fn eq(&self, other: &usize) -> bool {
+        *self as usize == *other
+    }
+}
+
 // Ensures the value fits in a range of `128u32..=u32::MAX`.
 pub(crate) fn sketch_capacity(max_capacity: u64) -> u32 {
     max_capacity.try_into().unwrap_or(u32::MAX).max(128)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,6 +4,7 @@ use crate::common::{deque::DeqNode, time::Instant};
 
 use parking_lot::Mutex;
 use std::{ptr::NonNull, sync::Arc};
+use tagptr::TagNonNull;
 use triomphe::Arc as TrioArc;
 
 pub(crate) mod base_cache;
@@ -172,7 +173,7 @@ impl<K> AccessTime for DeqNode<KeyHashDate<K>> {
 }
 
 // DeqNode for an access order queue.
-type KeyDeqNodeAo<K> = NonNull<DeqNode<KeyHashDate<K>>>;
+type KeyDeqNodeAo<K> = TagNonNull<DeqNode<KeyHashDate<K>>, 2>;
 
 // DeqNode for the write order queue.
 type KeyDeqNodeWo<K> = NonNull<DeqNode<KeyDate<K>>>;

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -5,6 +5,7 @@ mod cache;
 mod deques;
 
 use std::{ptr::NonNull, rc::Rc};
+use tagptr::TagNonNull;
 
 pub use builder::CacheBuilder;
 pub use cache::Cache;
@@ -48,7 +49,7 @@ impl<K> KeyHashDate<K> {
 }
 
 // DeqNode for an access order queue.
-type KeyDeqNodeAo<K> = NonNull<DeqNode<KeyHashDate<K>>>;
+type KeyDeqNodeAo<K> = TagNonNull<DeqNode<KeyHashDate<K>>, 2>;
 
 // DeqNode for the write order queue.
 type KeyDeqNodeWo<K> = NonNull<DeqNode<KeyDate<K>>>;

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1,9 +1,10 @@
 use super::{deques::Deques, AccessTime, CacheBuilder, KeyDate, KeyHashDate, ValueEntry, Weigher};
 use crate::common::{
     self,
-    deque::{CacheRegion, DeqNode, Deque},
+    deque::{DeqNode, Deque},
     frequency_sketch::FrequencySketch,
     time::{CheckedTimeOps, Clock, Instant},
+    CacheRegion,
 };
 
 use smallvec::SmallVec;


### PR DESCRIPTION
- Raise the minimum supported Rust version (MSRV) to 1.51.0.
- Add tagptr crate to the dependencies.
- Remove `region: CacheRegion` field from `DeqNode`.
- Change the pointer type used in `access_order_q_node` field of `DeqNodes` from `NonNull<DeqNode<T>>` to `TagNonNull<DeqNome<T>, 2>`, and embed `CacheRegion` value into the 2-bit tag space of the pointer.
- Update the methods in `Deques` to handle the `TagNonNull` pointers.

* * *
Relates to #72.