### PR TITLE
API stabilization: Smaller core cache API, prefer shorter names for common methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ Also `policy` method was added to all caches and `blocking` method was added to
 respectively. Some uncommon cache methods were moved to these structs, and old
 methods were removed without deprecating.
 
-Please see [#105](gh-pull-0105) for the complete list of the renamed and moved methods.
+Please see [#105][gh-pull-0105] for the complete list of the renamed and moved methods.
 
 ### Changed
 
 - API stabilization. (Smaller core cache API, shorter names for common methods)
-  ([#105](gh-pull-0105))
+  ([#105][gh-pull-0105])
 - Performance related:
     - Improve performance of `get_with` and `try_get_with`. ([#88][gh-pull-0088])
     - Avoid to calculate the same hash twice in `get`, `get_with`, `insert`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,44 @@
 
 ## Version 0.8.0
 
+As a part of stabilizing the cache API, the following cache methods have been renamed:
+
+- `get_or_insert_with(K, F)` → `get_with(K, F)`
+- `get_or_try_insert_with(K, F)` → `try_get_with(K, F)`
+
+Old methods are still available but marked as deprecated. They will be removed in a
+future version.
+
+Also `policy` method was added to all caches and `blocking` method was added to
+`future::Cache`. They return a `Policy` struct or `BlockingOp` struct
+respectively. Some uncommon cache methods were moved to these structs, and old
+methods were removed without deprecating.
+
+Please see [#105](gh-pull-0105) for the complete list of the renamed and moved methods.
+
+### Changed
+
+- API stabilization. (Smaller core cache API, shorter names for common methods)
+  ([#105](gh-pull-0105))
+- Performance related:
+    - Improve performance of `get_with` and `try_get_with`. ([#88][gh-pull-0088])
+    - Avoid to calculate the same hash twice in `get`, `get_with`, `insert`,
+      `invalidate`, etc. ([#90][gh-pull-0090])
+- Update the minimum versions of dependencies:
+    - crossbeam-channel to v0.5.4. ([#100][gh-pull-0100])
+    - scheduled-thread-pool to v0.2.5. ([#103][gh-pull-0103])
+    - (dev-dependency) skeptic to v0.13.5. ([#104][gh-pull-0104])
+
 ### Added
 
 #### Experimental Additions
 
-Please note that the following additions are highly experimental so their APIs will
-be frequently changed in next few releases.
-
 - Add a synchronous cache `moka::dash::Cache`, which uses `dashmap::DashMap` as the
   internal storage. ([#99][gh-pull-0099])
-- Add iterator to `moka::dash::Cache`. ([#101][gh-pull-0101]) 
+- Add iterator to `moka::dash::Cache`. ([#101][gh-pull-0101])
 
-### Changed
-
-- Performance related:
-    - Improve performance on `get_or_insert_with`. ([#88][gh-pull-0088])
-    - Avoid to calculate the same hash twice in `get`, `insert`, `invalidate`,
-      etc. ([#90][gh-pull-0090])
-- Update the minimum versions of dependencies:
-    - crossbeam-channel from v0.5.2 to v0.5.4. ([#100][gh-pull-0100])
-    - scheduled-thread-pool to v0.2.5. ([#103][gh-pull-0103]) 
-    - skeptic to v0.13.5. ([#104][gh-pull-0104])
+Please note that the above additions are highly experimental and their APIs will
+be frequently changed in next few releases.
 
 
 ## Version 0.7.2
@@ -261,6 +278,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0105]: https://github.com/moka-rs/moka/pull/105/
 [gh-pull-0104]: https://github.com/moka-rs/moka/pull/104/
 [gh-pull-0103]: https://github.com/moka-rs/moka/pull/103/
 [gh-pull-0101]: https://github.com/moka-rs/moka/pull/101/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ moka = { version = "0.8", features = ["future"] }
 
 The thread-safe, synchronous caches are defined in the `sync` module.
 
-Cache entries are manually added using `insert` or `get_or_insert_with` method, and
+Cache entries are manually added using `insert` or `get_with` method, and
 are stored in the cache until either evicted or manually invalidated.
 
 Here's an example of reading and updating a cache by using multiple threads:
@@ -162,9 +162,9 @@ fn main() {
 
 If you want to atomically initialize and insert a value when the key is not present,
 you might want to check [the document][doc-sync-cache] for other insertion methods
-`get_or_insert_with` and `get_or_try_insert_with`.
+`get_with` and `try_get_with`.
 
-[doc-sync-cache]: https://docs.rs/moka/*/moka/sync/struct.Cache.html#method.get_or_insert_with
+[doc-sync-cache]: https://docs.rs/moka/*/moka/sync/struct.Cache.html#method.get_with
 
 
 ## Example: Asynchronous Cache
@@ -255,9 +255,9 @@ async fn main() {
 
 If you want to atomically initialize and insert a value when the key is not present,
 you might want to check [the document][doc-future-cache] for other insertion methods
-`get_or_insert_with` and `get_or_try_insert_with`.
+`get_with` and `try_get_with`.
 
-[doc-future-cache]: https://docs.rs/moka/*/moka/future/struct.Cache.html#method.get_or_insert_with
+[doc-future-cache]: https://docs.rs/moka/*/moka/future/struct.Cache.html#method.get_with
 
 
 ## Avoiding to clone the value at `get`
@@ -473,7 +473,6 @@ $ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test \
     - e.g.
     - `get_or_insert_with(K, F)` → `get_with(K, F)`
     - `get_or_try_insert_with(K, F)` → `try_get_with(K, F)`
-    - `get(&Q)` → `get_if_present(&Q)`
     - `blocking_insert(K, V)` → `blocking().insert(K, V)`
     - `time_to_live()` → `config().time_to_live()`
 - [ ] Cache statistics. (Hit rate, etc.)

--- a/README.md
+++ b/README.md
@@ -468,13 +468,13 @@ $ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test \
 - [x] `async` optimized caches. (`v0.2.0`)
 - [x] Size-aware eviction. (`v0.7.0` via
       [#24](https://github.com/moka-rs/moka/pull/24))
-- [ ] API stabilization. (Smaller core cache API, shorter names for frequently
-      used methods)
+- [X] API stabilization. (Smaller core cache API, shorter names for frequently
+      used methods) (`v0.8.0` via [#105](https://github.com/moka-rs/moka/pull/105))
     - e.g.
     - `get_or_insert_with(K, F)` → `get_with(K, F)`
     - `get_or_try_insert_with(K, F)` → `try_get_with(K, F)`
     - `blocking_insert(K, V)` → `blocking().insert(K, V)`
-    - `time_to_live()` → `config().time_to_live()`
+    - `time_to_live()` → `policy().time_to_live()`
 - [ ] Cache statistics. (Hit rate, etc.)
 - [ ] Notifications on eviction, etc.
 - [ ] Upgrade TinyLFU to Window-TinyLFU. ([details][tiny-lfu])

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -14,6 +14,7 @@ use crate::{
         housekeeper::{Housekeeper, InnerSync, SyncPace},
         AccessTime, KeyDate, KeyHash, KeyHashDate, KvEntry, ReadOp, ValueEntry, Weigher, WriteOp,
     },
+    Policy,
 };
 
 use crossbeam_channel::{Receiver, Sender, TrySendError};
@@ -185,16 +186,8 @@ where
         self.inner.set_valid_after(now);
     }
 
-    pub(crate) fn max_capacity(&self) -> Option<usize> {
-        self.inner.max_capacity()
-    }
-
-    pub(crate) fn time_to_live(&self) -> Option<Duration> {
-        self.inner.time_to_live()
-    }
-
-    pub(crate) fn time_to_idle(&self) -> Option<Duration> {
-        self.inner.time_to_idle()
+    pub(crate) fn policy(&self) -> Policy {
+        self.inner.policy()
     }
 
     #[cfg(test)]
@@ -516,8 +509,8 @@ where
             .map(|(key, entry)| KvEntry::new(key, entry))
     }
 
-    fn max_capacity(&self) -> Option<usize> {
-        self.max_capacity.map(|n| n as usize)
+    fn policy(&self) -> Policy {
+        Policy::new(self.max_capacity, 1, self.time_to_live, self.time_to_idle)
     }
 
     #[inline]

--- a/src/dash/builder.rs
+++ b/src/dash/builder.rs
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(policy.time_to_idle(), None);
 
         cache.insert('a', "Alice");
-        assert_eq!(cache.get_if_present(&'a'), Some("Alice"));
+        assert_eq!(cache.get(&'a'), Some("Alice"));
 
         let cache = CacheBuilder::new(100)
             .time_to_live(Duration::from_secs(45 * 60))
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(policy.time_to_idle(), Some(Duration::from_secs(15 * 60)));
 
         cache.insert('a', "Alice");
-        assert_eq!(cache.get_if_present(&'a'), Some("Alice"));
+        assert_eq!(cache.get(&'a'), Some("Alice"));
     }
 
     #[test]

--- a/src/dash/builder.rs
+++ b/src/dash/builder.rs
@@ -33,7 +33,7 @@ use std::{
 /// cache.insert(0, "zero");
 ///
 /// // This get() will extend the entry life for another 5 minutes.
-/// cache.get_if_present(&0);
+/// cache.get(&0);
 ///
 /// // Even though we keep calling get(), the entry will expire
 /// // after 30 minutes (TTL) from the insert().

--- a/src/dash/builder.rs
+++ b/src/dash/builder.rs
@@ -202,10 +202,11 @@ mod tests {
     fn build_cache() {
         // Cache<char, String>
         let cache = CacheBuilder::new(100).build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), None);
-        assert_eq!(cache.time_to_idle(), None);
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), None);
+        assert_eq!(policy.time_to_idle(), None);
 
         cache.insert('a', "Alice");
         assert_eq!(cache.get_if_present(&'a'), Some("Alice"));
@@ -214,10 +215,11 @@ mod tests {
             .time_to_live(Duration::from_secs(45 * 60))
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
-        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(policy.time_to_idle(), Some(Duration::from_secs(15 * 60)));
 
         cache.insert('a', "Alice");
         assert_eq!(cache.get_if_present(&'a'), Some("Alice"));

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -2,7 +2,10 @@ use super::{
     base_cache::{BaseCache, HouseKeeperArc, MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
     CacheBuilder, ConcurrentCacheExt, Iter,
 };
-use crate::sync::{housekeeper::InnerSync, Weigher, WriteOp};
+use crate::{
+    sync::{housekeeper::InnerSync, Weigher, WriteOp},
+    Policy,
+};
 
 use crossbeam_channel::{Sender, TrySendError};
 use std::{
@@ -380,19 +383,12 @@ where
         self.base.invalidate_all();
     }
 
-    /// Returns the `max_capacity` of this cache.
-    pub fn max_capacity(&self) -> Option<usize> {
-        self.base.max_capacity()
-    }
-
-    /// Returns the `time_to_live` of this cache.
-    pub fn time_to_live(&self) -> Option<Duration> {
-        self.base.time_to_live()
-    }
-
-    /// Returns the `time_to_idle` of this cache.
-    pub fn time_to_idle(&self) -> Option<Duration> {
-        self.base.time_to_idle()
+    /// Returns a read-only cache policy of this cache.
+    ///
+    /// At this time, cache policy cannot be modified after cache creation.
+    /// A future version may support to modify it.
+    pub fn policy(&self) -> Policy {
+        self.base.policy()
     }
 
     #[cfg(test)]

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -341,7 +341,7 @@ where
 
     /// Deprecated, replaced with [`get`](#method.get)
     #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Replaced with `get_with`")]
+    #[deprecated(since = "0.8.0", note = "Replaced with `get`")]
     pub fn get_if_present<Q>(&self, key: &Q) -> Option<V>
     where
         Arc<K>: Borrow<Q>,

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -20,10 +20,10 @@ use std::{
 /// **Experimental**: A thread-safe concurrent in-memory cache built upon
 /// [`dashmap::DashMap`][dashmap].
 ///
-/// Unlike `sync` and `future` caches of Moka, `dash` cache does not provide full
-/// concurrency of retrievals and updates. This is because `dash` cache uses
-/// `DashMap` as the central key-value storage, which employs read-write locks on
-/// internal shards. Other caches use a lock-free concurrent hash table.
+/// The `dash::Cache` uses `DashMap` as the central key-value storage, while other
+/// `sync` and `future` caches are using a lock-free concurrent hash table.
+/// Since `DashMap` employs read-write locks on internal shards, it will have lower
+/// concurrency on retrievals and updates than other caches.
 ///
 /// On the other hand, `dash` cache provides iterator, which returns immutable
 /// references to the entries in a cache. Other caches do not provide iterator.
@@ -181,7 +181,7 @@ use std::{
 /// cache.insert(0, "zero");
 ///
 /// // This get() will extend the entry life for another 5 minutes.
-/// cache.get_if_present(&0);
+/// cache.get(&0);
 ///
 /// // Even though we keep calling get(), the entry will expire
 /// // after 30 minutes (TTL) from the insert().
@@ -286,8 +286,8 @@ where
         Self::with_everything(Some(max_capacity), None, build_hasher, None, None, None)
     }
 
-    /// Returns a [`CacheBuilder`][builder-struct], which can builds a `Cache` or
-    /// `SegmentedCache` with various configuration knobs.
+    /// Returns a [`CacheBuilder`][builder-struct], which can builds a `Cache` with
+    /// various configuration knobs.
     ///
     /// [builder-struct]: ./struct.CacheBuilder.html
     pub fn builder() -> CacheBuilder<K, V, Cache<K, V, RandomState>> {

--- a/src/future.rs
+++ b/src/future.rs
@@ -8,7 +8,7 @@ mod cache;
 mod value_initializer;
 
 pub use builder::CacheBuilder;
-pub use cache::Cache;
+pub use cache::{BlockingOp, Cache};
 
 /// Provides extra methods that will be useful for testing.
 pub trait ConcurrentCacheExt<K, V> {

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -224,11 +224,12 @@ mod tests {
     async fn build_cache() {
         // Cache<char, String>
         let cache = CacheBuilder::new(100).build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), None);
-        assert_eq!(cache.time_to_idle(), None);
-        assert_eq!(cache.num_segments(), 1);
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), None);
+        assert_eq!(policy.time_to_idle(), None);
+        assert_eq!(policy.num_segments(), 1);
 
         cache.insert('a', "Alice").await;
         assert_eq!(cache.get(&'a'), Some("Alice"));
@@ -237,11 +238,12 @@ mod tests {
             .time_to_live(Duration::from_secs(45 * 60))
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
-        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
-        assert_eq!(cache.num_segments(), 1);
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(policy.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(policy.num_segments(), 1);
 
         cache.insert('a', "Alice").await;
         assert_eq!(cache.get(&'a'), Some("Alice"));

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -681,7 +681,8 @@ where
     }
 
     /// Returns a `BlockingOp` for this cache. It provides blocking
-    /// [insert]() and [invalidate]() methods, which can be called outside
+    /// [insert](#method.insert) and [invalidate](#method.invalidate) methods, which
+    /// can be called outside of asynchronous contexts.
     pub fn blocking(&self) -> BlockingOp<'_, K, V, S> {
         BlockingOp(self)
     }
@@ -876,7 +877,7 @@ where
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
-    /// Blocking [insert](../struct.Cache.html#method.insert) to call outside of
+    /// Blocking [insert](./struct.Cache.html#method.insert) to call outside of
     /// asynchronous contexts.
     ///
     /// This method is intended for use cases where you are inserting from
@@ -885,7 +886,7 @@ where
         self.0.do_blocking_insert(key, value)
     }
 
-    /// Blocking [invalidate](../struct.Cache.html#method.invalidate) to call outside
+    /// Blocking [invalidate](./struct.Cache.html#method.invalidate) to call outside
     /// of asynchronous contexts.
     ///
     /// This method is intended for use cases where you are invalidating from

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -8,7 +8,7 @@ use crate::{
         housekeeper::InnerSync,
         PredicateId, Weigher, WriteOp,
     },
-    PredicateError,
+    Policy, PredicateError,
 };
 
 #[cfg(feature = "unstable-debug-counters")]
@@ -43,7 +43,7 @@ use std::{
 /// cache until either evicted or manually invalidated:
 ///
 /// - Inside an async context (`async fn` or `async` block), use
-///   [`insert`](#method.insert), [`get_or_insert_with`](#method.get_or_insert_with)
+///   [`insert`](#method.insert), [`get_with`](#method.get_with)
 ///   or [`invalidate`](#method.invalidate) methods for updating the cache and `await`
 ///   them.
 /// - Outside any async context, use [`blocking_insert`](#method.blocking_insert) or
@@ -120,8 +120,8 @@ use std::{
 ///
 /// If you want to atomically initialize and insert a value when the key is not
 /// present, you might want to check other insertion methods
-/// [`get_or_insert_with`](#method.get_or_insert_with) and
-/// [`get_or_try_insert_with`](#method.get_or_try_insert_with).
+/// [`get_with`](#method.get_with) and
+/// [`try_get_with`](#method.try_get_with).
 ///
 /// # Avoiding to clone the value at `get`
 ///
@@ -380,6 +380,22 @@ where
         self.base.get_with_hash(key, self.base.hash(key))
     }
 
+    /// Deprecated, replaced with [`get_with`](#method.get_with)
+    #[deprecated(since = "0.8.0", note = "Replaced with `get_with`")]
+    pub async fn get_or_insert_with(&self, key: K, init: impl Future<Output = V>) -> V {
+        self.get_with(key, init).await
+    }
+
+    /// Deprecated, replaced with [`try_get_with`](#method.try_get_with)
+    #[deprecated(since = "0.8.0", note = "Replaced with `try_get_with`")]
+    pub async fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
+    where
+        F: Future<Output = Result<V, E>>,
+        E: Send + Sync + 'static,
+    {
+        self.try_get_with(key, init).await
+    }
+
     /// Ensures the value of the key exists by inserting the output of the init
     /// future if not exist, and returns a _clone_ of the value.
     ///
@@ -413,10 +429,10 @@ where
     ///                 println!("Task {} started.", task_id);
     ///
     ///                 // Insert and get the value for key1. Although all four async tasks
-    ///                 // will call `get_or_insert_with` at the same time, the `init` async
+    ///                 // will call `get_with` at the same time, the `init` async
     ///                 // block must be resolved only once.
     ///                 let value = my_cache
-    ///                     .get_or_insert_with("key1", async move {
+    ///                     .get_with("key1", async move {
     ///                         println!("Task {} inserting a value.", task_id);
     ///                         Arc::new(vec![0u8; TEN_MIB])
     ///                     })
@@ -461,10 +477,7 @@ where
     /// 0, 1 and 2 above), this method will restart and resolve one of the remaining
     /// `init` futures.
     ///
-    pub async fn get_or_insert_with<F>(&self, key: K, init: F) -> V
-    where
-        F: Future<Output = V>,
-    {
+    pub async fn get_with(&self, key: K, init: impl Future<Output = V>) -> V {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
         self.get_or_insert_with_hash_and_fun(key, hash, init).await
@@ -509,10 +522,10 @@ where
     ///                 println!("Task {} started.", task_id);
     ///
     ///                 // Try to insert and get the value for key1. Although
-    ///                 // all four async tasks will call `get_or_try_insert_with`
+    ///                 // all four async tasks will call `try_get_with`
     ///                 // at the same time, get_html() must be called only once.
     ///                 let value = my_cache
-    ///                     .get_or_try_insert_with(
+    ///                     .try_get_with(
     ///                         "key1",
     ///                         get_html(task_id, "https://www.rust-lang.org"),
     ///                     ).await;
@@ -560,7 +573,7 @@ where
     /// 0, 1 and 3 above), this method will restart and resolve one of the remaining
     /// `init` futures.
     ///
-    pub async fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
+    pub async fn try_get_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
     where
         F: Future<Output = Result<V, E>>,
         E: Send + Sync + 'static,
@@ -676,26 +689,12 @@ where
         self.base.invalidate_entries_if(Arc::new(predicate))
     }
 
-    /// Returns the `max_capacity` of this cache.
-    pub fn max_capacity(&self) -> Option<usize> {
-        self.base.max_capacity()
-    }
-
-    /// Returns the `time_to_live` of this cache.
-    pub fn time_to_live(&self) -> Option<Duration> {
-        self.base.time_to_live()
-    }
-
-    /// Returns the `time_to_idle` of this cache.
-    pub fn time_to_idle(&self) -> Option<Duration> {
-        self.base.time_to_idle()
-    }
-
-    /// Returns the number of internal segments of this cache.
+    /// Returns a read-only cache policy of this cache.
     ///
-    /// `Cache` always returns `1`.
-    pub fn num_segments(&self) -> usize {
-        1
+    /// At this time, cache policy cannot be modified after cache creation.
+    /// A future version may support to modify it.
+    pub fn policy(&self) -> Policy {
+        self.base.policy()
     }
 
     #[cfg(feature = "unstable-debug-counters")]
@@ -1289,21 +1288,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_or_insert_with() {
+    async fn get_with() {
         let cache = Cache::new(100);
         const KEY: u32 = 0;
 
         // This test will run five async tasks:
         //
-        // Task1 will be the first task to call `get_or_insert_with` for a key, so
+        // Task1 will be the first task to call `get_with` for a key, so
         // its async block will be evaluated and then a &str value "task1" will be
         // inserted to the cache.
         let task1 = {
             let cache1 = cache.clone();
             async move {
-                // Call `get_or_insert_with` immediately.
+                // Call `get_with` immediately.
                 let v = cache1
-                    .get_or_insert_with(KEY, async {
+                    .get_with(KEY, async {
                         // Wait for 300 ms and return a &str value.
                         Timer::after(Duration::from_millis(300)).await;
                         "task1"
@@ -1313,22 +1312,20 @@ mod tests {
             }
         };
 
-        // Task2 will be the second task to call `get_or_insert_with` for the same
+        // Task2 will be the second task to call `get_with` for the same
         // key, so its async block will not be evaluated. Once task1's async block
         // finishes, it will get the value inserted by task1's async block.
         let task2 = {
             let cache2 = cache.clone();
             async move {
-                // Wait for 100 ms before calling `get_or_insert_with`.
+                // Wait for 100 ms before calling `get_with`.
                 Timer::after(Duration::from_millis(100)).await;
-                let v = cache2
-                    .get_or_insert_with(KEY, async { unreachable!() })
-                    .await;
+                let v = cache2.get_with(KEY, async { unreachable!() }).await;
                 assert_eq!(v, "task1");
             }
         };
 
-        // Task3 will be the third task to call `get_or_insert_with` for the same
+        // Task3 will be the third task to call `get_with` for the same
         // key. By the time it calls, task1's async block should have finished
         // already and the value should be already inserted to the cache. So its
         // async block will not be evaluated and will get the value insert by task1's
@@ -1336,11 +1333,9 @@ mod tests {
         let task3 = {
             let cache3 = cache.clone();
             async move {
-                // Wait for 400 ms before calling `get_or_insert_with`.
+                // Wait for 400 ms before calling `get_with`.
                 Timer::after(Duration::from_millis(400)).await;
-                let v = cache3
-                    .get_or_insert_with(KEY, async { unreachable!() })
-                    .await;
+                let v = cache3.get_with(KEY, async { unreachable!() }).await;
                 assert_eq!(v, "task1");
             }
         };
@@ -1373,7 +1368,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_or_try_insert_with() {
+    async fn try_get_with() {
         use std::sync::Arc;
 
         // Note that MyError does not implement std::error::Error trait
@@ -1388,15 +1383,15 @@ mod tests {
 
         // This test will run eight async tasks:
         //
-        // Task1 will be the first task to call `get_or_insert_with` for a key, so
+        // Task1 will be the first task to call `get_with` for a key, so
         // its async block will be evaluated and then an error will be returned.
         // Nothing will be inserted to the cache.
         let task1 = {
             let cache1 = cache.clone();
             async move {
-                // Call `get_or_try_insert_with` immediately.
+                // Call `try_get_with` immediately.
                 let v = cache1
-                    .get_or_try_insert_with(KEY, async {
+                    .try_get_with(KEY, async {
                         // Wait for 300 ms and return an error.
                         Timer::after(Duration::from_millis(300)).await;
                         Err(MyError("task1 error".into()))
@@ -1406,23 +1401,21 @@ mod tests {
             }
         };
 
-        // Task2 will be the second task to call `get_or_insert_with` for the same
+        // Task2 will be the second task to call `get_with` for the same
         // key, so its async block will not be evaluated. Once task1's async block
         // finishes, it will get the same error value returned by task1's async
         // block.
         let task2 = {
             let cache2 = cache.clone();
             async move {
-                // Wait for 100 ms before calling `get_or_try_insert_with`.
+                // Wait for 100 ms before calling `try_get_with`.
                 Timer::after(Duration::from_millis(100)).await;
-                let v: MyResult<_> = cache2
-                    .get_or_try_insert_with(KEY, async { unreachable!() })
-                    .await;
+                let v: MyResult<_> = cache2.try_get_with(KEY, async { unreachable!() }).await;
                 assert!(v.is_err());
             }
         };
 
-        // Task3 will be the third task to call `get_or_insert_with` for the same
+        // Task3 will be the third task to call `get_with` for the same
         // key. By the time it calls, task1's async block should have finished
         // already, but the key still does not exist in the cache. So its async block
         // will be evaluated and then an okay &str value will be returned. That value
@@ -1430,10 +1423,10 @@ mod tests {
         let task3 = {
             let cache3 = cache.clone();
             async move {
-                // Wait for 400 ms before calling `get_or_try_insert_with`.
+                // Wait for 400 ms before calling `try_get_with`.
                 Timer::after(Duration::from_millis(400)).await;
                 let v: MyResult<_> = cache3
-                    .get_or_try_insert_with(KEY, async {
+                    .try_get_with(KEY, async {
                         // Wait for 300 ms and return an Ok(&str) value.
                         Timer::after(Duration::from_millis(300)).await;
                         Ok("task3")
@@ -1443,22 +1436,20 @@ mod tests {
             }
         };
 
-        // Task4 will be the fourth task to call `get_or_insert_with` for the same
+        // Task4 will be the fourth task to call `get_with` for the same
         // key. So its async block will not be evaluated. Once task3's async block
         // finishes, it will get the same okay &str value.
         let task4 = {
             let cache4 = cache.clone();
             async move {
-                // Wait for 500 ms before calling `get_or_try_insert_with`.
+                // Wait for 500 ms before calling `try_get_with`.
                 Timer::after(Duration::from_millis(500)).await;
-                let v: MyResult<_> = cache4
-                    .get_or_try_insert_with(KEY, async { unreachable!() })
-                    .await;
+                let v: MyResult<_> = cache4.try_get_with(KEY, async { unreachable!() }).await;
                 assert_eq!(v.unwrap(), "task3");
             }
         };
 
-        // Task5 will be the fifth task to call `get_or_insert_with` for the same
+        // Task5 will be the fifth task to call `get_with` for the same
         // key. So its async block will not be evaluated. By the time it calls,
         // task3's async block should have finished already, so its async block will
         // not be evaluated and will get the value insert by task3's async block
@@ -1466,11 +1457,9 @@ mod tests {
         let task5 = {
             let cache5 = cache.clone();
             async move {
-                // Wait for 800 ms before calling `get_or_try_insert_with`.
+                // Wait for 800 ms before calling `try_get_with`.
                 Timer::after(Duration::from_millis(800)).await;
-                let v: MyResult<_> = cache5
-                    .get_or_try_insert_with(KEY, async { unreachable!() })
-                    .await;
+                let v: MyResult<_> = cache5.try_get_with(KEY, async { unreachable!() }).await;
                 assert_eq!(v.unwrap(), "task3");
             }
         };
@@ -1516,7 +1505,7 @@ mod tests {
 
     #[tokio::test]
     // https://github.com/moka-rs/moka/issues/43
-    async fn handle_panic_in_get_or_insert_with() {
+    async fn handle_panic_in_get_with() {
         use tokio::time::{sleep, Duration};
 
         let cache = Cache::new(16);
@@ -1526,21 +1515,21 @@ mod tests {
             let semaphore_ref = semaphore.clone();
             tokio::task::spawn(async move {
                 let _ = cache_ref
-                    .get_or_insert_with(1, async move {
+                    .get_with(1, async move {
                         semaphore_ref.add_permits(1);
                         sleep(Duration::from_millis(50)).await;
-                        panic!("Panic during get_or_try_insert_with");
+                        panic!("Panic during try_get_with");
                     })
                     .await;
             });
         }
         let _ = semaphore.acquire().await.expect("semaphore acquire failed");
-        assert_eq!(cache.get_or_insert_with(1, async { 5 }).await, 5);
+        assert_eq!(cache.get_with(1, async { 5 }).await, 5);
     }
 
     #[tokio::test]
     // https://github.com/moka-rs/moka/issues/43
-    async fn handle_panic_in_get_or_try_insert_with() {
+    async fn handle_panic_in_try_get_with() {
         use tokio::time::{sleep, Duration};
 
         let cache = Cache::new(16);
@@ -1550,24 +1539,24 @@ mod tests {
             let semaphore_ref = semaphore.clone();
             tokio::task::spawn(async move {
                 let _ = cache_ref
-                    .get_or_try_insert_with(1, async move {
+                    .try_get_with(1, async move {
                         semaphore_ref.add_permits(1);
                         sleep(Duration::from_millis(50)).await;
-                        panic!("Panic during get_or_try_insert_with");
+                        panic!("Panic during try_get_with");
                     })
                     .await as Result<_, Arc<Infallible>>;
             });
         }
         let _ = semaphore.acquire().await.expect("semaphore acquire failed");
         assert_eq!(
-            cache.get_or_try_insert_with(1, async { Ok(5) }).await as Result<_, Arc<Infallible>>,
+            cache.try_get_with(1, async { Ok(5) }).await as Result<_, Arc<Infallible>>,
             Ok(5)
         );
     }
 
     #[tokio::test]
     // https://github.com/moka-rs/moka/issues/59
-    async fn abort_get_or_insert_with() {
+    async fn abort_get_with() {
         use tokio::time::{sleep, Duration};
 
         let cache = Cache::new(16);
@@ -1580,7 +1569,7 @@ mod tests {
 
             handle = tokio::task::spawn(async move {
                 let _ = cache_ref
-                    .get_or_insert_with(1, async move {
+                    .get_with(1, async move {
                         semaphore_ref.add_permits(1);
                         sleep(Duration::from_millis(50)).await;
                         unreachable!();
@@ -1592,12 +1581,12 @@ mod tests {
         let _ = semaphore.acquire().await.expect("semaphore acquire failed");
         handle.abort();
 
-        assert_eq!(cache.get_or_insert_with(1, async { 5 }).await, 5);
+        assert_eq!(cache.get_with(1, async { 5 }).await, 5);
     }
 
     #[tokio::test]
     // https://github.com/moka-rs/moka/issues/59
-    async fn abort_get_or_try_insert_with() {
+    async fn abort_try_get_with() {
         use tokio::time::{sleep, Duration};
 
         let cache = Cache::new(16);
@@ -1610,7 +1599,7 @@ mod tests {
 
             handle = tokio::task::spawn(async move {
                 let _ = cache_ref
-                    .get_or_try_insert_with(1, async move {
+                    .try_get_with(1, async move {
                         semaphore_ref.add_permits(1);
                         sleep(Duration::from_millis(50)).await;
                         unreachable!();
@@ -1623,7 +1612,7 @@ mod tests {
         handle.abort();
 
         assert_eq!(
-            cache.get_or_try_insert_with(1, async { Ok(5) }).await as Result<_, Arc<Infallible>>,
+            cache.try_get_with(1, async { Ok(5) }).await as Result<_, Arc<Infallible>>,
             Ok(5)
         );
     }

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -214,8 +214,8 @@ where
                             // Retry from the beginning.
                             continue;
                         }
-                        // Somebody else (a future containing `get_or_insert_with`/
-                        // `get_or_try_insert_with`) has been aborted.
+                        // Somebody else (a future containing `get_with`/`try_get_with`)
+                        // has been aborted.
                         WaiterValue::EnclosingFutureAborted => {
                             retries += 1;
                             panic_if_retry_exhausted_for_aborting(retries, MAX_RETRIES);
@@ -273,8 +273,8 @@ fn panic_if_retry_exhausted_for_aborting(retries: usize, max: usize) {
     if retries >= max {
         panic!(
             "Too many retries. Tried to read the return value from the `init` future \
-    but failed {} times. Maybe the future containing `get_or_insert_with`/\
-    `get_or_try_insert_with` kept being aborted?",
+    but failed {} times. Maybe the future containing `get_with`/`try_get_with` \
+    kept being aborted?",
             retries
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,8 +165,10 @@ pub mod unsync;
 
 pub(crate) mod cht;
 pub(crate) mod common;
+pub(crate) mod policy;
 
 pub use common::error::PredicateError;
+pub use policy::Policy;
 
 #[cfg(feature = "unstable-debug-counters")]
 pub use sync::debug_counters::GlobalDebugCounters;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,54 @@
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+/// The policy of a cache.
+pub struct Policy {
+    max_capacity: Option<u64>,
+    num_segments: usize,
+    time_to_live: Option<Duration>,
+    time_to_idle: Option<Duration>,
+}
+
+impl Policy {
+    pub(crate) fn new(
+        max_capacity: Option<u64>,
+        num_segments: usize,
+        time_to_live: Option<Duration>,
+        time_to_idle: Option<Duration>,
+    ) -> Self {
+        Self {
+            max_capacity,
+            num_segments,
+            time_to_live,
+            time_to_idle,
+        }
+    }
+
+    /// Returns the `max_capacity` of the cache.
+    pub fn max_capacity(&self) -> Option<u64> {
+        self.max_capacity
+    }
+
+    pub(crate) fn set_max_capacity(&mut self, capacity: Option<u64>) {
+        self.max_capacity = capacity;
+    }
+
+    /// Returns the number of internal segments of the cache.
+    pub fn num_segments(&self) -> usize {
+        self.num_segments
+    }
+
+    pub(crate) fn set_num_segments(&mut self, num: usize) {
+        self.num_segments = num;
+    }
+
+    /// Returns the `time_to_live` of the cache.
+    pub fn time_to_live(&self) -> Option<Duration> {
+        self.time_to_live
+    }
+
+    /// Returns the `time_to_idle` of the cache.
+    pub fn time_to_idle(&self) -> Option<Duration> {
+        self.time_to_idle
+    }
+}

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -19,7 +19,7 @@ use crate::{
         time::{CheckedTimeOps, Clock, Instant},
         CacheRegion,
     },
-    PredicateError,
+    Policy, PredicateError,
 };
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use crossbeam_utils::atomic::AtomicCell;
@@ -208,16 +208,8 @@ where
         self.inner.register_invalidation_predicate(predicate, now)
     }
 
-    pub(crate) fn max_capacity(&self) -> Option<usize> {
-        self.inner.max_capacity()
-    }
-
-    pub(crate) fn time_to_live(&self) -> Option<Duration> {
-        self.inner.time_to_live()
-    }
-
-    pub(crate) fn time_to_idle(&self) -> Option<Duration> {
-        self.inner.time_to_idle()
+    pub(crate) fn policy(&self) -> Policy {
+        self.inner.policy()
     }
 
     #[cfg(feature = "unstable-debug-counters")]
@@ -583,8 +575,8 @@ where
             .map(|(key, entry)| KvEntry::new(key, entry))
     }
 
-    fn max_capacity(&self) -> Option<usize> {
-        self.max_capacity.map(|n| n as usize)
+    fn policy(&self) -> Policy {
+        Policy::new(self.max_capacity, 1, self.time_to_live, self.time_to_idle)
     }
 
     #[inline]

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -305,11 +305,12 @@ mod tests {
     fn build_cache() {
         // Cache<char, String>
         let cache = CacheBuilder::new(100).build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), None);
-        assert_eq!(cache.time_to_idle(), None);
-        assert_eq!(cache.num_segments(), 1);
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), None);
+        assert_eq!(policy.time_to_idle(), None);
+        assert_eq!(policy.num_segments(), 1);
 
         cache.insert('a', "Alice");
         assert_eq!(cache.get(&'a'), Some("Alice"));
@@ -318,11 +319,12 @@ mod tests {
             .time_to_live(Duration::from_secs(45 * 60))
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
+        let config = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
-        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
-        assert_eq!(cache.num_segments(), 1);
+        assert_eq!(config.max_capacity(), Some(100));
+        assert_eq!(config.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(config.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(config.num_segments(), 1);
 
         cache.insert('a', "Alice");
         assert_eq!(cache.get(&'a'), Some("Alice"));
@@ -332,11 +334,12 @@ mod tests {
     fn build_segmented_cache() {
         // SegmentCache<char, String>
         let cache = CacheBuilder::new(100).segments(16).build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), None);
-        assert_eq!(cache.time_to_idle(), None);
-        assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), None);
+        assert_eq!(policy.time_to_idle(), None);
+        assert_eq!(policy.num_segments(), 16_usize.next_power_of_two());
 
         cache.insert('b', "Bob");
         assert_eq!(cache.get(&'b'), Some("Bob"));
@@ -346,11 +349,12 @@ mod tests {
             .time_to_live(Duration::from_secs(45 * 60))
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
-        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
-        assert_eq!(cache.num_segments(), 16_usize.next_power_of_two());
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(policy.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(policy.num_segments(), 16_usize.next_power_of_two());
 
         cache.insert('b', "Bob");
         assert_eq!(cache.get(&'b'), Some("Bob"));

--- a/src/unsync/builder.rs
+++ b/src/unsync/builder.rs
@@ -193,10 +193,11 @@ mod tests {
     async fn build_cache() {
         // Cache<char, String>
         let mut cache = CacheBuilder::new(100).build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), None);
-        assert_eq!(cache.time_to_idle(), None);
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), None);
+        assert_eq!(policy.time_to_idle(), None);
 
         cache.insert('a', "Alice");
         assert_eq!(cache.get(&'a'), Some(&"Alice"));
@@ -205,10 +206,11 @@ mod tests {
             .time_to_live(Duration::from_secs(45 * 60))
             .time_to_idle(Duration::from_secs(15 * 60))
             .build();
+        let policy = cache.policy();
 
-        assert_eq!(cache.max_capacity(), Some(100));
-        assert_eq!(cache.time_to_live(), Some(Duration::from_secs(45 * 60)));
-        assert_eq!(cache.time_to_idle(), Some(Duration::from_secs(15 * 60)));
+        assert_eq!(policy.max_capacity(), Some(100));
+        assert_eq!(policy.time_to_live(), Some(Duration::from_secs(45 * 60)));
+        assert_eq!(policy.time_to_idle(), Some(Duration::from_secs(15 * 60)));
 
         cache.insert('a', "Alice");
         assert_eq!(cache.get(&'a'), Some(&"Alice"));

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1,10 +1,13 @@
 use super::{deques::Deques, AccessTime, CacheBuilder, KeyDate, KeyHashDate, ValueEntry, Weigher};
-use crate::common::{
-    self,
-    deque::{DeqNode, Deque},
-    frequency_sketch::FrequencySketch,
-    time::{CheckedTimeOps, Clock, Instant},
-    CacheRegion,
+use crate::{
+    common::{
+        self,
+        deque::{DeqNode, Deque},
+        frequency_sketch::FrequencySketch,
+        time::{CheckedTimeOps, Clock, Instant},
+        CacheRegion,
+    },
+    Policy,
 };
 
 use smallvec::SmallVec;
@@ -361,19 +364,12 @@ where
         self.saturating_sub_from_total_weight(invalidated);
     }
 
-    /// Returns the `max_capacity` of this cache.
-    pub fn max_capacity(&self) -> Option<usize> {
-        self.max_capacity.map(|n| n as usize)
-    }
-
-    /// Returns the `time_to_live` of this cache.
-    pub fn time_to_live(&self) -> Option<Duration> {
-        self.time_to_live
-    }
-
-    /// Returns the `time_to_idle` of this cache.
-    pub fn time_to_idle(&self) -> Option<Duration> {
-        self.time_to_idle
+    /// Returns a read-only cache policy of this cache.
+    ///
+    /// At this time, cache policy cannot be modified after cache creation.
+    /// A future version may support to modify it.
+    pub fn policy(&self) -> Policy {
+        Policy::new(self.max_capacity, 1, self.time_to_live, self.time_to_idle)
     }
 }
 


### PR DESCRIPTION
Rename the following cache methods, and make the methods with old names deprecated:

- `get_or_insert_with(K, F)` → `get_with(K, F)`
- `get_or_try_insert_with(K, F)` → `try_get_with(K, F)`

Add `policy()` method to caches returning a cache `Policy` struct. Move the following cache methods to it:
- `max_capacity()` → `policy().max_capacity()`
- `num_segments()` → `policy().num_segments()`
- `time_to_live()` → `policy().time_to_live()`
- `time_to_idle()` → `policy().time_to_idle()`

Add `blocking()` method to `future::Cache` returning a `BlockingOp` struct. Move the following cache methods to it:

- `blocking_insert(K, V)` → `blocking().insert(K, V)`
- `blocking_invalidate(K, V)` → `blocking().invalidate(K, V)`
