### PR TITLE
Add `iter` method to create an iterator to `unsync`, `sync` and `future` caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Moka &mdash; Change Log
 
+## Version 0.8.2
+
+### Added
+
+- Add iterator to the following caches: ([#114][gh-pull-0114])
+    - `sync::Cache`
+    - `sync::SegmentedCache`
+    - `future::Cache`
+    - `unsync::Cache`
+- Implement `IntoIterator` to the all caches (including experimental `dash::Cache`)
+  ([#114][gh-pull-0114])
+
+
 ## Version 0.8.1
 
 ### Added
@@ -287,6 +300,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0114]: https://github.com/moka-rs/moka/pull/114/
 [gh-pull-0105]: https://github.com/moka-rs/moka/pull/105/
 [gh-pull-0104]: https://github.com/moka-rs/moka/pull/104/
 [gh-pull-0103]: https://github.com/moka-rs/moka/pull/103/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 rust-version = "1.51"
 

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -436,13 +436,21 @@ where
     V: 'a,
     S: BuildHasher + Clone,
 {
-    /// Creates an iterator over a `moka::dash::Cache` yielding immutable references.
+    /// Creates an iterator visiting all key-value pairs in arbitrary order. The
+    /// iterator element type is [`EntryRef<'a, K, V, S>`][moka-entry-ref].
     ///
-    /// **Locking behavior**: This iterator relies on the iterator of
-    /// [`dashmap::DashMap`][dashmap-iter], which employs read-write locks. May
-    /// deadlock if the thread holding an iterator attempts to update the cache.
+    /// # Guarantees
     ///
-    /// [dashmap-iter]: https://docs.rs/dashmap/5.2.0/dashmap/struct.DashMap.html#method.iter
+    /// **TODO**
+    ///
+    /// # Locking behavior
+    ///
+    /// This iterator relies on the iterator of [`dashmap::DashMap`][dashmap-iter],
+    /// which employs read-write locks. May deadlock if the thread holding an
+    /// iterator attempts to update the cache.
+    ///
+    /// [moka-entry-ref]: ./struct.EntryRef.html
+    /// [dashmap-iter]: <https://docs.rs/dashmap/*/dashmap/struct.DashMap.html#method.iter>
     ///
     /// # Examples
     ///

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -25,9 +25,6 @@ use std::{
 /// Since `DashMap` employs read-write locks on internal shards, it will have lower
 /// concurrency on retrievals and updates than other caches.
 ///
-/// On the other hand, `dash` cache provides iterator, which returns immutable
-/// references to the entries in a cache. Other caches do not provide iterator.
-///
 /// `dash` cache performs a best-effort bounding of the map using an entry
 /// replacement algorithm to determine which entries to evict when the capacity is
 /// exceeded.
@@ -438,6 +435,9 @@ where
 {
     /// Creates an iterator visiting all key-value pairs in arbitrary order. The
     /// iterator element type is [`EntryRef<'a, K, V, S>`][moka-entry-ref].
+    ///
+    /// Unlike the `get` method, visiting entries via an iterator do not update the
+    /// historic popularity estimator or reset idle timers for keys.
     ///
     /// # Guarantees
     ///

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -700,7 +700,7 @@ where
     /// Creates an iterator visiting all key-value pairs in arbitrary order. The
     /// iterator element type is `(Arc<K>, V)`, where `V` is a clone of a stored
     /// value.
-    /// 
+    ///
     /// Iterators do not block concurrent reads and writes on the cache. An entry can
     /// be inserted to, invalidated or evicted from a cache while iterators are alive
     /// on the same cache.

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -6,6 +6,7 @@ use crate::{
     sync::{
         base_cache::{BaseCache, HouseKeeperArc, MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
         housekeeper::InnerSync,
+        iter::Iter,
         PredicateId, Weigher, WriteOp,
     },
     Policy, PredicateError,
@@ -694,6 +695,42 @@ where
         F: Fn(&K, &V) -> bool + Send + Sync + 'static,
     {
         self.base.invalidate_entries_if(Arc::new(predicate))
+    }
+
+    /// Creates an iterator visiting all key-value pairs in arbitrary order. The
+    /// iterator element type is `(Arc<K>, V)`, where `V` is a clone of a stored
+    /// value.
+    ///
+    /// # Guarantees
+    ///
+    /// **TODO**
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.8", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache = Cache::new(100);
+    ///     cache.insert("Julia", 14).await;
+    ///
+    ///     let mut iter = cache.iter();
+    ///     let (k, v) = iter.next().unwrap(); // (Arc<K>, V)
+    ///     assert_eq!(*k, "Julia");
+    ///     assert_eq!(v, 14);
+    ///
+    ///     assert!(iter.next().is_none());
+    /// }
+    /// ```
+    ///
+    pub fn iter(&self) -> Iter<'_, K, V, S> {
+        self.base.iter()
     }
 
     /// Returns a `BlockingOp` for this cache. It provides blocking

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -711,7 +711,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.8", features = ["future"] }
+    /// // moka = { version = "0.8.2", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     /// use moka::future::Cache;
     ///

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -729,8 +729,10 @@ where
     /// }
     /// ```
     ///
-    pub fn iter(&self) -> Iter<'_, K, V, S> {
-        self.base.iter()
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        use crate::sync::iter::ScanningGet;
+
+        Iter::with_single_cache_segment(&self.base, self.base.num_cht_segments())
     }
 
     /// Returns a `BlockingOp` for this cache. It provides blocking
@@ -775,7 +777,9 @@ where
     }
 }
 
+//
 // private methods
+//
 impl<K, V, S> Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -700,10 +700,13 @@ where
     /// Creates an iterator visiting all key-value pairs in arbitrary order. The
     /// iterator element type is `(Arc<K>, V)`, where `V` is a clone of a stored
     /// value.
-    ///
+    /// 
     /// Iterators do not block concurrent reads and writes on the cache. An entry can
     /// be inserted to, invalidated or evicted from a cache while iterators are alive
     /// on the same cache.
+    ///
+    /// Unlike the `get` method, visiting entries via an iterator do not update the
+    /// historic popularity estimator or reset idle timers for keys.
     ///
     /// # Guarantees
     ///

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -701,9 +701,29 @@ where
     /// iterator element type is `(Arc<K>, V)`, where `V` is a clone of a stored
     /// value.
     ///
+    /// Iterators do not block concurrent reads and writes on the cache. An entry can
+    /// be inserted to, invalidated or evicted from a cache while iterators are alive
+    /// on the same cache.
+    ///
     /// # Guarantees
     ///
-    /// **TODO**
+    /// In order to allow concurrent access to the cache, iterator's `next` method
+    /// does _not_ guarantee the following:
+    ///
+    /// - It does not guarantee to return a key-value pair (an entry) if its key has
+    ///   been inserted to the cache _after_ the iterator was created.
+    ///   - Such an entry may or may not be returned depending on key's hash and
+    ///     timing.
+    ///
+    /// and the `next` method guarantees the followings:
+    ///
+    /// - It guarantees not to return the same entry more than once.
+    /// - It guarantees not to return an entry if it has been removed from the cache
+    ///   after the iterator was created.
+    ///     - Note: An entry can be removed by following reasons:
+    ///         - Manually invalidated.
+    ///         - Expired (e.g. time-to-live).
+    ///         - Evicted as the cache capacity exceeded.
     ///
     /// # Examples
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -14,6 +14,7 @@ pub(crate) mod deques;
 pub(crate) mod entry_info;
 pub(crate) mod housekeeper;
 mod invalidator;
+pub(crate) mod iter;
 mod segment;
 mod value_initializer;
 
@@ -22,6 +23,7 @@ pub(crate) mod debug_counters;
 
 pub use builder::CacheBuilder;
 pub use cache::Cache;
+pub use iter::Iter;
 pub use segment::SegmentedCache;
 
 use self::entry_info::EntryInfo;

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -3,7 +3,7 @@ use super::{
     entry_info::EntryInfo,
     housekeeper::{Housekeeper, InnerSync, SyncPace},
     invalidator::{GetOrRemoveEntry, InvalidationResult, Invalidator, KeyDateLite, PredicateFun},
-    iter::Iter,
+    iter::ScanningGet,
     AccessTime, KeyDate, KeyHash, KeyHashDate, KvEntry, PredicateId, ReadOp, ValueEntry, Weigher,
     WriteOp,
 };
@@ -191,30 +191,6 @@ where
         }
     }
 
-    pub(crate) fn get_for_iter(&self, key: &Arc<K>) -> Option<V> {
-        let hash = self.hash(key);
-        self.inner.get_key_value_and_then(key, hash, |k, entry| {
-            let i = &self.inner;
-            let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
-            let now = i.current_time_from_expiration_clock();
-
-            if is_expired_entry_wo(ttl, va, entry, now)
-                || is_expired_entry_ao(tti, va, entry, now)
-                || i.is_invalidated_entry(k, entry)
-            {
-                // Expired or invalidated entry.
-                None
-            } else {
-                // Valid entry.
-                Some(entry.value.clone())
-            }
-        })
-    }
-
-    pub(crate) fn keys(&self, cht_segment: usize) -> Option<Vec<Weak<K>>> {
-        self.inner.keys(cht_segment)
-    }
-
     #[inline]
     pub(crate) fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<KvEntry<K, V>>
     where
@@ -251,11 +227,6 @@ where
         self.inner.register_invalidation_predicate(predicate, now)
     }
 
-    pub(crate) fn iter(&self) -> Iter<'_, K, V, S> {
-        let num_cht_segments = self.inner.num_cht_segments();
-        Iter::with_single_cache_segment(&self, num_cht_segments)
-    }
-
     pub(crate) fn policy(&self) -> Policy {
         self.inner.policy()
     }
@@ -273,6 +244,44 @@ where
     #[cfg(test)]
     pub(crate) fn weighted_size(&self) -> u64 {
         self.inner.weighted_size()
+    }
+}
+
+//
+// Iterator support
+//
+impl<K, V, S> ScanningGet<K, V> for BaseCache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    fn num_cht_segments(&self) -> usize {
+        self.inner.num_cht_segments()
+    }
+
+    fn scanning_get(&self, key: &Arc<K>) -> Option<V> {
+        let hash = self.hash(key);
+        self.inner.get_key_value_and_then(key, hash, |k, entry| {
+            let i = &self.inner;
+            let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
+            let now = i.current_time_from_expiration_clock();
+
+            if is_expired_entry_wo(ttl, va, entry, now)
+                || is_expired_entry_ao(tti, va, entry, now)
+                || i.is_invalidated_entry(k, entry)
+            {
+                // Expired or invalidated entry.
+                None
+            } else {
+                // Valid entry.
+                Some(entry.value.clone())
+            }
+        })
+    }
+
+    fn keys(&self, cht_segment: usize) -> Option<Vec<Weak<K>>> {
+        self.inner.keys(cht_segment)
     }
 }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -705,6 +705,9 @@ where
     /// be inserted to, invalidated or evicted from a cache while iterators are alive
     /// on the same cache.
     ///
+    /// Unlike the `get` method, visiting entries via an iterator do not update the
+    /// historic popularity estimator or reset idle timers for keys.
+    ///
     /// # Guarantees
     ///
     /// In order to allow concurrent access to the cache, iterator's `next` method

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1211,10 +1211,12 @@ mod tests {
         assert!(cache.contains_key(&"a"));
 
         mock.increment(Duration::from_secs(5)); // 10 secs.
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert!(!cache.contains_key(&"a"));
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.sync();
         assert!(cache.is_table_empty());
 
         cache.insert("b", "bob");
@@ -1240,12 +1242,15 @@ mod tests {
         assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(5)); // 25 secs
-        cache.sync();
 
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.sync();
         assert!(cache.is_table_empty());
     }
 
@@ -1291,21 +1296,25 @@ mod tests {
         assert_eq!(cache.estimated_entry_count(), 2);
 
         mock.increment(Duration::from_secs(3)); // 15 secs.
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), Some("bob"));
         assert!(!cache.contains_key(&"a"));
         assert!(cache.contains_key(&"b"));
+
+        assert_eq!(cache.iter().count(), 1);
+
+        cache.sync();
         assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(10)); // 25 secs
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.sync();
         assert!(cache.is_table_empty());
     }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -744,6 +744,21 @@ where
     }
 }
 
+impl<'a, K, V, S> IntoIterator for &'a Cache<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    type Item = (Arc<K>, V);
+
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl<K, V, S> ConcurrentCacheExt<K, V> for Cache<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
@@ -1269,6 +1284,35 @@ mod tests {
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
         assert!(cache.is_table_empty());
+    }
+
+    #[test]
+    fn test_iter() {
+        const NUM_KEYS: usize = 50;
+
+        fn make_value(key: usize) -> String {
+            format!("val: {}", key)
+        }
+
+        let cache = Cache::builder()
+            .max_capacity(100)
+            .time_to_idle(Duration::from_secs(10))
+            .build();
+
+        for key in 0..NUM_KEYS {
+            cache.insert(key, make_value(key));
+        }
+
+        let mut key_set = std::collections::HashSet::new();
+
+        for (key, value) in &cache {
+            assert_eq!(value, make_value(*key));
+
+            key_set.insert(*key);
+        }
+
+        // Ensure there are no missing or duplicate keys in the iteration.
+        assert_eq!(key_set.len(), NUM_KEYS);
     }
 
     #[test]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -13,7 +13,7 @@ use std::{
     borrow::Borrow,
     collections::hash_map::RandomState,
     hash::{BuildHasher, Hash},
-    sync::{Arc, Weak},
+    sync::Arc,
     time::Duration,
 };
 
@@ -787,7 +787,7 @@ where
         self.base.scanning_get(key)
     }
 
-    fn keys(&self, cht_segment: usize) -> Option<Vec<Weak<K>>> {
+    fn keys(&self, cht_segment: usize) -> Option<Vec<Arc<K>>> {
         self.base.keys(cht_segment)
     }
 }
@@ -1312,6 +1312,79 @@ mod tests {
         }
 
         // Ensure there are no missing or duplicate keys in the iteration.
+        assert_eq!(key_set.len(), NUM_KEYS);
+    }
+
+    /// Runs 16 threads at the same time and ensures no deadlock occurs.
+    ///
+    /// - Eight of the threads will update key-values in the cache.
+    /// - Eight others will iterate the cache.
+    ///
+    #[test]
+    fn test_iter_multi_threads() {
+        use std::collections::HashSet;
+
+        const NUM_KEYS: usize = 1024;
+        const NUM_THREADS: usize = 16;
+
+        fn make_value(key: usize) -> String {
+            format!("val: {}", key)
+        }
+
+        let cache = Cache::builder()
+            .max_capacity(2048)
+            .time_to_idle(Duration::from_secs(10))
+            .build();
+
+        // Initialize the cache.
+        for key in 0..NUM_KEYS {
+            cache.insert(key, make_value(key));
+        }
+
+        let rw_lock = Arc::new(std::sync::RwLock::<()>::default());
+        let write_lock = rw_lock.write().unwrap();
+
+        // https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect
+        #[allow(clippy::needless_collect)]
+        let handles = (0..NUM_THREADS)
+            .map(|n| {
+                let cache = cache.clone();
+                let rw_lock = Arc::clone(&rw_lock);
+
+                if n % 2 == 0 {
+                    // This thread will update the cache.
+                    std::thread::spawn(move || {
+                        let read_lock = rw_lock.read().unwrap();
+                        for key in 0..NUM_KEYS {
+                            // TODO: Update keys in a random order?
+                            cache.insert(key, make_value(key));
+                        }
+                        std::mem::drop(read_lock);
+                    })
+                } else {
+                    // This thread will iterate the cache.
+                    std::thread::spawn(move || {
+                        let read_lock = rw_lock.read().unwrap();
+                        let mut key_set = HashSet::new();
+                        for (key, value) in &cache {
+                            assert_eq!(value, make_value(*key));
+                            key_set.insert(*key);
+                        }
+                        // Ensure there are no missing or duplicate keys in the iteration.
+                        assert_eq!(key_set.len(), NUM_KEYS);
+                        std::mem::drop(read_lock);
+                    })
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Let these threads to run by releasing the write lock.
+        std::mem::drop(write_lock);
+
+        handles.into_iter().for_each(|h| h.join().expect("Failed"));
+
+        // Ensure there are no missing or duplicate keys in the iteration.
+        let key_set = cache.iter().map(|(k, _v)| *k).collect::<HashSet<_>>();
         assert_eq!(key_set.len(), NUM_KEYS);
     }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -701,9 +701,29 @@ where
     /// iterator element type is `(Arc<K>, V)`, where `V` is a clone of a stored
     /// value.
     ///
+    /// Iterators do not block concurrent reads and writes on the cache. An entry can
+    /// be inserted to, invalidated or evicted from a cache while iterators are alive
+    /// on the same cache.
+    ///
     /// # Guarantees
     ///
-    /// **TODO**
+    /// In order to allow concurrent access to the cache, iterator's `next` method
+    /// does _not_ guarantee the following:
+    ///
+    /// - It does not guarantee to return a key-value pair (an entry) if its key has
+    ///   been inserted to the cache _after_ the iterator was created.
+    ///   - Such an entry may or may not be returned depending on key's hash and
+    ///     timing.
+    ///
+    /// and the `next` method guarantees the followings:
+    ///
+    /// - It guarantees not to return the same entry more than once.
+    /// - It guarantees not to return an entry if it has been removed from the cache
+    ///   after the iterator was created.
+    ///     - Note: An entry can be removed by following reasons:
+    ///         - Manually invalidated.
+    ///         - Expired (e.g. time-to-live).
+    ///         - Evicted as the cache capacity exceeded.
     ///
     /// # Examples
     ///

--- a/src/sync/iter.rs
+++ b/src/sync/iter.rs
@@ -1,0 +1,126 @@
+use crate::sync::base_cache::BaseCache;
+
+use std::{
+    hash::{BuildHasher, Hash},
+    sync::{Arc, Weak},
+};
+
+pub struct Iter<'i, K, V, S> {
+    keys: Option<Vec<Weak<K>>>,
+    cache_segments: Box<[&'i BaseCache<K, V, S>]>,
+    num_cht_segments: usize,
+    cache_seg_index: usize,
+    cht_seg_index: usize,
+    is_done: bool,
+}
+
+impl<'i, K, V, S> Iter<'i, K, V, S> {
+    pub(crate) fn with_single_cache_segment(
+        cache: &'i BaseCache<K, V, S>,
+        num_cht_segments: usize,
+    ) -> Self {
+        Self {
+            keys: None,
+            cache_segments: Box::new([cache]),
+            num_cht_segments,
+            cache_seg_index: 0,
+            cht_seg_index: 0,
+            is_done: false,
+        }
+    }
+
+    // pub(crate) fn with_multiple_cache_segments(
+    //     cache_segments: Box<[&'i BaseCache<K, V, S>]>,
+    //     num_cht_segments: usize,
+    // ) -> Self {
+    //     Self {
+    //         keys: None,
+    //         cache_segments,
+    //         num_cht_segments,
+    //         cache_seg_index: 0,
+    //         cht_seg_index: 0,
+    //         is_done: false,
+    //     }
+    // }
+}
+
+impl<'i, K, V, S> Iterator for Iter<'i, K, V, S>
+where
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    type Item = (Arc<K>, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_done {
+            return None;
+        }
+
+        while let Some(key) = self.next_key() {
+            if let Some(v) = self.cache().get_for_iter(&key) {
+                return Some((key, v));
+            }
+        }
+
+        self.is_done = true;
+        None
+    }
+}
+
+impl<'i, K, V, S> Iter<'i, K, V, S>
+where
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    fn cache(&self) -> &'i BaseCache<K, V, S> {
+        self.cache_segments[self.cache_seg_index]
+    }
+
+    fn next_key(&mut self) -> Option<Arc<K>> {
+        while let Some(keys) = self.current_keys() {
+            if let key @ Some(_) = keys.pop().and_then(|k| k.upgrade()) {
+                return key;
+            }
+        }
+        None
+    }
+
+    fn current_keys(&mut self) -> Option<&mut Vec<Weak<K>>> {
+        // If keys is none or some but empty, try to get next keys.
+        while self.keys.as_ref().map_or(true, Vec::is_empty) {
+            // Adjust indices.
+            if self.cht_seg_index >= self.num_cht_segments {
+                self.cache_seg_index += 1;
+                self.cht_seg_index = 0;
+                if self.cache_seg_index >= self.cache_segments.len() {
+                    // No more cache segments left.
+                    return None;
+                }
+            }
+
+            self.keys = self.cache_segments[self.cache_seg_index].keys(dbg!(self.cht_seg_index));
+            self.cht_seg_index += 1;
+            dbg!(self.keys.as_ref().map_or(0, |ks| ks.len()));
+        }
+
+        self.keys.as_mut()
+    }
+}
+
+unsafe impl<'a, 'i, K, V, S> Send for Iter<'i, K, V, S>
+where
+    K: 'a + Eq + Hash + Send,
+    V: 'a + Send,
+    S: 'a + BuildHasher + Clone,
+{
+}
+
+unsafe impl<'a, 'i, K, V, S> Sync for Iter<'i, K, V, S>
+where
+    K: 'a + Eq + Hash + Sync,
+    V: 'a + Sync,
+    S: 'a + BuildHasher + Clone,
+{
+}

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -295,9 +295,29 @@ where
     /// iterator element type is `(Arc<K>, V)`, where `V` is a clone of a stored
     /// value.
     ///
+    /// Iterators do not block concurrent reads and writes on the cache. An entry can
+    /// be inserted to, invalidated or evicted from a cache while iterators are alive
+    /// on the same cache.
+    ///
     /// # Guarantees
     ///
-    /// **TODO**
+    /// In order to allow concurrent access to the cache, iterator's `next` method
+    /// does _not_ guarantee the following:
+    ///
+    /// - It does not guarantee to return a key-value pair (an entry) if its key has
+    ///   been inserted to the cache _after_ the iterator was created.
+    ///   - Such an entry may or may not be returned depending on key's hash and
+    ///     timing.
+    ///
+    /// and the `next` method guarantees the followings:
+    ///
+    /// - It guarantees not to return the same entry more than once.
+    /// - It guarantees not to return an entry if it has been removed from the cache
+    ///   after the iterator was created.
+    ///     - Note: An entry can be removed by following reasons:
+    ///         - Manually invalidated.
+    ///         - Expired (e.g. time-to-live).
+    ///         - Evicted as the cache capacity exceeded.
     ///
     /// # Examples
     ///

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -299,6 +299,9 @@ where
     /// be inserted to, invalidated or evicted from a cache while iterators are alive
     /// on the same cache.
     ///
+    /// Unlike the `get` method, visiting entries via an iterator do not update the
+    /// historic popularity estimator or reset idle timers for keys.
+    ///
     /// # Guarantees
     ///
     /// In order to allow concurrent access to the cache, iterator's `next` method

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -6,12 +6,14 @@
 mod builder;
 mod cache;
 mod deques;
+mod iter;
 
 use std::{ptr::NonNull, rc::Rc};
 use tagptr::TagNonNull;
 
 pub use builder::CacheBuilder;
 pub use cache::Cache;
+pub use iter::Iter;
 
 use crate::common::{deque::DeqNode, time::Instant};
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1236,6 +1236,7 @@ mod tests {
 
         assert_eq!(cache.get(&"a"), None);
         assert!(!cache.contains_key(&"a"));
+        assert_eq!(cache.iter().count(), 0);
         assert!(cache.cache.is_empty());
 
         cache.insert("b", "bob");
@@ -1262,6 +1263,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
+        assert_eq!(cache.iter().count(), 0);
         assert!(cache.cache.is_empty());
     }
 
@@ -1302,6 +1304,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), Some(&"bob"));
         assert!(!cache.contains_key(&"a"));
         assert!(cache.contains_key(&"b"));
+        assert_eq!(cache.iter().count(), 1);
         assert_eq!(cache.cache.len(), 1);
 
         mock.increment(Duration::from_secs(10)); // 25 secs
@@ -1310,6 +1313,7 @@ mod tests {
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
+        assert_eq!(cache.iter().count(), 0);
         assert!(cache.cache.is_empty());
     }
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -402,6 +402,9 @@ where
     /// Creates an iterator visiting all key-value pairs in arbitrary order. The
     /// iterator element type is `(&K, &V)`.
     ///
+    /// Unlike the `get` method, visiting entries via an iterator do not update the
+    /// historic popularity estimator or reset idle timers for keys.
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/src/unsync/iter.rs
+++ b/src/unsync/iter.rs
@@ -1,0 +1,36 @@
+use super::{Cache, ValueEntry};
+
+use std::{
+    hash::{BuildHasher, Hash},
+    rc::Rc,
+};
+
+type HashMapIter<'i, K, V> = std::collections::hash_map::Iter<'i, Rc<K>, ValueEntry<K, V>>;
+
+pub struct Iter<'i, K, V, S> {
+    cache: &'i Cache<K, V, S>,
+    iter: HashMapIter<'i, K, V>,
+}
+
+impl<'i, K, V, S> Iter<'i, K, V, S> {
+    pub(crate) fn new(cache: &'i Cache<K, V, S>, iter: HashMapIter<'i, K, V>) -> Self {
+        Self { cache, iter }
+    }
+}
+
+impl<'i, K, V, S> Iterator for Iter<'i, K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher + Clone,
+{
+    type Item = (&'i K, &'i V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, entry) in self.iter.by_ref() {
+            if !self.cache.is_expired_entry(entry) {
+                return Some((k, &entry.value));
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
## Changes

This PR adds iterator visiting all key-value pairs in arbitrary order.

- Add the `iter` method, who returns an iterator, to the following caches:
    - Not-thread-safe cache:
        - `unsync::Cache`
    - Concurrent Caches:
        - `sync::Cache`
        - `sync::SegmentedCache`
        - `future::Cache`
- Implement `IntoIterator` to all the caches including experimental `dash::Cache`.

Fixes #112

## Details

### `unsync` cache's iterator

The `unsync::Cache` employs `std::collections::HashMap` as the central key-value storage:

- The iterator element type is `(&K, &V)`.
- No mutation on the cache is allowed while an iterator is alive.
    - Mutations includes both read operations like `get` and write operations like `insert`.

### `sync` and `future` caches' iterators

These concurrent caches employ `moka::cht::SegmentedHashMap` as the central key-value storage:

- The iterator element type is `(std::sync::Arc<K>, V)`, where `V` is a clone of the stored values.
- Concurrent mutations on the cache is allowed while an iterator is alive.

To allow concurrent mutations, iterator's `next` method does not guarantee the following:

- It does not guarantee to return a key-value pair (aka entry) if its key has been inserted to the cache _after_ the iterator was created.
    - Such an entry may or may not be returned depending on key's hash and timing.

and the `next` method guarantees the followings:

- It guarantees not to return the same entry more than once.
- It guarantees not to return an entry if it has been removed from the cache after the iterator was created.
    - Note: An entry can be removed by following reasons:
        - It has been manually invalidated.
        - It has been expired (e.g. time-to-live).
        - It has been evicted as the cache capacity exceeded.

### An implementation note

`sync` and `future` caches' iterators have some memory overheads:

It creates a snapshot of keys (~~`Vec<std::sync::Weak<K>>`~~ `Vec<std::sync::Arc<K>>`) of an internal segment of `cht::SegmentedHashMap`. It uses some amount of heap memory depending on the number of keys in the segment. The number of segments of `cht::SegmentedHashMap` per cache is currently hard-coded to 64 (since Moka v0.1.0).