### PR TITLE
Prevent "index out of bounds" error when `sync::SegmentedCache` was created with a non-power-of-two segments

### DIFF
--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -507,7 +507,7 @@ where
         let seg_init_capacity = initial_capacity.map(|cap| cap / actual_num_segments);
         // NOTE: We cannot initialize the segments as `vec![cache; actual_num_segments]`
         // because Cache::clone() does not clone its inner but shares the same inner.
-        let segments = (0..num_segments)
+        let segments = (0..actual_num_segments)
             .map(|_| {
                 Cache::with_everything(
                     seg_max_capacity,
@@ -618,6 +618,25 @@ mod tests {
         cache.invalidate(&"b");
         assert_eq!(cache.get(&"b"), None);
         assert!(!cache.contains_key(&"b"));
+    }
+
+    #[test]
+    fn non_power_of_two_segments() {
+        let mut cache = SegmentedCache::new(100, 5);
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        assert_eq!(cache.iter().count(), 0);
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cindy");
+
+        assert_eq!(cache.iter().count(), 3);
+        cache.sync();
+        assert_eq!(cache.iter().count(), 3);
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes `sync::SegmentedCache` to create the correct number of internal segments when the specified number of segments is not a power of two (e.g. 5).

When a segmented cache is created with such a number of segments (e.g. 5), the number of the actual internal segments should be rounded up to a nearest power of two (e.g. 8). However the old code only created 5 of segments and caused a panic with "index out of bounds" when writing to or reading from the cache.

```rust
let cache = SegmentedCache::new(100, 5);
assert_eq!(cache.iter().count(), 0);
```

```
thread ... panicked at 'index out of bounds: the len is 5 but the index is 5', 
   src/sync/segment.rs:546:10
```

In addition to fixing the bug, add an unit test `sync::segment::tests::non_power_of_two_segments` to detect similar bugs in the future.