### PR TITLE
Update the minimum depending version of crossbeam-channel to v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 0.8.0
 
+### Changed
+
+- Update the minimum depending version of crossbeam-channel from v0.5.2 to v0.5.4.
+  ([#100][gh-pull-0100])
+
 
 ## Version 0.7.2
 
@@ -239,6 +244,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0100]: https://github.com/moka-rs/moka/pull/100/
 [gh-pull-0086]: https://github.com/moka-rs/moka/pull/86/
 [gh-pull-0084]: https://github.com/moka-rs/moka/pull/84/
 [gh-pull-0083]: https://github.com/moka-rs/moka/pull/83/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ atomic64 = []
 unstable-debug-counters = ["future"]
 
 [dependencies]
-crossbeam-channel = "0.5.2"
+crossbeam-channel = "0.5.4"
 crossbeam-epoch = "0.8.2"
 crossbeam-utils = "0.8"
 num_cpus = "1.13"
@@ -75,6 +75,8 @@ features = ["future"]
 # RUSTSEC, etc.
 #
 # crossbeam-channel:
+# - Workaround a bug in upstream related to TLS access on AArch64 Linux:
+#   - https://github.com/crossbeam-rs/crossbeam/pull/802 (Patched >= 0.5.4)
 # - Addressed some stacked borrow violations found by Miri:
 #   - https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-channel/CHANGELOG.md#version-052 (Patched >= 0.5.2)
 #


### PR DESCRIPTION
crossbeam-channel v0.5.4 has a workaround for a bug in upstream (`rustc` or LLVM?) related to TLS access on AArch64 Linux: https://github.com/crossbeam-rs/crossbeam/pull/802

Ensure that Moka uses crossbeam-channel v0.5.4 or newer v0.5.x.