### PR TITLE
Iterator for `dash::Cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 ### Added
 
-- Add a synchronous cache `moka::dash::Cache`, which uses `dash::DashMap` as
-  the internal storage. ([#99][gh-pull-0099])
+#### Experimental Additions
+
+Please note that the following additions are highly experimental so their APIs will
+be frequently changed in next few releases.
+
+- Add a synchronous cache `moka::dash::Cache`, which uses `dashmap::DashMap` as the
+  internal storage. ([#99][gh-pull-0099])
+- Add iterator to `moka::dash::Cache`. ([#101][gh-pull-0101]) 
 
 ### Changed
 
@@ -249,6 +255,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0101]: https://github.com/moka-rs/moka/pull/101/
 [gh-pull-0100]: https://github.com/moka-rs/moka/pull/100/
 [gh-pull-0099]: https://github.com/moka-rs/moka/pull/99/
 [gh-pull-0086]: https://github.com/moka-rs/moka/pull/86/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ default = ["atomic64"]
 # Enable this feature to use `moka::future::Cache`.
 future = ["async-io", "async-lock", "futures-util"]
 
-# Enable this feature to use `moka::dash::Cache`.
+# Enable this feature to use **experimental** `moka::dash::Cache`.
+# Please note that the APIs for this feature will be frequently changed in next
+# few releases.
 dash = ["dashmap"]
 
 # This feature is enabled by default. Disable it when the target platform does not

--- a/src/dash.rs
+++ b/src/dash.rs
@@ -1,5 +1,5 @@
-//! Provides a thread-safe, concurrent cache implementation built upon
-//! [`dashmap::DashMap`][dashmap].
+//! **Experimental**: Provides a thread-safe, concurrent cache implementation
+//! built upon [`dashmap::DashMap`][dashmap].
 //!
 //! To use this module, enable a crate feature called "dash".
 //!

--- a/src/dash.rs
+++ b/src/dash.rs
@@ -8,10 +8,13 @@
 mod base_cache;
 mod builder;
 mod cache;
-// mod value_initializer;
+mod iter;
+mod mapref;
 
 pub use builder::CacheBuilder;
 pub use cache::Cache;
+pub use iter::Iter;
+pub use mapref::EntryRef;
 
 /// Provides extra methods that will be useful for testing.
 pub trait ConcurrentCacheExt<K, V> {

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -1,3 +1,4 @@
+use super::Iter;
 use crate::{
     common::{
         self,
@@ -14,6 +15,7 @@ use crate::{
         AccessTime, KeyDate, KeyHash, KeyHashDate, KvEntry, ReadOp, ValueEntry, Weigher, WriteOp,
     },
 };
+
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use crossbeam_utils::atomic::AtomicCell;
 use dashmap::mapref::one::Ref as DashMapRef;
@@ -181,6 +183,10 @@ where
     pub(crate) fn invalidate_all(&self) {
         let now = self.inner.current_time_from_expiration_clock();
         self.inner.set_valid_after(now);
+    }
+
+    pub(crate) fn iter(&self) -> Iter<'_, K, V, S> {
+        self.inner.iter()
     }
 
     pub(crate) fn max_capacity(&self) -> Option<usize> {
@@ -501,6 +507,11 @@ where
         self.cache
             .remove(key)
             .map(|(key, entry)| KvEntry::new(key, entry))
+    }
+
+    fn iter(&self) -> Iter<'_, K, V, S> {
+        let map_iter = self.cache.iter();
+        Iter::new(map_iter)
     }
 
     fn max_capacity(&self) -> Option<usize> {

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -13,7 +13,8 @@ use std::{
     time::Duration,
 };
 
-/// A thread-safe concurrent in-memory cache built upon [`dashmap::DashMap`][dashmap].
+/// **Experimental**: A thread-safe concurrent in-memory cache built upon
+/// [`dashmap::DashMap`][dashmap].
 ///
 /// Unlike `sync` and `future` caches of Moka, `dash` cache does not provide full
 /// concurrency of retrievals. This is because `DashMap` employs read-write locks on
@@ -26,7 +27,9 @@ use std::{
 /// replacement algorithm to determine which entries to evict when the capacity is
 /// exceeded.
 ///
-/// To use this cache, enable a crate feature called "dash".
+/// To use this cache, enable a crate feature called "dash". Please note that the APIs
+/// will _be changed very often_ in next few releases as this is yet an experimental
+/// feature.
 ///
 /// # Examples
 ///

--- a/src/dash/iter.rs
+++ b/src/dash/iter.rs
@@ -1,0 +1,46 @@
+use super::mapref::EntryRef;
+use crate::sync::ValueEntry;
+
+use std::{
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+};
+use triomphe::Arc as TrioArc;
+
+type DashMapIter<'a, K, V, S> = dashmap::iter::Iter<'a, Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+
+pub struct Iter<'a, K, V, S>(DashMapIter<'a, K, V, S>);
+
+impl<'a, K, V, S> Iter<'a, K, V, S> {
+    pub(crate) fn new(map_iter: DashMapIter<'a, K, V, S>) -> Self {
+        Self(map_iter)
+    }
+}
+
+impl<'a, K, V, S> Iterator for Iter<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Clone,
+{
+    type Item = EntryRef<'a, K, V, S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|map_ref| EntryRef::new(map_ref))
+    }
+}
+
+unsafe impl<'a, 'i, K, V, S> Send for Iter<'i, K, V, S>
+where
+    K: 'a + Eq + Hash + Send,
+    V: 'a + Send,
+    S: 'a + BuildHasher + Clone,
+{
+}
+
+unsafe impl<'a, 'i, K, V, S> Sync for Iter<'i, K, V, S>
+where
+    K: 'a + Eq + Hash + Sync,
+    V: 'a + Sync,
+    S: 'a + BuildHasher + Clone,
+{
+}

--- a/src/dash/mapref.rs
+++ b/src/dash/mapref.rs
@@ -1,0 +1,54 @@
+use crate::sync::ValueEntry;
+
+use std::{
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+};
+use triomphe::Arc as TrioArc;
+
+type DashMapRef<'a, K, V, S> =
+    dashmap::mapref::multiple::RefMulti<'a, Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+
+pub struct EntryRef<'a, K, V, S>(DashMapRef<'a, K, V, S>);
+
+unsafe impl<'a, K, V, S> Sync for EntryRef<'a, K, V, S>
+where
+    K: Eq + Hash + Send + Sync,
+    V: Send + Sync,
+    S: BuildHasher,
+{
+}
+
+impl<'a, K, V, S> EntryRef<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Clone,
+{
+    pub(crate) fn new(map_ref: DashMapRef<'a, K, V, S>) -> Self {
+        Self(map_ref)
+    }
+
+    pub fn key(&self) -> &K {
+        self.0.key()
+    }
+
+    pub fn value(&self) -> &V {
+        &self.0.value().value
+    }
+
+    pub fn pair(&self) -> (&K, &V) {
+        (self.key(), self.value())
+    }
+}
+
+impl<'a, K, V, S> std::ops::Deref for EntryRef<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Clone,
+{
+    type Target = V;
+
+    fn deref(&self) -> &V {
+        self.value()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! - Thread-safe, synchronous caches:
 //!     - [`sync::Cache`][sync-cache-struct]
 //!     - [`sync::SegmentedCache`][sync-seg-cache-struct]
-//!     - [`dash::Cache`][dash-cache-struct] (Requires "dash" feature)
+//!     - [`dash::Cache`][dash-cache-struct] (Experimental, requires "dash" feature)
 //! - An asynchronous (futures aware) cache:
 //!     - [`future::Cache`][future-cache-struct] (Requires "future" feature)
 //! - A not thread-safe, blocking cache for single threaded applications:


### PR DESCRIPTION
This PR adds `iter` method to the `moka::dash::Cache`. This method returns an iterator of the cache, whose `next` method will return a reference to an entries in the cache.

* * *
Fixes #93