### PR TITLE
CI: Fix the code coverage job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,12 @@ jobs:
           name: Run cargo tarpaulin (Allowing a failure)
           command: |
             docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin \
-              cargo tarpaulin -v \
-                --features 'future, dash' \
-                --ciserver circle-ci \
-                --coveralls ${COVERALLS_TOKEN} \
-                --timeout 600 \
+              RUSTFLAGS='--cfg circleci' \
+                cargo tarpaulin -v \
+                  --features 'future, dash' \
+                  --ciserver circle-ci \
+                  --coveralls ${COVERALLS_TOKEN} \
+                  --timeout 600 \
             || true
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,21 @@
 version: 2
 jobs:
   rust/coverage:
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run:
           name: Run cargo tarpaulin (Allowing a failure)
           command: |
-            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin \
-              RUSTFLAGS='--cfg circleci' \
-                cargo tarpaulin -v \
-                  --features 'future, dash' \
-                  --ciserver circle-ci \
-                  --coveralls ${COVERALLS_TOKEN} \
-                  --timeout 600 \
+            docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" \
+              --env RUSTFLAGS='--cfg circleci' \
+              xd009642/tarpaulin \
+              cargo tarpaulin -v \
+                --features 'future, dash' \
+                --ciserver circle-ci \
+                --coveralls ${COVERALLS_TOKEN} \
+                --timeout 600 \
             || true
 
 workflows:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "ahash",
         "armv",
         "benmanes",
+        "circleci",
         "CLFU",
         "clippy",
         "compat",

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -1318,10 +1318,15 @@ mod tests {
             ensure_sketch_len(pot16, pot16, "pot16");
             // due to ceiling to next_power_of_two
             ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
-            // due to ceiling to next_power_of_two
-            ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
-            ensure_sketch_len(pot30, pot30, "pot30");
-            ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+
+            // The following tests will allocate large memory (~8GiB).
+            // Skip when running on Circle CI.
+            if !cfg!(circleci) {
+                // due to ceiling to next_power_of_two
+                ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
+                ensure_sketch_len(pot30, pot30, "pot30");
+                ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+            }
         };
     }
 }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -1534,10 +1534,15 @@ mod tests {
             ensure_sketch_len(pot16, pot16, "pot16");
             // due to ceiling to next_power_of_two
             ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
-            // due to ceiling to next_power_of_two
-            ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
-            ensure_sketch_len(pot30, pot30, "pot30");
-            ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+
+            // The following tests will allocate large memory (~8GiB).
+            // Skip when running on Circle CI.
+            if !cfg!(circleci) {
+                // due to ceiling to next_power_of_two
+                ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
+                ensure_sketch_len(pot30, pot30, "pot30");
+                ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+            }
         };
     }
 }

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1218,10 +1218,15 @@ mod tests {
             ensure_sketch_len(pot16, pot16, "pot16");
             // due to ceiling to next_power_of_two
             ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
-            // due to ceiling to next_power_of_two
-            ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
-            ensure_sketch_len(pot30, pot30, "pot30");
-            ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+
+            // The following tests will allocate large memory (~8GiB).
+            // Skip when running on Circle CI.
+            if !cfg!(circleci) {
+                // due to ceiling to next_power_of_two
+                ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
+                ensure_sketch_len(pot30, pot30, "pot30");
+                ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+            }
         };
     }
 }


### PR DESCRIPTION
Update the Circle CI job for Cargo Tarpaulin.

- Disable some test cases in `test_skt_capacity_will_not_overflow` to avoid out of memory error.
- Upgrade the Circle CI Ubuntu VM image to the latest version.

* * *
Fixes #108 