### PR TITLE
Avoid to calculate the same hash twice in `get`, `insert`, `invalidate`, etc. methods

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -601,7 +601,8 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if let Some(kv) = self.base.remove_entry(key) {
+        let hash = self.base.hash(key);
+        if let Some(kv) = self.base.remove_entry(key, hash) {
             let op = WriteOp::Remove(kv);
             let hk = self.base.housekeeper.as_ref();
             Self::schedule_write_op(&self.base.write_op_ch, op, hk)
@@ -620,7 +621,8 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if let Some(kv) = self.base.remove_entry(key) {
+        let hash = self.base.hash(key);
+        if let Some(kv) = self.base.remove_entry(key, hash) {
             let op = WriteOp::Remove(kv);
             let hk = self.base.housekeeper.as_ref();
             Self::blocking_schedule_write_op(&self.base.write_op_ch, op, hk)

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -235,8 +235,8 @@ where
 
     #[inline]
     pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
-        let key = Arc::clone(key);
-        self.waiters.remove(&(key, type_id));
+        let (cht_key, hash) = self.cht_key_hash(key, type_id);
+        self.waiters.remove(&cht_key, hash);
     }
 
     #[inline]
@@ -246,9 +246,16 @@ where
         type_id: TypeId,
         waiter: &Waiter<V>,
     ) -> Option<Waiter<V>> {
-        let key = Arc::clone(key);
+        let (cht_key, hash) = self.cht_key_hash(key, type_id);
         let waiter = TrioArc::clone(waiter);
-        self.waiters.insert_if_not_present((key, type_id), waiter)
+        self.waiters.insert_if_not_present(cht_key, hash, waiter)
+    }
+
+    #[inline]
+    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
+        let cht_key = (Arc::clone(key), type_id);
+        let hash = self.waiters.hash(&cht_key);
+        (cht_key, hash)
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -112,6 +112,10 @@ impl<K> KeyHashDate<K> {
         &self.key
     }
 
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
     pub(crate) fn entry_info(&self) -> &EntryInfo {
         &self.entry_info
     }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -1034,11 +1034,11 @@ where
             }
             if let Some(victim) = next_victim.take() {
                 next_victim = victim.next_node();
-                let element = &victim.element;
+                let vic_elem = &victim.element;
 
-                if let Some(vic_entry) = cache.get(element.key(), element.hash()) {
+                if let Some(vic_entry) = cache.get(vic_elem.key(), vic_elem.hash()) {
                     victims.add_policy_weight(vic_entry.policy_weight());
-                    victims.add_frequency(freq, victim.element.hash());
+                    victims.add_frequency(freq, vic_elem.hash());
                     victim_nodes.push(NonNull::from(victim));
                     retries = 0;
                 } else {

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -584,7 +584,16 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if let Some(kv) = self.base.remove_entry(key) {
+        let hash = self.base.hash(key);
+        self.invalidate_with_hash(key, hash);
+    }
+
+    pub(crate) fn invalidate_with_hash<Q>(&self, key: &Q, hash: u64)
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        if let Some(kv) = self.base.remove_entry(key, hash) {
             let op = WriteOp::Remove(kv);
             let hk = self.base.housekeeper.as_ref();
             Self::schedule_write_op(&self.base.write_op_ch, op, hk).expect("Failed to remove");

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -200,7 +200,7 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.inner.hash(key);
-        self.inner.select(hash).invalidate(key);
+        self.inner.select(hash).invalidate_with_hash(key, hash);
     }
 
     /// Discards all cached values.

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -146,8 +146,8 @@ where
 
     #[inline]
     pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
-        let key = Arc::clone(key);
-        self.waiters.remove(&(key, type_id));
+        let (cht_key, hash) = self.cht_key_hash(key, type_id);
+        self.waiters.remove(&cht_key, hash);
     }
 
     #[inline]
@@ -157,8 +157,15 @@ where
         type_id: TypeId,
         waiter: &Waiter<V>,
     ) -> Option<Waiter<V>> {
-        let key = Arc::clone(key);
+        let (cht_key, hash) = self.cht_key_hash(key, type_id);
         let waiter = TrioArc::clone(waiter);
-        self.waiters.insert_if_not_present((key, type_id), waiter)
+        self.waiters.insert_if_not_present(cht_key, hash, waiter)
+    }
+
+    #[inline]
+    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
+        let cht_key = (Arc::clone(key), type_id);
+        let hash = self.waiters.hash(&cht_key);
+        (cht_key, hash)
     }
 }


### PR DESCRIPTION
Update crate-internal `cht` methods to take a hash value of the key so that they do not have to recalculate the hash from the key.