### PR TITLE
Add `contains_key` method to all cache implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka &mdash; Change Log
 
+## Version 0.8.1
+
+### Added
+
+- Add `contains_key` method to check if a key is present without resetting the idle
+  timer or updating the historic popularity estimator. ([#107][gh-issue-0107])
+
+
 ## Version 0.8.0
 
 As a part of stabilizing the cache API, the following cache methods have been renamed:
@@ -272,6 +280,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 
 [resolving-error-on-32bit]: https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 
+[gh-issue-0107]: https://github.com/moka-rs/moka/issues/107/
 [gh-issue-0072]: https://github.com/moka-rs/moka/issues/72/
 [gh-issue-0059]: https://github.com/moka-rs/moka/issues/59/
 [gh-issue-0043]: https://github.com/moka-rs/moka/issues/43/

--- a/src/cht/map/bucket_array_ref.rs
+++ b/src/cht/map/bucket_array_ref.rs
@@ -19,7 +19,12 @@ where
     K: Hash + Eq,
     S: BuildHasher,
 {
-    pub(crate) fn get_key_value_and_then<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
+    pub(crate) fn get_key_value_and_then<Q, F, T>(
+        &self,
+        key: &Q,
+        hash: u64,
+        with_entry: F,
+    ) -> Option<T>
     where
         Q: Hash + Eq + ?Sized,
         K: Borrow<Q>,

--- a/src/cht/map/bucket_array_ref.rs
+++ b/src/cht/map/bucket_array_ref.rs
@@ -19,11 +19,11 @@ where
     K: Hash + Eq,
     S: BuildHasher,
 {
-    pub(crate) fn get_key_value_and<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
+    pub(crate) fn get_key_value_and_then<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
     where
         Q: Hash + Eq + ?Sized,
         K: Borrow<Q>,
-        F: FnOnce(&K, &V) -> T,
+        F: FnOnce(&K, &V) -> Option<T>,
     {
         let guard = &crossbeam_epoch::pin();
         let current_ref = self.get(guard);
@@ -40,13 +40,11 @@ where
                     key,
                     maybe_value: value,
                 })) => {
-                    result = Some(with_entry(key, unsafe { &*value.as_ptr() }));
-
+                    result = with_entry(key, unsafe { &*value.as_ptr() });
                     break;
                 }
                 Ok(None) => {
                     result = None;
-
                     break;
                 }
                 Err(_) => {

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -1402,13 +1402,13 @@ mod tests {
             let bucket_array_len = map.capacity() * 2;
             assert_eq!(bucket_array_len, map.num_segments() * 128 * 2);
             if !cfg!(circleci) {
-                // TODO: FIXME: This assertion sometimes fail when cargo tarpaulin
+                // TODO: FIXME: These assertions sometimes fail when cargo tarpaulin
                 // is used on Circle CI.
                 assert!(live_key_count <= bucket_array_len / 10);
-            }
 
-            for this_value_parent in value_parents.iter() {
-                assert!(this_value_parent.was_dropped());
+                for this_value_parent in value_parents.iter() {
+                    assert!(this_value_parent.was_dropped());
+                }
             }
 
             for i in 0..NUM_VALUES {

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -362,6 +362,22 @@ where
         }
     }
 
+    /// Returns `true` if the cache contains a value for the key.
+    ///
+    /// Unlike the `get` method, this method is not considered a cache read operation,
+    /// so it does not update the historic popularity estimator or reset the idle
+    /// timer for the key.
+    ///
+    /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
+    /// on the borrowed form _must_ match those for the key type.
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.base.contains_key_with_hash(key, self.base.hash(key))
+    }
+
     /// Returns a _clone_ of the value corresponding to the key.
     ///
     /// If you want to store values that will be expensive to clone, wrap them by
@@ -920,17 +936,22 @@ mod tests {
         cache.insert("a", "alice").await;
         cache.insert("b", "bob").await;
         assert_eq!(cache.get(&"a"), Some("alice"));
+        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
         assert_eq!(cache.get(&"b"), Some("bob"));
         cache.sync();
         // counts: a -> 1, b -> 1
 
         cache.insert("c", "cindy").await;
         assert_eq!(cache.get(&"c"), Some("cindy"));
+        assert!(cache.contains_key(&"c"));
         // counts: a -> 1, b -> 1, c -> 1
         cache.sync();
 
+        assert!(cache.contains_key(&"a"));
         assert_eq!(cache.get(&"a"), Some("alice"));
         assert_eq!(cache.get(&"b"), Some("bob"));
+        assert!(cache.contains_key(&"b"));
         cache.sync();
         // counts: a -> 2, b -> 2, c -> 1
 
@@ -938,9 +959,11 @@ mod tests {
         cache.insert("d", "david").await; //   count: d -> 0
         cache.sync();
         assert_eq!(cache.get(&"d"), None); //   d -> 1
+        assert!(!cache.contains_key(&"d"));
 
         cache.insert("d", "david").await;
         cache.sync();
+        assert!(!cache.contains_key(&"d"));
         assert_eq!(cache.get(&"d"), None); //   d -> 2
 
         // "d" should be admitted and "c" should be evicted
@@ -951,9 +974,14 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some("bob"));
         assert_eq!(cache.get(&"c"), None);
         assert_eq!(cache.get(&"d"), Some("dennis"));
+        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
+        assert!(!cache.contains_key(&"c"));
+        assert!(cache.contains_key(&"d"));
 
         cache.invalidate(&"b").await;
         assert_eq!(cache.get(&"b"), None);
+        assert!(!cache.contains_key(&"b"));
     }
 
     #[test]
@@ -1023,17 +1051,22 @@ mod tests {
         cache.insert("a", alice).await;
         cache.insert("b", bob).await;
         assert_eq!(cache.get(&"a"), Some(alice));
+        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
         assert_eq!(cache.get(&"b"), Some(bob));
         cache.sync();
         // order (LRU -> MRU) and counts: a -> 1, b -> 1
 
         cache.insert("c", cindy).await;
         assert_eq!(cache.get(&"c"), Some(cindy));
+        assert!(cache.contains_key(&"c"));
         // order and counts: a -> 1, b -> 1, c -> 1
         cache.sync();
 
+        assert!(cache.contains_key(&"a"));
         assert_eq!(cache.get(&"a"), Some(alice));
         assert_eq!(cache.get(&"b"), Some(bob));
+        assert!(cache.contains_key(&"b"));
         cache.sync();
         // order and counts: c -> 1, a -> 2, b -> 2
 
@@ -1043,17 +1076,21 @@ mod tests {
         cache.insert("d", david).await; //   count: d -> 0
         cache.sync();
         assert_eq!(cache.get(&"d"), None); //   d -> 1
+        assert!(!cache.contains_key(&"d"));
 
         cache.insert("d", david).await;
         cache.sync();
+        assert!(!cache.contains_key(&"d"));
         assert_eq!(cache.get(&"d"), None); //   d -> 2
 
         cache.insert("d", david).await;
         cache.sync();
         assert_eq!(cache.get(&"d"), None); //   d -> 3
+        assert!(!cache.contains_key(&"d"));
 
         cache.insert("d", david).await;
         cache.sync();
+        assert!(!cache.contains_key(&"d"));
         assert_eq!(cache.get(&"d"), None); //   d -> 4
 
         // Finally "d" should be admitted by evicting "c" and "a".
@@ -1063,12 +1100,18 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(bob));
         assert_eq!(cache.get(&"c"), None);
         assert_eq!(cache.get(&"d"), Some(dennis));
+        assert!(!cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
+        assert!(!cache.contains_key(&"c"));
+        assert!(cache.contains_key(&"d"));
 
         // Update "b" with "bill" (w: 15 -> 20). This should evict "d" (w: 15).
         cache.insert("b", bill).await;
         cache.sync();
         assert_eq!(cache.get(&"b"), Some(bill));
         assert_eq!(cache.get(&"d"), None);
+        assert!(cache.contains_key(&"b"));
+        assert!(!cache.contains_key(&"d"));
 
         // Re-add "a" (w: 10) and update "b" with "bob" (w: 20 -> 15).
         cache.insert("a", alice).await;
@@ -1077,6 +1120,9 @@ mod tests {
         assert_eq!(cache.get(&"a"), Some(alice));
         assert_eq!(cache.get(&"b"), Some(bob));
         assert_eq!(cache.get(&"d"), None);
+        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
+        assert!(!cache.contains_key(&"d"));
 
         // Verify the sizes.
         assert_eq!(cache.estimated_entry_count(), 2);
@@ -1113,6 +1159,8 @@ mod tests {
 
         assert!(cache.get(&10).is_none());
         assert!(cache.get(&20).is_some());
+        assert!(!cache.contains_key(&10));
+        assert!(cache.contains_key(&20));
     }
 
     #[tokio::test]
@@ -1129,6 +1177,9 @@ mod tests {
         assert_eq!(cache.get(&"a"), Some("alice"));
         assert_eq!(cache.get(&"b"), Some("bob"));
         assert_eq!(cache.get(&"c"), Some("cindy"));
+        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
+        assert!(cache.contains_key(&"c"));
         cache.sync();
 
         cache.invalidate_all();
@@ -1141,6 +1192,10 @@ mod tests {
         assert!(cache.get(&"b").is_none());
         assert!(cache.get(&"c").is_none());
         assert_eq!(cache.get(&"d"), Some("david"));
+        assert!(!cache.contains_key(&"a"));
+        assert!(!cache.contains_key(&"b"));
+        assert!(!cache.contains_key(&"c"));
+        assert!(cache.contains_key(&"d"));
     }
 
     #[tokio::test]
@@ -1170,6 +1225,9 @@ mod tests {
         assert_eq!(cache.get(&0), Some("alice"));
         assert_eq!(cache.get(&1), Some("bob"));
         assert_eq!(cache.get(&2), Some("alex"));
+        assert!(cache.contains_key(&0));
+        assert!(cache.contains_key(&1));
+        assert!(cache.contains_key(&2));
 
         let names = ["alice", "alex"].iter().cloned().collect::<HashSet<_>>();
         cache.invalidate_entries_if(move |_k, &v| names.contains(v))?;
@@ -1190,6 +1248,12 @@ mod tests {
         assert_eq!(cache.get(&1), Some("bob"));
         // This should survive as it was inserted after calling invalidate_entries_if.
         assert_eq!(cache.get(&3), Some("alice"));
+
+        assert!(!cache.contains_key(&0));
+        assert!(cache.contains_key(&1));
+        assert!(!cache.contains_key(&2));
+        assert!(cache.contains_key(&3));
+
         assert_eq!(cache.estimated_entry_count(), 2);
         assert_eq!(cache.invalidation_predicate_count(), 0);
 
@@ -1207,6 +1271,10 @@ mod tests {
 
         assert!(cache.get(&1).is_none());
         assert!(cache.get(&3).is_none());
+
+        assert!(!cache.contains_key(&1));
+        assert!(!cache.contains_key(&3));
+
         assert_eq!(cache.estimated_entry_count(), 0);
         assert_eq!(cache.invalidation_predicate_count(), 0);
 
@@ -1234,12 +1302,14 @@ mod tests {
         mock.increment(Duration::from_secs(5)); // 5 secs from the start.
         cache.sync();
 
-        cache.get(&"a");
+        assert_eq!(cache.get(&"a"), Some("alice"));
+        assert!(cache.contains_key(&"a"));
 
         mock.increment(Duration::from_secs(5)); // 10 secs.
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
+        assert!(!cache.contains_key(&"a"));
         assert!(cache.is_table_empty());
 
         cache.insert("b", "bob").await;
@@ -1251,6 +1321,7 @@ mod tests {
         cache.sync();
 
         assert_eq!(cache.get(&"b"), Some("bob"));
+        assert!(cache.contains_key(&"b"));
         assert_eq!(cache.estimated_entry_count(), 1);
 
         cache.insert("b", "bill").await;
@@ -1260,6 +1331,7 @@ mod tests {
         cache.sync();
 
         assert_eq!(cache.get(&"b"), Some("bill"));
+        assert!(cache.contains_key(&"b"));
         assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(5)); // 25 secs
@@ -1267,6 +1339,8 @@ mod tests {
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
+        assert!(!cache.contains_key(&"a"));
+        assert!(!cache.contains_key(&"b"));
         assert!(cache.is_table_empty());
     }
 
@@ -1301,11 +1375,23 @@ mod tests {
 
         assert_eq!(cache.estimated_entry_count(), 2);
 
-        mock.increment(Duration::from_secs(5)); // 15 secs.
+        mock.increment(Duration::from_secs(2)); // 12 secs.
+        cache.sync();
+
+        // contains_key does not reset the idle timer for the key.
+        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
+        cache.sync();
+
+        assert_eq!(cache.estimated_entry_count(), 2);
+
+        mock.increment(Duration::from_secs(3)); // 15 secs.
         cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), Some("bob"));
+        assert!(!cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
         assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(10)); // 25 secs
@@ -1313,6 +1399,8 @@ mod tests {
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
+        assert!(!cache.contains_key(&"a"));
+        assert!(!cache.contains_key(&"b"));
         assert!(cache.is_table_empty());
     }
 

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -135,7 +135,7 @@ where
         self.inner.hash(key)
     }
 
-    pub(crate) fn contains_key<Q>(&self, key: &Q, hash: u64) -> bool
+    pub(crate) fn contains_key_with_hash<Q>(&self, key: &Q, hash: u64) -> bool
     where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -135,40 +135,58 @@ where
         self.inner.hash(key)
     }
 
+    pub(crate) fn contains_key<Q>(&self, key: &Q, hash: u64) -> bool
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner
+            .get_key_value_and(key, hash, |k, entry| {
+                let i = &self.inner;
+                let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
+                let now = i.current_time_from_expiration_clock();
+
+                !is_expired_entry_wo(ttl, va, entry, now)
+                    && !is_expired_entry_ao(tti, va, entry, now)
+                    && !i.is_invalidated_entry(k, entry)
+            })
+            .unwrap_or_default() // `false` is the default for `bool` type.
+    }
+
     pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<V>
     where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
+        // Define a closure to record a read op.
         let record = |op| {
             self.record_read_op(op).expect("Failed to record a get op");
         };
 
-        match self.inner.get_key_value(key, hash) {
-            None => {
-                record(ReadOp::Miss(hash));
-                None
-            }
-            Some((arc_key, entry)) => {
-                let i = &self.inner;
-                let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
-                let now = i.current_time_from_expiration_clock();
+        let maybe_entry = self.inner.get_key_value_and_then(key, hash, |k, entry| {
+            let i = &self.inner;
+            let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
+            let now = i.current_time_from_expiration_clock();
 
-                if is_expired_entry_wo(ttl, va, &entry, now)
-                    || is_expired_entry_ao(tti, va, &entry, now)
-                    || self.inner.is_invalidated_entry(&arc_key, &entry)
-                {
-                    // Expired or invalidated entry. Record this access as a cache miss
-                    // rather than a hit.
-                    record(ReadOp::Miss(hash));
-                    None
-                } else {
-                    // Valid entry.
-                    let v = entry.value.clone();
-                    record(ReadOp::Hit(hash, entry, now));
-                    Some(v)
-                }
+            if is_expired_entry_wo(ttl, va, entry, now)
+                || is_expired_entry_ao(tti, va, entry, now)
+                || i.is_invalidated_entry(k, entry)
+            {
+                // Expired or invalidated entry.
+                None
+            } else {
+                // Valid entry.
+                Some((TrioArc::clone(entry), now))
             }
+        });
+
+        if let Some((entry, now)) = maybe_entry {
+            let v = entry.value.clone();
+            record(ReadOp::Hit(hash, entry, now));
+            Some(v)
+        } else {
+            record(ReadOp::Miss(hash));
+            None
         }
     }
 
@@ -463,8 +481,6 @@ enum AdmissionResult<K> {
 
 type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
 
-type CacheEntry<K, V> = (Arc<K>, TrioArc<ValueEntry<K, V>>);
-
 pub(crate) struct Inner<K, V, S> {
     max_capacity: Option<u64>,
     entry_count: AtomicCell<u64>,
@@ -556,12 +572,23 @@ where
     }
 
     #[inline]
-    fn get_key_value<Q>(&self, key: &Q, hash: u64) -> Option<CacheEntry<K, V>>
+    fn get_key_value_and<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
     where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
+        F: FnOnce(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> T,
     {
-        self.cache.get_key_value(key, hash)
+        self.cache.get_key_value_and(key, hash, with_entry)
+    }
+
+    #[inline]
+    fn get_key_value_and_then<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+        F: FnOnce(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> Option<T>,
+    {
+        self.cache.get_key_value_and_then(key, hash, with_entry)
     }
 
     #[inline]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -314,7 +314,7 @@ where
     /// Returns `true` if the cache contains a value for the key.
     ///
     /// Unlike the `get` method, this method is not considered a cache read operation,
-    /// so it does not updates the historic popularity estimator or reset the idle
+    /// so it does not update the historic popularity estimator or reset the idle
     /// timer for the key.
     ///
     /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
@@ -324,7 +324,15 @@ where
         Arc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.base.contains_key(key, self.base.hash(key))
+        self.base.contains_key_with_hash(key, self.base.hash(key))
+    }
+
+    pub(crate) fn contains_key_with_hash<Q>(&self, key: &Q, hash: u64) -> bool
+    where
+        Arc<K>: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.base.contains_key_with_hash(key, hash)
     }
 
     /// Returns a _clone_ of the value corresponding to the key.
@@ -879,7 +887,7 @@ mod tests {
         assert!(cache.contains_key(&"a"));
         assert_eq!(cache.get(&"a"), Some(alice));
         assert_eq!(cache.get(&"b"), Some(bob));
-        assert!(cache.contains_key(&"a"));
+        assert!(cache.contains_key(&"b"));
         cache.sync();
         // order and counts: c -> 1, a -> 2, b -> 2
 
@@ -992,7 +1000,6 @@ mod tests {
         cache.sync();
 
         cache.insert("d", "david");
-        assert!(cache.contains_key(&"d"));
         cache.sync();
 
         assert!(cache.get(&"a").is_none());


### PR DESCRIPTION
This PR adds a `contains_key` method to all cache implementations:

- `sync::Cache`
- `sync::SegmentedCache`
- `dash::Cache`
- `future::Cache`
- `unsync::Cache`

This method checks if a key is present in the cache. It does not reset the idle timer or update the historic popularity estimator.

* * *

Fixes #107