### PR TITLE
Prepare for v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 
 ### Fixed
 
-- Addressed a memory utilization issue that will get worse when keys have very
-  high cardinality ([#72][gh-issue-0072]):
+- Addressed a memory utilization issue that will get worse when keys have hight
+  cardinality ([#72][gh-issue-0072]):
     - Reduce memory overhead in the internal concurrent hash table (cht).
       ([#79][gh-pull-0079])
     - Fix a bug that can create oversized frequency sketch when weigher is set.
@@ -27,7 +27,8 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 
 ### Changed
 
-- Import (include) cht source files for better integration. ([#77][gh-pull-0077])
+- Import (include) cht source files for better integration. ([#77][gh-pull-0077],
+  [#86](gh-pull-0086))
 
 
 ## Version 0.7.1
@@ -235,6 +236,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0086]: https://github.com/moka-rs/moka/pull/86/
 [gh-pull-0084]: https://github.com/moka-rs/moka/pull/84/
 [gh-pull-0083]: https://github.com/moka-rs/moka/pull/83/
 [gh-pull-0082]: https://github.com/moka-rs/moka/pull/82/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,40 @@
 # Moka &mdash; Change Log
 
+## Version 0.7.2
+
+The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
+
+### Fixed
+
+- Addressed a memory utilization issue that will get worse when keys have very
+  high cardinality ([#72][gh-issue-0072]):
+    - Reduce memory overhead in the internal concurrent hash table (cht).
+      ([#79][gh-pull-0079])
+    - Fix a bug that can create oversized frequency sketch when weigher is set.
+      ([#75][gh-pull-0075])
+    - Change `EntryInfo` from `enum` to `struct` to reduce memory utilization.
+      ([#76][gh-pull-0076])
+    - Replace some `std::sync::Arc` usages with `triomphe::Arc` to reduce memory
+      utilization. ([#80][gh-pull-0080])
+    - Embed `CacheRegion` value into a 2-bit tag space of `TagNonNull` pointer.
+      ([#84][gh-pull-0084])
+- Fix a bug that will use wrong (oversized) initial capacity for the internal cht.
+  ([#83][gh-pull-0083])
+
+### Added
+
+- Add `unstable-debug-counters` feature for testing purpose. ([#82][gh-pull-0082])
+
+### Changed
+
+- Import (include) cht source files for better integration. ([#77][gh-pull-0077])
+
+
 ## Version 0.7.1
 
 - **Important Fix**: A memory leak issue (#65 below) was found in all previous
   versions (since v0.1.0) and fixed in this version. All users are encouraged to
-  upgrade to this version.
+  upgrade to this or newer version.
 
 ### Fixed
 
@@ -199,11 +229,20 @@
 
 [resolving-error-on-32bit]: https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 
+[gh-issue-0072]: https://github.com/moka-rs/moka/issues/72/
 [gh-issue-0059]: https://github.com/moka-rs/moka/issues/59/
 [gh-issue-0043]: https://github.com/moka-rs/moka/issues/43/
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0084]: https://github.com/moka-rs/moka/pull/84/
+[gh-pull-0083]: https://github.com/moka-rs/moka/pull/83/
+[gh-pull-0082]: https://github.com/moka-rs/moka/pull/82/
+[gh-pull-0080]: https://github.com/moka-rs/moka/pull/80/
+[gh-pull-0079]: https://github.com/moka-rs/moka/pull/79/
+[gh-pull-0077]: https://github.com/moka-rs/moka/pull/77/
+[gh-pull-0076]: https://github.com/moka-rs/moka/pull/76/
+[gh-pull-0075]: https://github.com/moka-rs/moka/pull/75/
 [gh-pull-0067]: https://github.com/moka-rs/moka/pull/67/
 [gh-pull-0065]: https://github.com/moka-rs/moka/pull/65/
 [gh-pull-0056]: https://github.com/moka-rs/moka/pull/56/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "moka"
 version = "0.7.2"
-authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 rust-version = "1.51"
 

--- a/README.md
+++ b/README.md
@@ -498,8 +498,8 @@ This name would imply the following facts and hopes:
 ### cht
 
 The source files of the concurrent hash table under `moka::cht` module were copied
-from the [cht v0.4.1][cht-v041] and modified by us. We did so for better integration
-between Moka and cht.
+from the [cht crate v0.4.1][cht-v041] and modified by us. We did so for better
+integration.
 
 The cht is authored by Gregory Meyer and its v0.4.1 and earlier versions are licensed
 under the MIT license.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ routers. Here are some highlights:
 [aliyundrive-webdav-git]: https://github.com/messense/aliyundrive-webdav
 
 
+## Change Log
+
+- [CHANGELOG.md](https://github.com/moka-rs/moka/blob/master/CHANGELOG.md)
+
 ## Usage
 
 Add this to your `Cargo.toml`:

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -30,14 +30,12 @@ use std::{
 /// `Cache` supports full concurrency of retrievals and a high expected concurrency
 /// for updates. It can be accessed inside and outside of asynchronous contexts.
 ///
-/// `Cache` utilizes a lock-free concurrent hash table `SegmentedHashMap` from the
-/// [moka-cht][moka-cht-crate] crate for the central key-value storage. `Cache`
-/// performs a best-effort bounding of the map using an entry replacement algorithm
-/// to determine which entries to evict when the capacity is exceeded.
+/// `Cache` utilizes a lock-free concurrent hash table as the central key-value
+/// storage. `Cache` performs a best-effort bounding of the map using an entry
+/// replacement algorithm to determine which entries to evict when the capacity is
+/// exceeded.
 ///
 /// To use this cache, enable a crate feature called "future".
-///
-/// [moka-cht-crate]: https://crates.io/crates/moka-cht
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! Moka provides in-memory concurrent cache implementations on top of hash maps.
 //! They support full concurrency of retrievals and a high expected concurrency for
-//! updates. They utilize a lock-free concurrent hash table `SegmentedHashMap` from
-//! the [moka-cht][moka-cht-crate] crate for the central key-value storage.
+//! updates. They utilize a lock-free concurrent hash table as the central key-value
+//! storage.
 //!
 //! Moka also provides an in-memory, non-thread-safe cache implementation for single
 //! thread applications.
@@ -17,7 +17,6 @@
 //! is exceeded.
 //!
 //! [caffeine-git]: https://github.com/ben-manes/caffeine
-//! [moka-cht-crate]: https://crates.io/crates/moka-cht
 //!
 //! # Features
 //!

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -264,7 +264,7 @@ where
         let mut op1 = None;
         let mut op2 = None;
 
-        // Since the cache (moka-cht::SegmentedHashMap) employs optimistic locking
+        // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation
         // conflicted with other concurrent hash table operations. In that case, it
         // has to retry the insertion or modification, so on_insert and/or on_modify

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -21,12 +21,10 @@ use std::{
 /// `Cache` supports full concurrency of retrievals and a high expected concurrency
 /// for updates.
 ///
-/// `Cache` utilizes a lock-free concurrent hash table `SegmentedHashMap` from the
-/// [moka-cht][moka-cht-crate] crate for the central key-value storage. `Cache`
-/// performs a best-effort bounding of the map using an entry replacement algorithm
-/// to determine which entries to evict when the capacity is exceeded.
-///
-/// [moka-cht-crate]: https://crates.io/crates/moka-cht
+/// `Cache` utilizes a lock-free concurrent hash table as the central key-value
+/// storage. `Cache` performs a best-effort bounding of the map using an entry
+/// replacement algorithm to determine which entries to evict when the capacity is
+/// exceeded.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
- Update the change log.
- Remove authors field from Cargo.toml:
    - https://rust-lang.github.io/rfcs/3052-optional-authors-field.html