### PR TITLE
Disable the default features for Triomphe crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,11 @@ scheduled-thread-pool = "0.2.5"
 smallvec = "1.8"
 tagptr = "0.2"
 thiserror = "1.0"
-triomphe = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
+
+# Opt-out serde and stable_deref_trait features
+# https://github.com/Manishearth/triomphe/pull/5
+triomphe = { version = "0.1", default-features = false }
 
 # Optional dependencies (dashmap)
 dashmap = { version = "5.2", optional = true }


### PR DESCRIPTION
Disable the default-features for [Triomphe crate](https://crates.io/crates/triomphe) to remove`serde` and `stable_deref_trait` crates from the dependency. (https://github.com/Manishearth/triomphe/pull/5)

**Before**

```console
$ cargo tree --all-features --target x86_64-unknown-linux-gnu

├── triomphe v0.1.5
│   ├── memoffset v0.6.5
│   │   [build-dependencies]
│   │   └── autocfg v1.1.0
│   ├── serde v1.0.136
│   │   └── serde_derive v1.0.136 (proc-macro)
│   │       ├── proc-macro2 v1.0.37 (*)
│   │       ├── quote v1.0.17 (*)
│   │       └── syn v1.0.91 (*)
│   └── stable_deref_trait v1.2.0
```

**After**

```console
├── triomphe v0.1.5
│   └── memoffset v0.6.5
│       [build-dependencies]
│       └── autocfg v1.1.0
```
