### PR TITLE
Fix the `dash::Cache` iterator not to return expired entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Implement `IntoIterator` to the all caches (including experimental `dash::Cache`)
   ([#114][gh-pull-0114])
 
+### Fixed
+
+- Fix the `dash::Cache` iterator not to return expired entries.
+  ([#116][gh-pull-0116])
+
 
 ## Version 0.8.1
 
@@ -300,6 +305,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0038]: https://github.com/moka-rs/moka/issues/38/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0116]: https://github.com/moka-rs/moka/pull/116/
 [gh-pull-0114]: https://github.com/moka-rs/moka/pull/114/
 [gh-pull-0105]: https://github.com/moka-rs/moka/pull/105/
 [gh-pull-0104]: https://github.com/moka-rs/moka/pull/104/

--- a/src/dash/cache.rs
+++ b/src/dash/cache.rs
@@ -439,10 +439,6 @@ where
     /// Unlike the `get` method, visiting entries via an iterator do not update the
     /// historic popularity estimator or reset idle timers for keys.
     ///
-    /// # Guarantees
-    ///
-    /// **TODO**
-    ///
     /// # Locking behavior
     ///
     /// This iterator relies on the iterator of [`dashmap::DashMap`][dashmap-iter],
@@ -808,10 +804,12 @@ mod tests {
         assert!(cache.contains_key(&"a"));
 
         mock.increment(Duration::from_secs(5)); // 10 secs.
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert!(!cache.contains_key(&"a"));
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.sync();
         assert!(cache.is_table_empty());
 
         cache.insert("b", "bob");
@@ -837,12 +835,14 @@ mod tests {
         assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(5)); // 25 secs
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.sync();
         assert!(cache.is_table_empty());
     }
 
@@ -888,21 +888,25 @@ mod tests {
         assert_eq!(cache.estimated_entry_count(), 2);
 
         mock.increment(Duration::from_secs(3)); // 15 secs.
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), Some("bob"));
         assert!(!cache.contains_key(&"a"));
         assert!(cache.contains_key(&"b"));
+
+        assert_eq!(cache.iter().count(), 1);
+
+        cache.sync();
         assert_eq!(cache.estimated_entry_count(), 1);
 
         mock.increment(Duration::from_secs(10)); // 25 secs
-        cache.sync();
-
         assert_eq!(cache.get(&"a"), None);
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"a"));
         assert!(!cache.contains_key(&"b"));
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.sync();
         assert!(cache.is_table_empty());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 //! Moka is a fast, concurrent cache library for Rust. Moka is inspired by
 //! the [Caffeine][caffeine-git] library for Java.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
-
 // Temporary disable this lint as the MSRV (1.51) require an older lint name:
 // #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
-#![deny(rustdoc::broken_intra_doc_links)]
+
+// Temporary disable this lint as the MSRV (1.51) require an older lint name:
+// #![deny(rustdoc::broken_intra_doc_links)]
 
 //! Moka is a fast, concurrent cache library for Rust. Moka is inspired by
 //! the [Caffeine][caffeine-git] library for Java.


### PR DESCRIPTION
This PR fixes a bug that the `dash::Cache` iterator can return expired entries.

- Now the `next` method of `dash::Cache` iterator checks whether next entry is expired or not and skip it when expired.
- Update the unit test cases to detect this bug.