### PR TITLE
Add `moka::dash::Cache`, which uses `dash::DashMap` as the internal storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           command: |
             docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin \
               cargo tarpaulin -v \
-                --features future \
+                --features 'future, dash' \
                 --ciserver circle-ci \
                 --coveralls ${COVERALLS_TOKEN} \
                 --timeout 600 \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,15 +49,22 @@ jobs:
         with:
           command: build
 
-      - name: Run tests (future)
+      - name: Run tests (release, no features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
+
+      - name: Run tests (future feature)
         uses: actions-rs/cargo@v1
         if: ${{ matrix.rust != '1.45.2' }}
         with:
           command: test
           args: --features future
 
-      - name: Run tests (release, no features)
+      - name: Run tests (dash feature)
         uses: actions-rs/cargo@v1
+        if: ${{ matrix.rust != '1.45.2' }}
         with:
           command: test
-          args: --release
+          args: --features dash

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -72,3 +72,10 @@ jobs:
           use-cross: true
           command: test
           args: --release --features future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+
+      - name: Run tests (dash feature)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --release --features dash --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}

--- a/.github/workflows/Skeptic.yml
+++ b/.github/workflows/Skeptic.yml
@@ -46,27 +46,27 @@ jobs:
         env:
           RUSTFLAGS: '--cfg skeptic'
 
-      - name: Run tests (release, future)
+      - name: Run tests (release, future and dash)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --features future
+          args: --release --features 'future, dash'
         env:
           RUSTFLAGS: '--cfg skeptic'
 
-      - name: Run tests (future, without atomic64)
+      - name: Run tests (future and dash, without atomic64)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --no-default-features --features future
+          args: --release --no-default-features --features 'future, dash'
         env:
           RUSTFLAGS: '--cfg skeptic'
 
-      - name: Run UI tests (future, trybuild)
+      - name: Run UI tests (future and dash features, trybuild)
         uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'stable' }}
         with:
           command: test
-          args: ui_trybuild --release --features future
+          args: ui_trybuild --release --features 'future, dash'
         env:
           RUSTFLAGS: '--cfg trybuild'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "rust-analyzer.cargo.features": ["future", "unstable-debug-counters"],
+    "rust-analyzer.cargo.features": ["future", "dash", "unstable-debug-counters"],
     "rust-analyzer.server.extraEnv": {
         "CARGO_TARGET_DIR": "target/ra"
     },
@@ -13,6 +13,7 @@
         "clippy",
         "compat",
         "cpus",
+        "dashmap",
         "deqs",
         "Deque",
         "Deques",
@@ -22,6 +23,7 @@
         "getrandom",
         "Hasher",
         "Kawano",
+        "mapref",
         "Moka",
         "mpsc",
         "MSRV",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 0.8.0
 
+### Added
+
+- Add a synchronous cache `moka::dash::Cache`, which uses `dash::DashMap` as
+  the internal storage. ([#99][gh-pull-0099])
+
 ### Changed
 
 - Update the minimum depending version of crossbeam-channel from v0.5.2 to v0.5.4.
@@ -245,6 +250,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
 [gh-pull-0100]: https://github.com/moka-rs/moka/pull/100/
+[gh-pull-0099]: https://github.com/moka-rs/moka/pull/99/
 [gh-pull-0086]: https://github.com/moka-rs/moka/pull/86/
 [gh-pull-0084]: https://github.com/moka-rs/moka/pull/84/
 [gh-pull-0083]: https://github.com/moka-rs/moka/pull/83/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ default = ["atomic64"]
 # Enable this feature to use `moka::future::Cache`.
 future = ["async-io", "async-lock", "futures-util"]
 
+# Enable this feature to use `moka::dash::Cache`.
+dash = ["dashmap"]
+
 # This feature is enabled by default. Disable it when the target platform does not
 # support `std::sync::atomic::AtomicU64`. (e.g. `armv5te-unknown-linux-musleabi`
 # or `mips-unknown-linux-musl`)
@@ -47,7 +50,10 @@ thiserror = "1.0"
 triomphe = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 
-# Optional dependencies
+# Optional dependencies (dashmap)
+dashmap = { version = "5.2", optional = true }
+
+# Optional dependencies (future)
 async-io = { version = "1.4", optional = true }
 async-lock = { version = "2.4", optional = true }
 futures-util = { version = "0.3", optional = true }
@@ -68,8 +74,8 @@ skeptic = "0.13"
 
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]
-# Build the doc with "future" feature enabled.
-features = ["future"]
+# Build the doc with some features enabled.
+features = ["future", "dash"]
 
 # ----------------------------------
 # RUSTSEC, etc.

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ This crate's minimum supported Rust versions (MSRV) are the followings:
 | no feature |                     | Rust 1.51.0 |
 | `atomic64` |       yes           | Rust 1.51.0 |
 | `future`   |                     | Rust 1.51.0 |
+| `dash`     |                     | Rust 1.51.0 |
 
 If only the default features are enabled, MSRV will be updated conservatively. When
 using other features, like `future`, MSRV might be updated more frequently, up to the
@@ -470,8 +471,8 @@ $ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test \
 - [ ] API stabilization. (Smaller core cache API, shorter names for frequently
       used methods)
     - e.g.
-    - `get_or_insert_with(K, F)` → `get(K, F)`
-    - `get_or_try_insert_with(K, F)` → `try_get(K, F)`
+    - `get_or_insert_with(K, F)` → `get_with(K, F)`
+    - `get_or_try_insert_with(K, F)` → `try_get_with(K, F)`
     - `get(&Q)` → `get_if_present(&Q)`
     - `blocking_insert(K, V)` → `blocking().insert(K, V)`
     - `time_to_live()` → `config().time_to_live()`

--- a/src/dash.rs
+++ b/src/dash.rs
@@ -1,0 +1,20 @@
+//! Provides a thread-safe, concurrent cache implementation built upon
+//! [`dashmap::DashMap`][dashmap].
+//!
+//! To use this module, enable a crate feature called "dash".
+//!
+//! [dashmap]: https://docs.rs/dashmap/*/dashmap/struct.DashMap.html
+
+mod base_cache;
+mod builder;
+mod cache;
+// mod value_initializer;
+
+pub use builder::CacheBuilder;
+pub use cache::Cache;
+
+/// Provides extra methods that will be useful for testing.
+pub trait ConcurrentCacheExt<K, V> {
+    /// Performs any pending maintenance operations needed by the cache.
+    fn sync(&self);
+}

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -1,0 +1,1309 @@
+use crate::{
+    common::{
+        self,
+        atomic_time::AtomicInstant,
+        deque::{DeqNode, Deque},
+        frequency_sketch::FrequencySketch,
+        time::{CheckedTimeOps, Clock, Instant},
+        CacheRegion,
+    },
+    sync::{
+        deques::Deques,
+        entry_info::EntryInfo,
+        housekeeper::{Housekeeper, InnerSync, SyncPace},
+        AccessTime, KeyDate, KeyHash, KeyHashDate, KvEntry, ReadOp, ValueEntry, Weigher, WriteOp,
+    },
+};
+use crossbeam_channel::{Receiver, Sender, TrySendError};
+use crossbeam_utils::atomic::AtomicCell;
+use dashmap::mapref::one::Ref as DashMapRef;
+use parking_lot::{Mutex, RwLock};
+use smallvec::SmallVec;
+use std::{
+    borrow::Borrow,
+    collections::hash_map::RandomState,
+    hash::{BuildHasher, Hash, Hasher},
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use triomphe::Arc as TrioArc;
+
+pub(crate) const MAX_SYNC_REPEATS: usize = 4;
+
+const READ_LOG_FLUSH_POINT: usize = 512;
+const READ_LOG_SIZE: usize = READ_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2);
+
+const WRITE_LOG_FLUSH_POINT: usize = 512;
+const WRITE_LOG_LOW_WATER_MARK: usize = WRITE_LOG_FLUSH_POINT / 2;
+const WRITE_LOG_SIZE: usize = WRITE_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2);
+
+pub(crate) const WRITE_RETRY_INTERVAL_MICROS: u64 = 50;
+
+pub(crate) type HouseKeeperArc<K, V, S> = Arc<Housekeeper<Inner<K, V, S>>>;
+
+pub(crate) struct BaseCache<K, V, S = RandomState> {
+    pub(crate) inner: Arc<Inner<K, V, S>>,
+    read_op_ch: Sender<ReadOp<K, V>>,
+    pub(crate) write_op_ch: Sender<WriteOp<K, V>>,
+    pub(crate) housekeeper: Option<HouseKeeperArc<K, V, S>>,
+}
+
+impl<K, V, S> Clone for BaseCache<K, V, S> {
+    /// Makes a clone of this shared cache.
+    ///
+    /// This operation is cheap as it only creates thread-safe reference counted
+    /// pointers to the shared internal data structures.
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            read_op_ch: self.read_op_ch.clone(),
+            write_op_ch: self.write_op_ch.clone(),
+            housekeeper: self.housekeeper.as_ref().map(Arc::clone),
+        }
+    }
+}
+
+impl<K, V, S> Drop for BaseCache<K, V, S> {
+    fn drop(&mut self) {
+        // The housekeeper needs to be dropped before the inner is dropped.
+        std::mem::drop(self.housekeeper.take());
+    }
+}
+
+impl<K, V, S> BaseCache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn new(
+        max_capacity: Option<u64>,
+        initial_capacity: Option<usize>,
+        build_hasher: S,
+        weigher: Option<Weigher<K, V>>,
+        time_to_live: Option<Duration>,
+        time_to_idle: Option<Duration>,
+    ) -> Self {
+        let (r_snd, r_rcv) = crossbeam_channel::bounded(READ_LOG_SIZE);
+        let (w_snd, w_rcv) = crossbeam_channel::bounded(WRITE_LOG_SIZE);
+        let inner = Arc::new(Inner::new(
+            max_capacity,
+            initial_capacity,
+            build_hasher,
+            weigher,
+            r_rcv,
+            w_rcv,
+            time_to_live,
+            time_to_idle,
+        ));
+        let housekeeper = Housekeeper::new(Arc::downgrade(&inner));
+        Self {
+            inner,
+            read_op_ch: r_snd,
+            write_op_ch: w_snd,
+            housekeeper: Some(Arc::new(housekeeper)),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn hash<Q>(&self, key: &Q) -> u64
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.hash(key)
+    }
+
+    pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<V>
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let record = |op| {
+            self.record_read_op(op).expect("Failed to record a get op");
+        };
+
+        match self.inner.get(key) {
+            None => {
+                record(ReadOp::Miss(hash));
+                None
+            }
+            Some(entry) => {
+                let i = &self.inner;
+                let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
+                let now = i.current_time_from_expiration_clock();
+                let entry = &*entry;
+
+                if is_expired_entry_wo(ttl, va, entry, now)
+                    || is_expired_entry_ao(tti, va, entry, now)
+                {
+                    // Expired or invalidated entry. Record this access as a cache miss
+                    // rather than a hit.
+                    record(ReadOp::Miss(hash));
+                    None
+                } else {
+                    // Valid entry.
+                    let v = entry.value.clone();
+                    record(ReadOp::Hit(hash, TrioArc::clone(entry), now));
+                    Some(v)
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn remove_entry<Q>(&self, key: &Q) -> Option<KvEntry<K, V>>
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.remove_entry(key)
+    }
+
+    #[inline]
+    pub(crate) fn apply_reads_writes_if_needed(
+        ch: &Sender<WriteOp<K, V>>,
+        housekeeper: Option<&HouseKeeperArc<K, V, S>>,
+    ) {
+        let w_len = ch.len();
+
+        if Self::should_apply_writes(w_len) {
+            if let Some(h) = housekeeper {
+                h.try_schedule_sync();
+            }
+        }
+    }
+
+    pub(crate) fn invalidate_all(&self) {
+        let now = self.inner.current_time_from_expiration_clock();
+        self.inner.set_valid_after(now);
+    }
+
+    pub(crate) fn max_capacity(&self) -> Option<usize> {
+        self.inner.max_capacity()
+    }
+
+    pub(crate) fn time_to_live(&self) -> Option<Duration> {
+        self.inner.time_to_live()
+    }
+
+    pub(crate) fn time_to_idle(&self) -> Option<Duration> {
+        self.inner.time_to_idle()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn estimated_entry_count(&self) -> u64 {
+        self.inner.estimated_entry_count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.inner.weighted_size()
+    }
+}
+
+//
+// private methods
+//
+impl<K, V, S> BaseCache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    #[inline]
+    fn record_read_op(&self, op: ReadOp<K, V>) -> Result<(), TrySendError<ReadOp<K, V>>> {
+        self.apply_reads_if_needed();
+        let ch = &self.read_op_ch;
+        match ch.try_send(op) {
+            // Discard the ReadOp when the channel is full.
+            Ok(()) | Err(TrySendError::Full(_)) => Ok(()),
+            Err(e @ TrySendError::Disconnected(_)) => Err(e),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn do_insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) -> WriteOp<K, V> {
+        let weight = self.inner.weigh(&key, &value);
+        let mut insert_op = None;
+        let mut update_op = None;
+
+        self.inner
+            .cache
+            .entry(Arc::clone(&key))
+            // Update
+            .and_modify(|entry| {
+                // NOTES on `new_value_entry_from` method:
+                // 1. The internal EntryInfo will be shared between the old and new ValueEntries.
+                // 2. This method will set the last_accessed and last_modified to the max value to
+                //    prevent this new ValueEntry from being evicted by an expiration policy.
+                // 3. This method will update the policy_weight with the new weight.
+                let old_weight = entry.policy_weight();
+                *entry = self.new_value_entry_from(value.clone(), weight, entry);
+                update_op = Some(WriteOp::Upsert {
+                    key_hash: KeyHash::new(Arc::clone(&key), hash),
+                    value_entry: TrioArc::clone(entry),
+                    old_weight,
+                    new_weight: weight,
+                });
+            })
+            // Insert
+            .or_insert_with(|| {
+                let entry = self.new_value_entry(value.clone(), weight);
+                insert_op = Some(WriteOp::Upsert {
+                    key_hash: KeyHash::new(Arc::clone(&key), hash),
+                    value_entry: TrioArc::clone(&entry),
+                    old_weight: 0,
+                    new_weight: weight,
+                });
+                entry
+            });
+
+        match (insert_op, update_op) {
+            (Some(ins_op), None) => ins_op,
+            (None, Some(upd_op)) => upd_op,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn new_value_entry(&self, value: V, policy_weight: u32) -> TrioArc<ValueEntry<K, V>> {
+        let info = TrioArc::new(EntryInfo::new(policy_weight));
+        TrioArc::new(ValueEntry::new(value, info))
+    }
+
+    #[inline]
+    fn new_value_entry_from(
+        &self,
+        value: V,
+        policy_weight: u32,
+        other: &ValueEntry<K, V>,
+    ) -> TrioArc<ValueEntry<K, V>> {
+        let info = TrioArc::clone(other.entry_info());
+        info.set_policy_weight(policy_weight);
+        TrioArc::new(ValueEntry::new_from(value, info, other))
+    }
+
+    #[inline]
+    fn apply_reads_if_needed(&self) {
+        let len = self.read_op_ch.len();
+
+        if Self::should_apply_reads(len) {
+            if let Some(h) = &self.housekeeper {
+                h.try_schedule_sync();
+            }
+        }
+    }
+
+    #[inline]
+    fn should_apply_reads(ch_len: usize) -> bool {
+        ch_len >= READ_LOG_FLUSH_POINT
+    }
+
+    #[inline]
+    fn should_apply_writes(ch_len: usize) -> bool {
+        ch_len >= WRITE_LOG_FLUSH_POINT
+    }
+}
+
+//
+// for testing
+//
+#[cfg(test)]
+impl<K, V, S> BaseCache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn reconfigure_for_testing(&mut self) {
+        // Stop the housekeeping job that may cause sync() method to return earlier.
+        if let Some(housekeeper) = &self.housekeeper {
+            // TODO: Extract this into a housekeeper method.
+            let mut job = housekeeper.periodical_sync_job().lock();
+            if let Some(job) = job.take() {
+                job.cancel();
+            }
+        }
+        // Enable the frequency sketch.
+        self.inner.enable_frequency_sketch_for_testing();
+    }
+
+    pub(crate) fn set_expiration_clock(&self, clock: Option<Clock>) {
+        self.inner.set_expiration_clock(clock);
+    }
+}
+
+struct EvictionCounters {
+    entry_count: u64,
+    weighted_size: u64,
+}
+
+impl EvictionCounters {
+    #[inline]
+    fn new(entry_count: u64, weighted_size: u64) -> Self {
+        Self {
+            entry_count,
+            weighted_size,
+        }
+    }
+
+    #[inline]
+    fn saturating_add(&mut self, entry_count: u64, weight: u32) {
+        self.entry_count += entry_count;
+        let total = &mut self.weighted_size;
+        *total = total.saturating_add(weight as u64);
+    }
+
+    #[inline]
+    fn saturating_sub(&mut self, entry_count: u64, weight: u32) {
+        self.entry_count -= entry_count;
+        let total = &mut self.weighted_size;
+        *total = total.saturating_sub(weight as u64);
+    }
+}
+
+#[derive(Default)]
+struct EntrySizeAndFrequency {
+    policy_weight: u64,
+    freq: u32,
+}
+
+impl EntrySizeAndFrequency {
+    fn new(policy_weight: u32) -> Self {
+        Self {
+            policy_weight: policy_weight as u64,
+            ..Default::default()
+        }
+    }
+
+    fn add_policy_weight(&mut self, weight: u32) {
+        self.policy_weight += weight as u64;
+    }
+
+    fn add_frequency(&mut self, freq: &FrequencySketch, hash: u64) {
+        self.freq += freq.frequency(hash) as u32;
+    }
+}
+
+// Access-Order Queue Node
+type AoqNode<K> = NonNull<DeqNode<KeyHashDate<K>>>;
+
+enum AdmissionResult<K> {
+    Admitted {
+        victim_nodes: SmallVec<[AoqNode<K>; 8]>,
+        skipped_nodes: SmallVec<[AoqNode<K>; 4]>,
+    },
+    Rejected {
+        skipped_nodes: SmallVec<[AoqNode<K>; 4]>,
+    },
+}
+
+type CacheStore<K, V, S> = dashmap::DashMap<Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+
+type CacheEntryRef<'a, K, V, S> = DashMapRef<'a, Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+
+pub(crate) struct Inner<K, V, S> {
+    max_capacity: Option<u64>,
+    entry_count: AtomicCell<u64>,
+    weighted_size: AtomicCell<u64>,
+    cache: CacheStore<K, V, S>,
+    build_hasher: S,
+    deques: Mutex<Deques<K>>,
+    frequency_sketch: RwLock<FrequencySketch>,
+    frequency_sketch_enabled: AtomicBool,
+    read_op_ch: Receiver<ReadOp<K, V>>,
+    write_op_ch: Receiver<WriteOp<K, V>>,
+    time_to_live: Option<Duration>,
+    time_to_idle: Option<Duration>,
+    valid_after: AtomicInstant,
+    weigher: Option<Weigher<K, V>>,
+    has_expiration_clock: AtomicBool,
+    expiration_clock: RwLock<Option<Clock>>,
+}
+
+// functions/methods used by BaseCache
+impl<K, V, S> Inner<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone,
+{
+    // Disable a Clippy warning for having more than seven arguments.
+    // https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        max_capacity: Option<u64>,
+        initial_capacity: Option<usize>,
+        build_hasher: S,
+        weigher: Option<Weigher<K, V>>,
+        read_op_ch: Receiver<ReadOp<K, V>>,
+        write_op_ch: Receiver<WriteOp<K, V>>,
+        time_to_live: Option<Duration>,
+        time_to_idle: Option<Duration>,
+    ) -> Self {
+        let initial_capacity = initial_capacity
+            .map(|cap| cap + WRITE_LOG_SIZE * 4)
+            .unwrap_or_default();
+        let cache =
+            dashmap::DashMap::with_capacity_and_hasher(initial_capacity, build_hasher.clone());
+
+        Self {
+            max_capacity: max_capacity.map(|n| n as u64),
+            entry_count: Default::default(),
+            weighted_size: Default::default(),
+            cache,
+            build_hasher,
+            deques: Mutex::new(Default::default()),
+            frequency_sketch: RwLock::new(Default::default()),
+            frequency_sketch_enabled: Default::default(),
+            read_op_ch,
+            write_op_ch,
+            time_to_live,
+            time_to_idle,
+            valid_after: Default::default(),
+            weigher,
+            has_expiration_clock: AtomicBool::new(false),
+            expiration_clock: RwLock::new(None),
+        }
+    }
+
+    #[inline]
+    fn hash<Q>(&self, key: &Q) -> u64
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let mut hasher = self.build_hasher.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[inline]
+    fn get<Q>(&self, key: &Q) -> Option<CacheEntryRef<'_, K, V, S>>
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.cache.get(key)
+    }
+
+    #[inline]
+    fn remove_entry<Q>(&self, key: &Q) -> Option<KvEntry<K, V>>
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.cache
+            .remove(key)
+            .map(|(key, entry)| KvEntry::new(key, entry))
+    }
+
+    fn max_capacity(&self) -> Option<usize> {
+        self.max_capacity.map(|n| n as usize)
+    }
+
+    #[inline]
+    fn time_to_live(&self) -> Option<Duration> {
+        self.time_to_live
+    }
+
+    #[inline]
+    fn time_to_idle(&self) -> Option<Duration> {
+        self.time_to_idle
+    }
+
+    #[cfg(test)]
+    #[inline]
+    fn estimated_entry_count(&self) -> u64 {
+        self.entry_count.load()
+    }
+
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.weighted_size.load()
+    }
+
+    #[inline]
+    fn has_expiry(&self) -> bool {
+        self.time_to_live.is_some() || self.time_to_idle.is_some()
+    }
+
+    #[inline]
+    fn is_write_order_queue_enabled(&self) -> bool {
+        self.time_to_live.is_some()
+    }
+
+    #[inline]
+    fn valid_after(&self) -> Option<Instant> {
+        self.valid_after.instant()
+    }
+
+    #[inline]
+    fn set_valid_after(&self, timestamp: Instant) {
+        self.valid_after.set_instant(timestamp);
+    }
+
+    #[inline]
+    fn has_valid_after(&self) -> bool {
+        self.valid_after.is_set()
+    }
+
+    #[inline]
+    fn weigh(&self, key: &K, value: &V) -> u32 {
+        self.weigher.as_ref().map(|w| w(key, value)).unwrap_or(1)
+    }
+
+    #[inline]
+    fn current_time_from_expiration_clock(&self) -> Instant {
+        if self.has_expiration_clock.load(Ordering::Relaxed) {
+            Instant::new(
+                self.expiration_clock
+                    .read()
+                    .as_ref()
+                    .expect("Cannot get the expiration clock")
+                    .now(),
+            )
+        } else {
+            Instant::now()
+        }
+    }
+}
+
+mod batch_size {
+    pub(crate) const EVICTION_BATCH_SIZE: usize = 500;
+}
+
+// TODO: Divide this method into smaller methods so that unit tests can do more
+// precise testing.
+// - sync_reads
+// - sync_writes
+// - evict
+// - invalidate_entries
+impl<K, V, S> InnerSync for Inner<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    fn sync(&self, max_repeats: usize) -> Option<SyncPace> {
+        let mut deqs = self.deques.lock();
+        let mut calls = 0;
+        let mut should_sync = true;
+
+        let current_ec = self.entry_count.load();
+        let current_ws = self.weighted_size.load();
+        let mut counters = EvictionCounters::new(current_ec, current_ws);
+
+        while should_sync && calls <= max_repeats {
+            let r_len = self.read_op_ch.len();
+            if r_len > 0 {
+                self.apply_reads(&mut deqs, r_len);
+            }
+
+            let w_len = self.write_op_ch.len();
+            if w_len > 0 {
+                self.apply_writes(&mut deqs, w_len, &mut counters);
+            }
+
+            if self.should_enable_frequency_sketch(&counters) {
+                self.enable_frequency_sketch(&counters);
+            }
+
+            calls += 1;
+            should_sync = self.read_op_ch.len() >= READ_LOG_FLUSH_POINT
+                || self.write_op_ch.len() >= WRITE_LOG_FLUSH_POINT;
+        }
+
+        if self.has_expiry() || self.has_valid_after() {
+            self.evict_expired(&mut deqs, batch_size::EVICTION_BATCH_SIZE, &mut counters);
+        }
+
+        // Evict if this cache has more entries than its capacity.
+        let weights_to_evict = self.weights_to_evict(&counters);
+        if weights_to_evict > 0 {
+            self.evict_lru_entries(
+                &mut deqs,
+                batch_size::EVICTION_BATCH_SIZE,
+                weights_to_evict,
+                &mut counters,
+            );
+        }
+
+        debug_assert_eq!(self.entry_count.load(), current_ec);
+        debug_assert_eq!(self.weighted_size.load(), current_ws);
+        self.entry_count.store(counters.entry_count);
+        self.weighted_size.store(counters.weighted_size);
+
+        if should_sync {
+            Some(SyncPace::Fast)
+        } else if self.write_op_ch.len() <= WRITE_LOG_LOW_WATER_MARK {
+            Some(SyncPace::Normal)
+        } else {
+            // Keep the current pace.
+            None
+        }
+    }
+}
+
+//
+// private methods
+//
+impl<K, V, S> Inner<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    fn has_enough_capacity(&self, candidate_weight: u32, counters: &EvictionCounters) -> bool {
+        self.max_capacity
+            .map(|limit| counters.weighted_size + candidate_weight as u64 <= limit)
+            .unwrap_or(true)
+    }
+
+    fn weights_to_evict(&self, counters: &EvictionCounters) -> u64 {
+        self.max_capacity
+            .map(|limit| counters.weighted_size.saturating_sub(limit))
+            .unwrap_or_default()
+    }
+
+    #[inline]
+    fn should_enable_frequency_sketch(&self, counters: &EvictionCounters) -> bool {
+        if self.frequency_sketch_enabled.load(Ordering::Acquire) {
+            false
+        } else if let Some(max_cap) = self.max_capacity {
+            counters.weighted_size >= max_cap / 2
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn enable_frequency_sketch(&self, counters: &EvictionCounters) {
+        if let Some(max_cap) = self.max_capacity {
+            let c = counters;
+            let cap = if self.weigher.is_none() {
+                max_cap
+            } else {
+                (c.entry_count as f64 * (c.weighted_size as f64 / max_cap as f64)) as u64
+            };
+            self.do_enable_frequency_sketch(cap);
+        }
+    }
+
+    #[cfg(test)]
+    fn enable_frequency_sketch_for_testing(&self) {
+        if let Some(max_cap) = self.max_capacity {
+            self.do_enable_frequency_sketch(max_cap);
+        }
+    }
+
+    #[inline]
+    fn do_enable_frequency_sketch(&self, cache_capacity: u64) {
+        let skt_capacity = common::sketch_capacity(cache_capacity);
+        self.frequency_sketch.write().ensure_capacity(skt_capacity);
+        self.frequency_sketch_enabled.store(true, Ordering::Release);
+    }
+
+    fn apply_reads(&self, deqs: &mut Deques<K>, count: usize) {
+        use ReadOp::*;
+        let mut freq = self.frequency_sketch.write();
+        let ch = &self.read_op_ch;
+        for _ in 0..count {
+            match ch.try_recv() {
+                Ok(Hit(hash, entry, timestamp)) => {
+                    freq.increment(hash);
+                    entry.set_last_accessed(timestamp);
+                    deqs.move_to_back_ao(&entry)
+                }
+                Ok(Miss(hash)) => freq.increment(hash),
+                Err(_) => break,
+            }
+        }
+    }
+
+    fn apply_writes(&self, deqs: &mut Deques<K>, count: usize, counters: &mut EvictionCounters) {
+        use WriteOp::*;
+        let freq = self.frequency_sketch.read();
+        let ch = &self.write_op_ch;
+        let ts = self.current_time_from_expiration_clock();
+
+        for _ in 0..count {
+            match ch.try_recv() {
+                Ok(Upsert {
+                    key_hash: kh,
+                    value_entry: entry,
+                    old_weight,
+                    new_weight,
+                }) => {
+                    self.handle_upsert(kh, entry, old_weight, new_weight, ts, deqs, &freq, counters)
+                }
+                Ok(Remove(KvEntry { key: _key, entry })) => {
+                    Self::handle_remove(deqs, entry, counters)
+                }
+                Err(_) => break,
+            };
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn handle_upsert(
+        &self,
+        kh: KeyHash<K>,
+        entry: TrioArc<ValueEntry<K, V>>,
+        old_weight: u32,
+        new_weight: u32,
+        timestamp: Instant,
+        deqs: &mut Deques<K>,
+        freq: &FrequencySketch,
+        counters: &mut EvictionCounters,
+    ) {
+        entry.set_last_accessed(timestamp);
+        entry.set_last_modified(timestamp);
+
+        if entry.is_admitted() {
+            // The entry has been already admitted, so treat this as an update.
+            counters.saturating_sub(0, old_weight);
+            counters.saturating_add(0, new_weight);
+            deqs.move_to_back_ao(&entry);
+            deqs.move_to_back_wo(&entry);
+            return;
+        }
+
+        if self.has_enough_capacity(new_weight, counters) {
+            // There are enough room in the cache (or the cache is unbounded).
+            // Add the candidate to the deques.
+            self.handle_admit(kh, &entry, new_weight, deqs, counters);
+            return;
+        }
+
+        if let Some(max) = self.max_capacity {
+            if new_weight as u64 > max {
+                // The candidate is too big to fit in the cache. Reject it.
+                self.cache.remove(&Arc::clone(&kh.key));
+                return;
+            }
+        }
+
+        let skipped_nodes;
+        let mut candidate = EntrySizeAndFrequency::new(new_weight);
+        candidate.add_frequency(freq, kh.hash);
+
+        // Try to admit the candidate.
+        match Self::admit(&candidate, &self.cache, deqs, freq) {
+            AdmissionResult::Admitted {
+                victim_nodes,
+                skipped_nodes: mut skipped,
+            } => {
+                // Try to remove the victims from the cache (hash map).
+                for victim in victim_nodes {
+                    if let Some((_vic_key, vic_entry)) =
+                        self.cache.remove(unsafe { victim.as_ref().element.key() })
+                    {
+                        // And then remove the victim from the deques.
+                        Self::handle_remove(deqs, vic_entry, counters);
+                    } else {
+                        // Could not remove the victim from the cache. Skip this
+                        // victim node as its ValueEntry might have been
+                        // invalidated. Add it to the skipped nodes.
+                        skipped.push(victim);
+                    }
+                }
+                skipped_nodes = skipped;
+
+                // Add the candidate to the deques.
+                self.handle_admit(kh, &entry, new_weight, deqs, counters);
+            }
+            AdmissionResult::Rejected { skipped_nodes: s } => {
+                skipped_nodes = s;
+                // Remove the candidate from the cache (hash map).
+                self.cache.remove(&Arc::clone(&kh.key));
+            }
+        };
+
+        // Move the skipped nodes to the back of the deque. We do not unlink (drop)
+        // them because ValueEntries in the write op queue should be pointing them.
+        for node in skipped_nodes {
+            unsafe { deqs.probation.move_to_back(node) };
+        }
+    }
+
+    /// Performs size-aware admission explained in the paper:
+    /// [Lightweight Robust Size Aware Cache Management][size-aware-cache-paper]
+    /// by Gil Einziger, Ohad Eytan, Roy Friedman, Ben Manes.
+    ///
+    /// [size-aware-cache-paper]: https://arxiv.org/abs/2105.08770
+    ///
+    /// There are some modifications in this implementation:
+    /// - To admit to the main space, candidate's frequency must be higher than
+    ///   the aggregated frequencies of the potential victims. (In the paper,
+    ///   `>=` operator is used rather than `>`)  The `>` operator will do a better
+    ///   job to prevent the main space from polluting.
+    /// - When a candidate is rejected, the potential victims will stay at the LRU
+    ///   position of the probation access-order queue. (In the paper, they will be
+    ///   promoted (to the MRU position?) to force the eviction policy to select a
+    ///   different set of victims for the next candidate). We may implement the
+    ///   paper's behavior later?
+    ///
+    #[inline]
+    fn admit(
+        candidate: &EntrySizeAndFrequency,
+        cache: &CacheStore<K, V, S>,
+        deqs: &Deques<K>,
+        freq: &FrequencySketch,
+    ) -> AdmissionResult<K> {
+        const MAX_CONSECUTIVE_RETRIES: usize = 5;
+        let mut retries = 0;
+
+        let mut victims = EntrySizeAndFrequency::default();
+        let mut victim_nodes = SmallVec::default();
+        let mut skipped_nodes = SmallVec::default();
+
+        // Get first potential victim at the LRU position.
+        let mut next_victim = deqs.probation.peek_front();
+
+        // Aggregate potential victims.
+        while victims.policy_weight < candidate.policy_weight {
+            if candidate.freq < victims.freq {
+                break;
+            }
+            if let Some(victim) = next_victim.take() {
+                next_victim = victim.next_node();
+
+                if let Some(vic_entry) = cache.get(victim.element.key()) {
+                    victims.add_policy_weight(vic_entry.policy_weight());
+                    victims.add_frequency(freq, victim.element.hash());
+                    victim_nodes.push(NonNull::from(victim));
+                    retries = 0;
+                } else {
+                    // Could not get the victim from the cache (hash map). Skip this node
+                    // as its ValueEntry might have been invalidated.
+                    skipped_nodes.push(NonNull::from(victim));
+
+                    retries += 1;
+                    if retries > MAX_CONSECUTIVE_RETRIES {
+                        break;
+                    }
+                }
+            } else {
+                // No more potential victims.
+                break;
+            }
+        }
+
+        // Admit or reject the candidate.
+
+        // TODO: Implement some randomness to mitigate hash DoS attack.
+        // See Caffeine's implementation.
+
+        if victims.policy_weight >= candidate.policy_weight && candidate.freq > victims.freq {
+            AdmissionResult::Admitted {
+                victim_nodes,
+                skipped_nodes,
+            }
+        } else {
+            AdmissionResult::Rejected { skipped_nodes }
+        }
+    }
+
+    fn handle_admit(
+        &self,
+        kh: KeyHash<K>,
+        entry: &TrioArc<ValueEntry<K, V>>,
+        policy_weight: u32,
+        deqs: &mut Deques<K>,
+        counters: &mut EvictionCounters,
+    ) {
+        let key = Arc::clone(&kh.key);
+        counters.saturating_add(1, policy_weight);
+        deqs.push_back_ao(
+            CacheRegion::MainProbation,
+            KeyHashDate::new(kh, entry.entry_info()),
+            entry,
+        );
+        if self.is_write_order_queue_enabled() {
+            deqs.push_back_wo(KeyDate::new(key, entry.entry_info()), entry);
+        }
+        entry.set_is_admitted(true);
+    }
+
+    fn handle_remove(
+        deqs: &mut Deques<K>,
+        entry: TrioArc<ValueEntry<K, V>>,
+        counters: &mut EvictionCounters,
+    ) {
+        if entry.is_admitted() {
+            entry.set_is_admitted(false);
+            counters.saturating_sub(1, entry.policy_weight());
+            // The following two unlink_* functions will unset the deq nodes.
+            deqs.unlink_ao(&entry);
+            Deques::unlink_wo(&mut deqs.write_order, &entry);
+        } else {
+            entry.unset_q_nodes();
+        }
+    }
+
+    fn handle_remove_with_deques(
+        ao_deq_name: &str,
+        ao_deq: &mut Deque<KeyHashDate<K>>,
+        wo_deq: &mut Deque<KeyDate<K>>,
+        entry: TrioArc<ValueEntry<K, V>>,
+        counters: &mut EvictionCounters,
+    ) {
+        if entry.is_admitted() {
+            entry.set_is_admitted(false);
+            counters.saturating_sub(1, entry.policy_weight());
+            // The following two unlink_* functions will unset the deq nodes.
+            Deques::unlink_ao_from_deque(ao_deq_name, ao_deq, &entry);
+            Deques::unlink_wo(wo_deq, &entry);
+        } else {
+            entry.unset_q_nodes();
+        }
+    }
+
+    fn evict_expired(
+        &self,
+        deqs: &mut Deques<K>,
+        batch_size: usize,
+        counters: &mut EvictionCounters,
+    ) {
+        let now = self.current_time_from_expiration_clock();
+
+        if self.is_write_order_queue_enabled() {
+            self.remove_expired_wo(deqs, batch_size, now, counters);
+        }
+
+        if self.time_to_idle.is_some() || self.has_valid_after() {
+            let (window, probation, protected, wo) = (
+                &mut deqs.window,
+                &mut deqs.probation,
+                &mut deqs.protected,
+                &mut deqs.write_order,
+            );
+
+            let mut rm_expired_ao =
+                |name, deq| self.remove_expired_ao(name, deq, wo, batch_size, now, counters);
+
+            rm_expired_ao("window", window);
+            rm_expired_ao("probation", probation);
+            rm_expired_ao("protected", protected);
+        }
+    }
+
+    #[inline]
+    fn remove_expired_ao(
+        &self,
+        deq_name: &str,
+        deq: &mut Deque<KeyHashDate<K>>,
+        write_order_deq: &mut Deque<KeyDate<K>>,
+        batch_size: usize,
+        now: Instant,
+        counters: &mut EvictionCounters,
+    ) {
+        let tti = &self.time_to_idle;
+        let va = &self.valid_after();
+        for _ in 0..batch_size {
+            // Peek the front node of the deque and check if it is expired.
+            let key = deq.peek_front().and_then(|node| {
+                if is_expired_entry_ao(tti, va, &*node, now) {
+                    Some(Arc::clone(node.element.key()))
+                } else {
+                    None
+                }
+            });
+
+            if key.is_none() {
+                break;
+            }
+
+            let key = key.as_ref().unwrap();
+
+            // Remove the key from the map only when the entry is really
+            // expired. This check is needed because it is possible that the entry in
+            // the map has been updated or deleted but its deque node we checked
+            // above have not been updated yet.
+            let maybe_entry = self
+                .cache
+                .remove_if(key, |_, v| is_expired_entry_ao(tti, va, v, now));
+
+            if let Some((_k, entry)) = maybe_entry {
+                Self::handle_remove_with_deques(deq_name, deq, write_order_deq, entry, counters);
+            } else if !self.try_skip_updated_entry(key, deq_name, deq, write_order_deq) {
+                break;
+            }
+        }
+    }
+
+    #[inline]
+    fn try_skip_updated_entry(
+        &self,
+        key: &K,
+        deq_name: &str,
+        deq: &mut Deque<KeyHashDate<K>>,
+        write_order_deq: &mut Deque<KeyDate<K>>,
+    ) -> bool {
+        if let Some(entry) = self.cache.get(key) {
+            if entry.last_accessed().is_none() {
+                // The key exists and the entry has been updated.
+                Deques::move_to_back_ao_in_deque(deq_name, deq, &entry);
+                Deques::move_to_back_wo_in_deque(write_order_deq, &entry);
+                true
+            } else {
+                // The key exists but something unexpected.
+                false
+            }
+        } else {
+            // Skip this entry as the key might have been invalidated. Since the
+            // invalidated ValueEntry (which should be still in the write op
+            // queue) has a pointer to this node, move the node to the back of
+            // the deque instead of popping (dropping) it.
+            if let Some(node) = deq.peek_front() {
+                let node = NonNull::from(node);
+                unsafe { deq.move_to_back(node) };
+            }
+            true
+        }
+    }
+
+    #[inline]
+    fn remove_expired_wo(
+        &self,
+        deqs: &mut Deques<K>,
+        batch_size: usize,
+        now: Instant,
+        counters: &mut EvictionCounters,
+    ) {
+        let ttl = &self.time_to_live;
+        let va = &self.valid_after();
+        for _ in 0..batch_size {
+            let key = deqs.write_order.peek_front().and_then(|node| {
+                if is_expired_entry_wo(ttl, va, &*node, now) {
+                    Some(Arc::clone(node.element.key()))
+                } else {
+                    None
+                }
+            });
+
+            if key.is_none() {
+                break;
+            }
+
+            let key = key.as_ref().unwrap();
+
+            let maybe_entry = self
+                .cache
+                .remove_if(key, |_, v| is_expired_entry_wo(ttl, va, v, now));
+
+            if let Some((_k, entry)) = maybe_entry {
+                Self::handle_remove(deqs, entry, counters);
+            } else if let Some(entry) = self.cache.get(key) {
+                if entry.last_modified().is_none() {
+                    deqs.move_to_back_ao(&entry);
+                    deqs.move_to_back_wo(&entry);
+                } else {
+                    // The key exists but something unexpected. Break.
+                    break;
+                }
+            } else {
+                // Skip this entry as the key might have been invalidated. Since the
+                // invalidated ValueEntry (which should be still in the write op
+                // queue) has a pointer to this node, move the node to the back of
+                // the deque instead of popping (dropping) it.
+                if let Some(node) = deqs.write_order.peek_front() {
+                    let node = NonNull::from(node);
+                    unsafe { deqs.write_order.move_to_back(node) };
+                }
+            }
+        }
+    }
+
+    fn evict_lru_entries(
+        &self,
+        deqs: &mut Deques<K>,
+        batch_size: usize,
+        weights_to_evict: u64,
+        counters: &mut EvictionCounters,
+    ) {
+        const DEQ_NAME: &str = "probation";
+        let mut evicted = 0u64;
+        let (deq, write_order_deq) = (&mut deqs.probation, &mut deqs.write_order);
+
+        for _ in 0..batch_size {
+            if evicted >= weights_to_evict {
+                break;
+            }
+
+            let maybe_key_and_ts = deq.peek_front().map(|node| {
+                (
+                    Arc::clone(node.element.key()),
+                    node.element.entry_info().last_modified(),
+                )
+            });
+
+            let (key, ts) = match maybe_key_and_ts {
+                Some((key, Some(ts))) => (key, ts),
+                Some((key, None)) => {
+                    if self.try_skip_updated_entry(&key, DEQ_NAME, deq, write_order_deq) {
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                None => break,
+            };
+
+            let maybe_entry = self.cache.remove_if(&key, |_, v| {
+                if let Some(lm) = v.last_modified() {
+                    lm == ts
+                } else {
+                    false
+                }
+            });
+
+            if let Some((_k, entry)) = maybe_entry {
+                let weight = entry.policy_weight();
+                Self::handle_remove_with_deques(DEQ_NAME, deq, write_order_deq, entry, counters);
+                evicted = evicted.saturating_add(weight as u64);
+            } else if !self.try_skip_updated_entry(&key, DEQ_NAME, deq, write_order_deq) {
+                break;
+            }
+        }
+    }
+}
+
+//
+// for testing
+//
+#[cfg(test)]
+impl<K, V, S> Inner<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Clone,
+{
+    fn set_expiration_clock(&self, clock: Option<Clock>) {
+        let mut exp_clock = self.expiration_clock.write();
+        if let Some(clock) = clock {
+            *exp_clock = Some(clock);
+            self.has_expiration_clock.store(true, Ordering::SeqCst);
+        } else {
+            self.has_expiration_clock.store(false, Ordering::SeqCst);
+            *exp_clock = None;
+        }
+    }
+}
+
+//
+// private free-standing functions
+//
+#[inline]
+fn is_expired_entry_ao(
+    time_to_idle: &Option<Duration>,
+    valid_after: &Option<Instant>,
+    entry: &impl AccessTime,
+    now: Instant,
+) -> bool {
+    if let Some(ts) = entry.last_accessed() {
+        if let Some(va) = valid_after {
+            if ts < *va {
+                return true;
+            }
+        }
+        if let Some(tti) = time_to_idle {
+            let checked_add = ts.checked_add(*tti);
+            if checked_add.is_none() {
+                panic!("ttl overflow")
+            }
+            return checked_add.unwrap() <= now;
+        }
+    }
+    false
+}
+
+#[inline]
+fn is_expired_entry_wo(
+    time_to_live: &Option<Duration>,
+    valid_after: &Option<Instant>,
+    entry: &impl AccessTime,
+    now: Instant,
+) -> bool {
+    if let Some(ts) = entry.last_modified() {
+        if let Some(va) = valid_after {
+            if ts < *va {
+                return true;
+            }
+        }
+        if let Some(ttl) = time_to_live {
+            let checked_add = ts.checked_add(*ttl);
+            if checked_add.is_none() {
+                panic!("ttl overflow");
+            }
+            return checked_add.unwrap() <= now;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BaseCache;
+
+    #[cfg_attr(target_pointer_width = "16", ignore)]
+    #[test]
+    fn test_skt_capacity_will_not_overflow() {
+        use std::collections::hash_map::RandomState;
+
+        // power of two
+        let pot = |exp| 2u64.pow(exp);
+
+        let ensure_sketch_len = |max_capacity, len, name| {
+            let cache = BaseCache::<u8, u8>::new(
+                Some(max_capacity),
+                None,
+                RandomState::default(),
+                None,
+                None,
+                None,
+            );
+            cache.inner.enable_frequency_sketch_for_testing();
+            assert_eq!(
+                cache.inner.frequency_sketch.read().table_len(),
+                len as usize,
+                "{}",
+                name
+            );
+        };
+
+        if cfg!(target_pointer_width = "32") {
+            let pot24 = pot(24);
+            let pot16 = pot(16);
+            ensure_sketch_len(0, 128, "0");
+            ensure_sketch_len(128, 128, "128");
+            ensure_sketch_len(pot16, pot16, "pot16");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot24 - 1, pot24, "pot24 - 1");
+            ensure_sketch_len(pot24, pot24, "pot24");
+            ensure_sketch_len(pot(27), pot24, "pot(27)");
+            ensure_sketch_len(u32::MAX as u64, pot24, "u32::MAX");
+        } else {
+            // target_pointer_width: 64 or larger.
+            let pot30 = pot(30);
+            let pot16 = pot(16);
+            ensure_sketch_len(0, 128, "0");
+            ensure_sketch_len(128, 128, "128");
+            ensure_sketch_len(pot16, pot16, "pot16");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
+            // due to ceiling to next_power_of_two
+            ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
+            ensure_sketch_len(pot30, pot30, "pot30");
+            ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+        };
+    }
+}

--- a/src/dash/builder.rs
+++ b/src/dash/builder.rs
@@ -1,0 +1,247 @@
+use super::Cache;
+use crate::{common::builder_utils, sync::Weigher};
+
+use std::{
+    collections::hash_map::RandomState,
+    hash::{BuildHasher, Hash},
+    marker::PhantomData,
+    sync::Arc,
+    time::Duration,
+};
+
+/// Builds a [`Cache`][cache-struct] or with various configuration knobs.
+///
+/// [cache-struct]: ./struct.Cache.html
+///
+/// # Examples
+///
+/// ```rust
+/// use moka::dash::Cache;
+/// use std::time::Duration;
+///
+/// let cache = Cache::builder()
+///     // Max 10,000 entries
+///     .max_capacity(10_000)
+///     // Time to live (TTL): 30 minutes
+///     .time_to_live(Duration::from_secs(30 * 60))
+///     // Time to idle (TTI):  5 minutes
+///     .time_to_idle(Duration::from_secs( 5 * 60))
+///     // Create the cache.
+///     .build();
+///
+/// // This entry will expire after 5 minutes (TTI) if there is no get().
+/// cache.insert(0, "zero");
+///
+/// // This get() will extend the entry life for another 5 minutes.
+/// cache.get_if_present(&0);
+///
+/// // Even though we keep calling get(), the entry will expire
+/// // after 30 minutes (TTL) from the insert().
+/// ```
+///
+#[must_use]
+pub struct CacheBuilder<K, V, C> {
+    max_capacity: Option<u64>,
+    initial_capacity: Option<usize>,
+    weigher: Option<Weigher<K, V>>,
+    time_to_live: Option<Duration>,
+    time_to_idle: Option<Duration>,
+    cache_type: PhantomData<C>,
+}
+
+impl<K, V> Default for CacheBuilder<K, V, Cache<K, V, RandomState>>
+where
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            max_capacity: None,
+            initial_capacity: None,
+            weigher: None,
+            time_to_live: None,
+            time_to_idle: None,
+            cache_type: Default::default(),
+        }
+    }
+}
+
+impl<K, V> CacheBuilder<K, V, Cache<K, V, RandomState>>
+where
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Construct a new `CacheBuilder` that will be used to build a `Cache` or
+    /// `SegmentedCache` holding up to `max_capacity` entries.
+    pub fn new(max_capacity: u64) -> Self {
+        Self {
+            max_capacity: Some(max_capacity),
+            ..Default::default()
+        }
+    }
+
+    /// Builds a `Cache<K, V>`.
+    ///
+    /// If you want to build a `SegmentedCache<K, V>`, call `segments` method before
+    /// calling this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
+    pub fn build(self) -> Cache<K, V, RandomState> {
+        let build_hasher = RandomState::default();
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
+        Cache::with_everything(
+            self.max_capacity,
+            self.initial_capacity,
+            build_hasher,
+            self.weigher,
+            self.time_to_live,
+            self.time_to_idle,
+        )
+    }
+
+    /// Builds a `Cache<K, V, S>`, with the given `hasher`.
+    ///
+    /// If you want to build a `SegmentedCache<K, V>`, call `segments` method  before
+    /// calling this method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if configured with either `time_to_live` or `time_to_idle` higher than
+    /// 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
+    pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
+    where
+        S: BuildHasher + Clone + Send + Sync + 'static,
+    {
+        builder_utils::ensure_expirations_or_panic(self.time_to_live, self.time_to_idle);
+        Cache::with_everything(
+            self.max_capacity,
+            self.initial_capacity,
+            hasher,
+            self.weigher,
+            self.time_to_live,
+            self.time_to_idle,
+        )
+    }
+}
+
+impl<K, V, C> CacheBuilder<K, V, C> {
+    /// Sets the max capacity of the cache.
+    pub fn max_capacity(self, max_capacity: u64) -> Self {
+        Self {
+            max_capacity: Some(max_capacity),
+            ..self
+        }
+    }
+
+    /// Sets the initial capacity (number of entries) of the cache.
+    pub fn initial_capacity(self, number_of_entries: usize) -> Self {
+        Self {
+            initial_capacity: Some(number_of_entries),
+            ..self
+        }
+    }
+
+    /// Sets the weigher closure of the cache.
+    ///
+    /// The closure should take `&K` and `&V` as the arguments and returns a `u32`
+    /// representing the relative size of the entry.
+    pub fn weigher(self, weigher: impl Fn(&K, &V) -> u32 + Send + Sync + 'static) -> Self {
+        Self {
+            weigher: Some(Arc::new(weigher)),
+            ..self
+        }
+    }
+
+    /// Sets the time to live of the cache.
+    ///
+    /// A cached entry will be expired after the specified duration past from
+    /// `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
+    pub fn time_to_live(self, duration: Duration) -> Self {
+        Self {
+            time_to_live: Some(duration),
+            ..self
+        }
+    }
+
+    /// Sets the time to idle of the cache.
+    ///
+    /// A cached entry will be expired after the specified duration past from `get`
+    /// or `insert`.
+    ///
+    /// # Panics
+    ///
+    /// `CacheBuilder::build*` methods will panic if the given `duration` is longer
+    /// than 1000 years. This is done to protect against overflow when computing key
+    /// expiration.
+    pub fn time_to_idle(self, duration: Duration) -> Self {
+        Self {
+            time_to_idle: Some(duration),
+            ..self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CacheBuilder;
+
+    use std::time::Duration;
+
+    #[test]
+    fn build_cache() {
+        // Cache<char, String>
+        let cache = CacheBuilder::new(100).build();
+
+        assert_eq!(cache.max_capacity(), Some(100));
+        assert_eq!(cache.time_to_live(), None);
+        assert_eq!(cache.time_to_idle(), None);
+
+        cache.insert('a', "Alice");
+        assert_eq!(cache.get_if_present(&'a'), Some("Alice"));
+
+        let cache = CacheBuilder::new(100)
+            .time_to_live(Duration::from_secs(45 * 60))
+            .time_to_idle(Duration::from_secs(15 * 60))
+            .build();
+
+        assert_eq!(cache.max_capacity(), Some(100));
+        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+
+        cache.insert('a', "Alice");
+        assert_eq!(cache.get_if_present(&'a'), Some("Alice"));
+    }
+
+    #[test]
+    #[should_panic(expected = "time_to_live is longer than 1000 years")]
+    fn build_cache_too_long_ttl() {
+        let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
+        let builder: CacheBuilder<char, String, _> = CacheBuilder::new(100);
+        let duration = Duration::from_secs(thousand_years_secs);
+        builder
+            .time_to_live(duration + Duration::from_secs(1))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "time_to_idle is longer than 1000 years")]
+    fn build_cache_too_long_tti() {
+        let thousand_years_secs: u64 = 1000 * 365 * 24 * 3600;
+        let builder: CacheBuilder<char, String, _> = CacheBuilder::new(100);
+        let duration = Duration::from_secs(thousand_years_secs);
+        builder
+            .time_to_idle(duration + Duration::from_secs(1))
+            .build();
+    }
+}

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -1,0 +1,740 @@
+use super::{
+    base_cache::{BaseCache, HouseKeeperArc, MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
+    CacheBuilder, ConcurrentCacheExt,
+};
+use crate::sync::{housekeeper::InnerSync, Weigher, WriteOp};
+
+use crossbeam_channel::{Sender, TrySendError};
+use std::{
+    borrow::Borrow,
+    collections::hash_map::RandomState,
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+    time::Duration,
+};
+
+/// A thread-safe concurrent in-memory cache built upon [`dashmap::DashMap`][dashmap].
+///
+/// `Cache` supports full concurrency of retrievals and a high expected concurrency
+/// for updates.
+///
+/// `Cache` utilizes a lock-free concurrent hash table as the central key-value
+/// storage. `Cache` performs a best-effort bounding of the map using an entry
+/// replacement algorithm to determine which entries to evict when the capacity is
+/// exceeded.
+///
+/// To use this cache, enable a crate feature called "dash".
+///
+/// # Examples
+///
+/// Cache entries are manually added using [`insert`](#method.insert) method, and are
+/// stored in the cache until either evicted or manually invalidated.
+///
+/// Here's an example of reading and updating a cache by using multiple threads:
+///
+/// ```rust
+/// use moka::dash::Cache;
+///
+/// use std::thread;
+///
+/// fn value(n: usize) -> String {
+///     format!("value {}", n)
+/// }
+///
+/// const NUM_THREADS: usize = 16;
+/// const NUM_KEYS_PER_THREAD: usize = 64;
+///
+/// // Create a cache that can store up to 10,000 entries.
+/// let cache = Cache::new(10_000);
+///
+/// // Spawn threads and read and update the cache simultaneously.
+/// let threads: Vec<_> = (0..NUM_THREADS)
+///     .map(|i| {
+///         // To share the same cache across the threads, clone it.
+///         // This is a cheap operation.
+///         let my_cache = cache.clone();
+///         let start = i * NUM_KEYS_PER_THREAD;
+///         let end = (i + 1) * NUM_KEYS_PER_THREAD;
+///
+///         thread::spawn(move || {
+///             // Insert 64 entries. (NUM_KEYS_PER_THREAD = 64)
+///             for key in start..end {
+///                 my_cache.insert(key, value(key));
+///                 // get() returns Option<String>, a clone of the stored value.
+///                 assert_eq!(my_cache.get_if_present(&key), Some(value(key)));
+///             }
+///
+///             // Invalidate every 4 element of the inserted entries.
+///             for key in (start..end).step_by(4) {
+///                 my_cache.invalidate(&key);
+///             }
+///         })
+///     })
+///     .collect();
+///
+/// // Wait for all threads to complete.
+/// threads.into_iter().for_each(|t| t.join().expect("Failed"));
+///
+/// // Verify the result.
+/// for key in 0..(NUM_THREADS * NUM_KEYS_PER_THREAD) {
+///     if key % 4 == 0 {
+///         assert_eq!(cache.get_if_present(&key), None);
+///     } else {
+///         assert_eq!(cache.get_if_present(&key), Some(value(key)));
+///     }
+/// }
+/// ```
+///
+/// # Avoiding to clone the value at `get_if_present`
+///
+/// The return type of `get_if_present` method is `Option<V>` instead of `Option<&V>`.
+/// Every time `get_if_present` is called for an existing key, it creates a clone of
+/// the stored value `V` and returns it. This is because the `Cache` allows
+/// concurrent updates from threads so a value stored in the cache can be dropped or
+/// replaced at any time by any other thread. `get` cannot return a reference `&V` as
+/// it is impossible to guarantee the value outlives the reference.
+///
+/// If you want to store values that will be expensive to clone, wrap them by
+/// `std::sync::Arc` before storing in a cache. [`Arc`][rustdoc-std-arc] is a
+/// thread-safe reference-counted pointer and its `clone()` method is cheap.
+///
+/// [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+///
+/// # Size-based Eviction
+///
+/// ```rust
+/// use std::convert::TryInto;
+/// use moka::dash::Cache;
+///
+/// // Evict based on the number of entries in the cache.
+/// let cache = Cache::builder()
+///     // Up to 10,000 entries.
+///     .max_capacity(10_000)
+///     // Create the cache.
+///     .build();
+/// cache.insert(1, "one".to_string());
+///
+/// // Evict based on the byte length of strings in the cache.
+/// let cache = Cache::builder()
+///     // A weigher closure takes &K and &V and returns a u32
+///     // representing the relative size of the entry.
+///     .weigher(|_key, value: &String| -> u32 {
+///         value.len().try_into().unwrap_or(u32::MAX)
+///     })
+///     // This cache will hold up to 32MiB of values.
+///     .max_capacity(32 * 1024 * 1024)
+///     .build();
+/// cache.insert(2, "two".to_string());
+/// ```
+///
+/// If your cache should not grow beyond a certain size, use the `max_capacity`
+/// method of the [`CacheBuilder`][builder-struct] to set the upper bound. The cache
+/// will try to evict entries that have not been used recently or very often.
+///
+/// At the cache creation time, a weigher closure can be set by the `weigher` method
+/// of the `CacheBuilder`. A weigher closure takes `&K` and `&V` as the arguments and
+/// returns a `u32` representing the relative size of the entry:
+///
+/// - If the `weigher` is _not_ set, the cache will treat each entry has the same
+///   size of `1`. This means the cache will be bounded by the number of entries.
+/// - If the `weigher` is set, the cache will call the weigher to calculate the
+///   weighted size (relative size) on an entry. This means the cache will be bounded
+///   by the total weighted size of entries.
+///
+/// Note that weighted sizes are not used when making eviction selections.
+///
+/// [builder-struct]: ./struct.CacheBuilder.html
+///
+/// # Time-based Expirations
+///
+/// `Cache` supports the following expiration policies:
+///
+/// - **Time to live**: A cached entry will be expired after the specified duration
+///   past from `insert`.
+/// - **Time to idle**: A cached entry will be expired after the specified duration
+///   past from `get` or `insert`.
+///
+/// ```rust
+/// use moka::dash::Cache;
+/// use std::time::Duration;
+///
+/// let cache = Cache::builder()
+///     // Time to live (TTL): 30 minutes
+///     .time_to_live(Duration::from_secs(30 * 60))
+///     // Time to idle (TTI):  5 minutes
+///     .time_to_idle(Duration::from_secs( 5 * 60))
+///     // Create the cache.
+///     .build();
+///
+/// // This entry will expire after 5 minutes (TTI) if there is no get().
+/// cache.insert(0, "zero");
+///
+/// // This get() will extend the entry life for another 5 minutes.
+/// cache.get_if_present(&0);
+///
+/// // Even though we keep calling get(), the entry will expire
+/// // after 30 minutes (TTL) from the insert().
+/// ```
+///
+/// # Thread Safety
+///
+/// All methods provided by the `Cache` are considered thread-safe, and can be safely
+/// accessed by multiple concurrent threads.
+///
+/// - `Cache<K, V, S>` requires trait bounds `Send`, `Sync` and `'static` for `K`
+///   (key), `V` (value) and `S` (hasher state).
+/// - `Cache<K, V, S>` will implement `Send` and `Sync`.
+///
+/// # Sharing a cache across threads
+///
+/// To share a cache across threads, do one of the followings:
+///
+/// - Create a clone of the cache by calling its `clone` method and pass it to other
+///   thread.
+/// - Wrap the cache by a `sync::OnceCell` or `sync::Lazy` from
+///   [once_cell][once-cell-crate] create, and set it to a `static` variable.
+///
+/// Cloning is a cheap operation for `Cache` as it only creates thread-safe
+/// reference-counted pointers to the internal data structures.
+///
+/// [once-cell-crate]: https://crates.io/crates/once_cell
+///
+/// # Hashing Algorithm
+///
+/// By default, `Cache` uses a hashing algorithm selected to provide resistance
+/// against HashDoS attacks. It will be the same one used by
+/// `std::collections::HashMap`, which is currently SipHash 1-3.
+///
+/// While SipHash's performance is very competitive for medium sized keys, other
+/// hashing algorithms will outperform it for small keys such as integers as well as
+/// large keys such as long strings. However those algorithms will typically not
+/// protect against attacks such as HashDoS.
+///
+/// The hashing algorithm can be replaced on a per-`Cache` basis using the
+/// [`build_with_hasher`][build-with-hasher-method] method of the
+/// `CacheBuilder`. Many alternative algorithms are available on crates.io, such
+/// as the [aHash][ahash-crate] crate.
+///
+/// [build-with-hasher-method]: ./struct.CacheBuilder.html#method.build_with_hasher
+/// [ahash-crate]: https://crates.io/crates/ahash
+///
+#[derive(Clone)]
+pub struct Cache<K, V, S = RandomState> {
+    base: BaseCache<K, V, S>,
+}
+
+// TODO: https://github.com/moka-rs/moka/issues/54
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl<K, V, S> Send for Cache<K, V, S>
+where
+    K: Send + Sync,
+    V: Send + Sync,
+    S: Send,
+{
+}
+
+unsafe impl<K, V, S> Sync for Cache<K, V, S>
+where
+    K: Send + Sync,
+    V: Send + Sync,
+    S: Sync,
+{
+}
+
+impl<K, V> Cache<K, V, RandomState>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Constructs a new `Cache<K, V>` that will store up to the `max_capacity`.
+    ///
+    /// To adjust various configuration knobs such as `initial_capacity` or
+    /// `time_to_live`, use the [`CacheBuilder`][builder-struct].
+    ///
+    /// [builder-struct]: ./struct.CacheBuilder.html
+    pub fn new(max_capacity: u64) -> Self {
+        let build_hasher = RandomState::default();
+        Self::with_everything(Some(max_capacity), None, build_hasher, None, None, None)
+    }
+
+    /// Returns a [`CacheBuilder`][builder-struct], which can builds a `Cache` or
+    /// `SegmentedCache` with various configuration knobs.
+    ///
+    /// [builder-struct]: ./struct.CacheBuilder.html
+    pub fn builder() -> CacheBuilder<K, V, Cache<K, V, RandomState>> {
+        CacheBuilder::default()
+    }
+}
+
+impl<K, V, S> Cache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn with_everything(
+        max_capacity: Option<u64>,
+        initial_capacity: Option<usize>,
+        build_hasher: S,
+        weigher: Option<Weigher<K, V>>,
+        time_to_live: Option<Duration>,
+        time_to_idle: Option<Duration>,
+    ) -> Self {
+        Self {
+            base: BaseCache::new(
+                max_capacity,
+                initial_capacity,
+                build_hasher,
+                weigher,
+                time_to_live,
+                time_to_idle,
+            ),
+        }
+    }
+
+    /// Returns a _clone_ of the value corresponding to the key.
+    ///
+    /// If you want to store values that will be expensive to clone, wrap them by
+    /// `std::sync::Arc` before storing in a cache. [`Arc`][rustdoc-std-arc] is a
+    /// thread-safe reference-counted pointer and its `clone()` method is cheap.
+    ///
+    /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
+    /// on the borrowed form _must_ match those for the key type.
+    ///
+    /// [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+    pub fn get_if_present<Q>(&self, key: &Q) -> Option<V>
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.base.get_with_hash(key, self.base.hash(key))
+    }
+
+    /// Inserts a key-value pair into the cache.
+    ///
+    /// If the cache has this key present, the value is updated.
+    pub fn insert(&self, key: K, value: V) {
+        let hash = self.base.hash(&key);
+        let key = Arc::new(key);
+        self.insert_with_hash(key, hash, value)
+    }
+
+    pub(crate) fn insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) {
+        let op = self.base.do_insert_with_hash(key, hash, value);
+        let hk = self.base.housekeeper.as_ref();
+        Self::schedule_write_op(&self.base.write_op_ch, op, hk).expect("Failed to insert");
+    }
+
+    /// Discards any cached value for the key.
+    ///
+    /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
+    /// on the borrowed form _must_ match those for the key type.
+    pub fn invalidate<Q>(&self, key: &Q)
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        if let Some(kv) = self.base.remove_entry(key) {
+            let op = WriteOp::Remove(kv);
+            let hk = self.base.housekeeper.as_ref();
+            Self::schedule_write_op(&self.base.write_op_ch, op, hk).expect("Failed to remove");
+        }
+    }
+
+    /// Discards all cached values.
+    ///
+    /// This method returns immediately and a background thread will evict all the
+    /// cached values inserted before the time when this method was called. It is
+    /// guaranteed that the `get` method must not return these invalidated values
+    /// even if they have not been evicted.
+    ///
+    /// Like the `invalidate` method, this method does not clear the historic
+    /// popularity estimator of keys so that it retains the client activities of
+    /// trying to retrieve an item.
+    pub fn invalidate_all(&self) {
+        self.base.invalidate_all();
+    }
+
+    /// Returns the `max_capacity` of this cache.
+    pub fn max_capacity(&self) -> Option<usize> {
+        self.base.max_capacity()
+    }
+
+    /// Returns the `time_to_live` of this cache.
+    pub fn time_to_live(&self) -> Option<Duration> {
+        self.base.time_to_live()
+    }
+
+    /// Returns the `time_to_idle` of this cache.
+    pub fn time_to_idle(&self) -> Option<Duration> {
+        self.base.time_to_idle()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn estimated_entry_count(&self) -> u64 {
+        self.base.estimated_entry_count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.base.weighted_size()
+    }
+}
+
+impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    fn sync(&self) {
+        self.base.inner.sync(MAX_SYNC_REPEATS);
+    }
+}
+
+// private methods
+impl<K, V, S> Cache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    #[inline]
+    fn schedule_write_op(
+        ch: &Sender<WriteOp<K, V>>,
+        op: WriteOp<K, V>,
+        housekeeper: Option<&HouseKeeperArc<K, V, S>>,
+    ) -> Result<(), TrySendError<WriteOp<K, V>>> {
+        let mut op = op;
+
+        // NOTES:
+        // - This will block when the channel is full.
+        // - We are doing a busy-loop here. We were originally calling `ch.send(op)?`,
+        //   but we got a notable performance degradation.
+        loop {
+            BaseCache::apply_reads_writes_if_needed(ch, housekeeper);
+            match ch.try_send(op) {
+                Ok(()) => break,
+                Err(TrySendError::Full(op1)) => {
+                    op = op1;
+                    std::thread::sleep(Duration::from_micros(WRITE_RETRY_INTERVAL_MICROS));
+                }
+                Err(e @ TrySendError::Disconnected(_)) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}
+
+// For unit tests.
+#[cfg(test)]
+impl<K, V, S> Cache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn is_table_empty(&self) -> bool {
+        self.estimated_entry_count() == 0
+    }
+
+    pub(crate) fn reconfigure_for_testing(&mut self) {
+        self.base.reconfigure_for_testing();
+    }
+
+    pub(crate) fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
+        self.base.set_expiration_clock(clock);
+    }
+}
+
+// To see the debug prints, run test as `cargo test -- --nocapture`
+#[cfg(test)]
+mod tests {
+    use super::{Cache, ConcurrentCacheExt};
+    use crate::common::time::Clock;
+
+    use std::time::Duration;
+
+    #[test]
+    fn basic_single_thread() {
+        let mut cache = Cache::new(3);
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        assert_eq!(cache.get_if_present(&"a"), Some("alice"));
+        assert_eq!(cache.get_if_present(&"b"), Some("bob"));
+        cache.sync();
+        // counts: a -> 1, b -> 1
+
+        cache.insert("c", "cindy");
+        assert_eq!(cache.get_if_present(&"c"), Some("cindy"));
+        // counts: a -> 1, b -> 1, c -> 1
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), Some("alice"));
+        assert_eq!(cache.get_if_present(&"b"), Some("bob"));
+        cache.sync();
+        // counts: a -> 2, b -> 2, c -> 1
+
+        // "d" should not be admitted because its frequency is too low.
+        cache.insert("d", "david"); //   count: d -> 0
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"d"), None); //   d -> 1
+
+        cache.insert("d", "david");
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"d"), None); //   d -> 2
+
+        // "d" should be admitted and "c" should be evicted
+        // because d's frequency is higher than c's.
+        cache.insert("d", "dennis");
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"a"), Some("alice"));
+        assert_eq!(cache.get_if_present(&"b"), Some("bob"));
+        assert_eq!(cache.get_if_present(&"c"), None);
+        assert_eq!(cache.get_if_present(&"d"), Some("dennis"));
+
+        cache.invalidate(&"b");
+        assert_eq!(cache.get_if_present(&"b"), None);
+    }
+
+    #[test]
+    fn size_aware_eviction() {
+        let weigher = |_k: &&str, v: &(&str, u32)| v.1;
+
+        let alice = ("alice", 10);
+        let bob = ("bob", 15);
+        let bill = ("bill", 20);
+        let cindy = ("cindy", 5);
+        let david = ("david", 15);
+        let dennis = ("dennis", 15);
+
+        let mut cache = Cache::builder().max_capacity(31).weigher(weigher).build();
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", alice);
+        cache.insert("b", bob);
+        assert_eq!(cache.get_if_present(&"a"), Some(alice));
+        assert_eq!(cache.get_if_present(&"b"), Some(bob));
+        cache.sync();
+        // order (LRU -> MRU) and counts: a -> 1, b -> 1
+
+        cache.insert("c", cindy);
+        assert_eq!(cache.get_if_present(&"c"), Some(cindy));
+        // order and counts: a -> 1, b -> 1, c -> 1
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), Some(alice));
+        assert_eq!(cache.get_if_present(&"b"), Some(bob));
+        cache.sync();
+        // order and counts: c -> 1, a -> 2, b -> 2
+
+        // To enter "d" (weight: 15), it needs to evict "c" (w: 5) and "a" (w: 10).
+        // "d" must have higher count than 3, which is the aggregated count
+        // of "a" and "c".
+        cache.insert("d", david); //   count: d -> 0
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"d"), None); //   d -> 1
+
+        cache.insert("d", david);
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"d"), None); //   d -> 2
+
+        cache.insert("d", david);
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"d"), None); //   d -> 3
+
+        cache.insert("d", david);
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"d"), None); //   d -> 4
+
+        // Finally "d" should be admitted by evicting "c" and "a".
+        cache.insert("d", dennis);
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"a"), None);
+        assert_eq!(cache.get_if_present(&"b"), Some(bob));
+        assert_eq!(cache.get_if_present(&"c"), None);
+        assert_eq!(cache.get_if_present(&"d"), Some(dennis));
+
+        // Update "b" with "bill" (w: 15 -> 20). This should evict "d" (w: 15).
+        cache.insert("b", bill);
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"b"), Some(bill));
+        assert_eq!(cache.get_if_present(&"d"), None);
+
+        // Re-add "a" (w: 10) and update "b" with "bob" (w: 20 -> 15).
+        cache.insert("a", alice);
+        cache.insert("b", bob);
+        cache.sync();
+        assert_eq!(cache.get_if_present(&"a"), Some(alice));
+        assert_eq!(cache.get_if_present(&"b"), Some(bob));
+        assert_eq!(cache.get_if_present(&"d"), None);
+
+        // Verify the sizes.
+        assert_eq!(cache.estimated_entry_count(), 2);
+        assert_eq!(cache.weighted_size(), 25);
+    }
+
+    #[test]
+    fn basic_multi_threads() {
+        let num_threads = 4;
+        let cache = Cache::new(100);
+
+        // https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect
+        #[allow(clippy::needless_collect)]
+        let handles = (0..num_threads)
+            .map(|id| {
+                let cache = cache.clone();
+                std::thread::spawn(move || {
+                    cache.insert(10, format!("{}-100", id));
+                    cache.get_if_present(&10);
+                    cache.insert(20, format!("{}-200", id));
+                    cache.invalidate(&10);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        handles.into_iter().for_each(|h| h.join().expect("Failed"));
+
+        assert!(cache.get_if_present(&10).is_none());
+        assert!(cache.get_if_present(&20).is_some());
+    }
+
+    #[test]
+    fn invalidate_all() {
+        let mut cache = Cache::new(100);
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cindy");
+        assert_eq!(cache.get_if_present(&"a"), Some("alice"));
+        assert_eq!(cache.get_if_present(&"b"), Some("bob"));
+        assert_eq!(cache.get_if_present(&"c"), Some("cindy"));
+        cache.sync();
+
+        cache.invalidate_all();
+        cache.sync();
+
+        cache.insert("d", "david");
+        cache.sync();
+
+        assert!(cache.get_if_present(&"a").is_none());
+        assert!(cache.get_if_present(&"b").is_none());
+        assert!(cache.get_if_present(&"c").is_none());
+        assert_eq!(cache.get_if_present(&"d"), Some("david"));
+    }
+
+    #[test]
+    fn time_to_live() {
+        let mut cache = Cache::builder()
+            .max_capacity(100)
+            .time_to_live(Duration::from_secs(10))
+            .build();
+
+        cache.reconfigure_for_testing();
+
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice");
+        cache.sync();
+
+        mock.increment(Duration::from_secs(5)); // 5 secs from the start.
+        cache.sync();
+
+        cache.get_if_present(&"a");
+
+        mock.increment(Duration::from_secs(5)); // 10 secs.
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), None);
+        assert!(cache.is_table_empty());
+
+        cache.insert("b", "bob");
+        cache.sync();
+
+        assert_eq!(cache.estimated_entry_count(), 1);
+
+        mock.increment(Duration::from_secs(5)); // 15 secs.
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"b"), Some("bob"));
+        assert_eq!(cache.estimated_entry_count(), 1);
+
+        cache.insert("b", "bill");
+        cache.sync();
+
+        mock.increment(Duration::from_secs(5)); // 20 secs
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"b"), Some("bill"));
+        assert_eq!(cache.estimated_entry_count(), 1);
+
+        mock.increment(Duration::from_secs(5)); // 25 secs
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), None);
+        assert_eq!(cache.get_if_present(&"b"), None);
+        assert!(cache.is_table_empty());
+    }
+
+    #[test]
+    fn time_to_idle() {
+        let mut cache = Cache::builder()
+            .max_capacity(100)
+            .time_to_idle(Duration::from_secs(10))
+            .build();
+
+        cache.reconfigure_for_testing();
+
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice");
+        cache.sync();
+
+        mock.increment(Duration::from_secs(5)); // 5 secs from the start.
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), Some("alice"));
+
+        mock.increment(Duration::from_secs(5)); // 10 secs.
+        cache.sync();
+
+        cache.insert("b", "bob");
+        cache.sync();
+
+        assert_eq!(cache.estimated_entry_count(), 2);
+
+        mock.increment(Duration::from_secs(5)); // 15 secs.
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), None);
+        assert_eq!(cache.get_if_present(&"b"), Some("bob"));
+        assert_eq!(cache.estimated_entry_count(), 1);
+
+        mock.increment(Duration::from_secs(10)); // 25 secs
+        cache.sync();
+
+        assert_eq!(cache.get_if_present(&"a"), None);
+        assert_eq!(cache.get_if_present(&"b"), None);
+        assert!(cache.is_table_empty());
+    }
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,4 +1,5 @@
-//! Provides a thread-safe, asynchronous (futures aware) cache implementation.
+//! Provides a thread-safe, concurrent asynchronous (futures aware) cache
+//! implementation.
 //!
 //! To use this module, enable a crate feature called "future".
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -53,7 +53,6 @@ use std::{
 /// Here's an example of reading and updating a cache by using multiple asynchronous
 /// tasks with [Tokio][tokio-crate] runtime:
 ///
-/// [dashmap]: https://docs.rs/dashmap/*/dashmap/struct.DashMap.html
 /// [tokio-crate]: https://crates.io/crates/tokio
 ///
 ///```rust

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -44,7 +44,7 @@ use std::{
 ///
 /// - Inside an async context (`async fn` or `async` block), use
 ///   [`insert`](#method.insert), [`get_or_insert_with`](#method.get_or_insert_with)
-///   or [`invalidate`](#method.invalidate) method for updating the cache and `await`
+///   or [`invalidate`](#method.invalidate) methods for updating the cache and `await`
 ///   them.
 /// - Outside any async context, use [`blocking_insert`](#method.blocking_insert) or
 ///   [`blocking_invalidate`](#method.blocking_invalidate) methods. They will block
@@ -53,6 +53,7 @@ use std::{
 /// Here's an example of reading and updating a cache by using multiple asynchronous
 /// tasks with [Tokio][tokio-crate] runtime:
 ///
+/// [dashmap]: https://docs.rs/dashmap/*/dashmap/struct.DashMap.html
 /// [tokio-crate]: https://crates.io/crates/tokio
 ///
 ///```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,17 +40,20 @@
 //! See the following document:
 //!
 //! - Thread-safe, synchronous caches:
-//!     - [`sync::Cache`][sync-cache-struct] and
-//!       [`sync::SegmentedCache`][sync-seg-cache-struct].
+//!     - [`sync::Cache`][sync-cache-struct]
+//!     - [`sync::SegmentedCache`][sync-seg-cache-struct]
+//!     - [`dash::Cache`][dash-cache-struct] (Requires "dash" feature)
 //! - An asynchronous (futures aware) cache:
-//!     - [`future::Cache`][future-cache-struct].
+//!     - [`future::Cache`][future-cache-struct] (Requires "future" feature)
 //! - A not thread-safe, blocking cache for single threaded applications:
-//!     - [`unsync::Cache`][unsync-cache-struct].
+//!     - [`unsync::Cache`][unsync-cache-struct]
 //!
+//! [dash-cache-struct]: ./dash/struct.Cache.html
 //! [future-cache-struct]: ./future/struct.Cache.html
 //! [sync-cache-struct]: ./sync/struct.Cache.html
 //! [sync-seg-cache-struct]: ./sync/struct.SegmentedCache.html
 //! [unsync-cache-struct]: ./unsync/struct.Cache.html
+//! [dashmap]: https://docs.rs/dashmap/*/dashmap/struct.DashMap.html
 //!
 //! # Minimum Supported Rust Versions
 //!
@@ -61,6 +64,7 @@
 //! | no feature |                     | Rust 1.51.0 |
 //! | `atomic64` |       yes           | Rust 1.51.0 |
 //! | `future`   |                     | Rust 1.51.0 |
+//! | `dash`     |                     | Rust 1.51.0 |
 //!
 //! If only the default features are enabled, MSRV will be updated conservatively.
 //! When using other features, like `future`, MSRV might be updated more frequently,
@@ -149,6 +153,9 @@
 //! timer wheel paper, try to change the URL from `https:` to `http:`.
 //!
 //! [timer-wheel]: http://www.cs.columbia.edu/~nahum/w6998/papers/ton97-timing-wheels.pdf
+
+#[cfg(feature = "dash")]
+pub mod dash;
 
 #[cfg(feature = "future")]
 pub mod future;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-//! Provides thread-safe, blocking cache implementations.
+//! Provides thread-safe, concurrent cache implementations.
 
 use crate::common::{deque::DeqNode, time::Instant};
 
@@ -10,7 +10,7 @@ use triomphe::Arc as TrioArc;
 pub(crate) mod base_cache;
 mod builder;
 mod cache;
-mod deques;
+pub(crate) mod deques;
 pub(crate) mod entry_info;
 pub(crate) mod housekeeper;
 mod invalidator;
@@ -112,6 +112,11 @@ impl<K> KeyHashDate<K> {
         &self.key
     }
 
+    #[cfg(feature = "dash")]
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
     pub(crate) fn entry_info(&self) -> &EntryInfo {
         &self.entry_info
     }
@@ -193,7 +198,7 @@ pub(crate) struct ValueEntry<K, V> {
 }
 
 impl<K, V> ValueEntry<K, V> {
-    fn new(value: V, entry_info: TrioArc<EntryInfo>) -> Self {
+    pub(crate) fn new(value: V, entry_info: TrioArc<EntryInfo>) -> Self {
         #[cfg(feature = "unstable-debug-counters")]
         self::debug_counters::InternalGlobalDebugCounters::value_entry_created();
 
@@ -207,7 +212,7 @@ impl<K, V> ValueEntry<K, V> {
         }
     }
 
-    fn new_from(value: V, entry_info: TrioArc<EntryInfo>, other: &Self) -> Self {
+    pub(crate) fn new_from(value: V, entry_info: TrioArc<EntryInfo>, other: &Self) -> Self {
         #[cfg(feature = "unstable-debug-counters")]
         self::debug_counters::InternalGlobalDebugCounters::value_entry_created();
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 
-/// A thread-safe concurrent in-memory cache.
+/// A thread-safe concurrent synchronous in-memory cache.
 ///
 /// `Cache` supports full concurrency of retrievals and a high expected concurrency
 /// for updates.
@@ -29,8 +29,8 @@ use std::{
 /// # Examples
 ///
 /// Cache entries are manually added using [`insert`](#method.insert) or
-/// [`get_or_insert_with`](#method.get_or_insert_with) method, and are stored in the
-/// cache until either evicted or manually invalidated.
+/// [`get_or_insert_with`](#method.get_or_insert_with) methods, and are stored in
+/// the cache until either evicted or manually invalidated.
 ///
 /// Here's an example of reading and updating a cache by using multiple threads:
 ///

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -1,4 +1,7 @@
-//! Provides a *not* thread-safe, blocking cache implementation.
+//! Provides a *not* thread-safe cache implementation built upon
+//! [`std::collections::HashMap`][std-hashmap].
+//!
+//! [std-hashmap]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 
 mod builder;
 mod cache;

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -23,10 +23,12 @@ type CacheStore<K, V, S> = std::collections::HashMap<Rc<K>, ValueEntry<K, V>, S>
 
 /// An in-memory cache that is _not_ thread-safe.
 ///
-/// `Cache` utilizes a hash table `std::collections::HashMap` from the standard
-/// library for the central key-value storage. `Cache` performs a best-effort
-/// bounding of the map using an entry replacement algorithm to determine which
-/// entries to evict when the capacity is exceeded.
+/// `Cache` utilizes a hash table [`std::collections::HashMap`][std-hashmap] from the
+/// standard library for the central key-value storage. `Cache` performs a
+/// best-effort bounding of the map using an entry replacement algorithm to determine
+/// which entries to evict when the capacity is exceeded.
+///
+/// [std-hashmap]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 ///
 /// # Characteristic difference between `unsync` and `sync`/`future` caches
 ///
@@ -41,7 +43,7 @@ type CacheStore<K, V, S> = std::collections::HashMap<Rc<K>, ValueEntry<K, V>, S>
 ///
 /// # Examples
 ///
-/// Cache entries are manually added using an insert method, and are stored in the
+/// Cache entries are manually added using the insert method, and are stored in the
 /// cache until either evicted or manually invalidated.
 ///
 /// Here's an example of reading and updating a cache by using the main thread:


### PR DESCRIPTION
Add an optional cache implementation `moka::dash::Cache`, which uses the `dashmap::DashMap` as the internal storage. The `moka::dash::Cache` provides similar (but less) APIs to `moka::sync::Cache`.

To use this optional cache, add "dash" feature for the moka dependency in Cargo.toml.

* * *
Fixes #92 