### PR TITLE
Add `get_with_if` method to `sync` and `future` caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Moka &mdash; Change Log
 
+## Version 0.8.4
+
+### Added
+
+- Add `get_with_if` method to the following caches: ([#123][gh-issue-0123])
+    - `sync::Cache`
+    - `sync::SegmentedCache`
+    - `future::Cache`
+
+
 ## Version 0.8.3
 
 ### Changed
@@ -312,10 +322,10 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [caffeine-git]: https://github.com/ben-manes/caffeine
 [quanta-crate]: https://crates.io/crates/quanta
 
-[panic_in_quanta]: https://github.com/moka-rs/moka#integer-overflow-in-quanta-crate-on-some-x8664-machines
-
+[panic_in_quanta]: https://github.com/moka-rs/moka#integer-overflow-in-quanta-crate-on-some-x86_64-machines
 [resolving-error-on-32bit]: https://github.com/moka-rs/moka#compile-errors-on-some-32-bit-platforms
 
+[gh-issue-0123]: https://github.com/moka-rs/moka/issues/123/
 [gh-issue-0119]: https://github.com/moka-rs/moka/issues/119/
 [gh-issue-0107]: https://github.com/moka-rs/moka/issues/107/
 [gh-issue-0072]: https://github.com/moka-rs/moka/issues/72/

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -497,7 +497,19 @@ where
     pub async fn get_with(&self, key: K, init: impl Future<Output = V>) -> V {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
-        self.get_or_insert_with_hash_and_fun(key, hash, init).await
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if)
+            .await
+    }
+
+    pub async fn get_with_if<F>(&self, key: K, init: impl Future<Output = V>, replace_if: F) -> V
+    where
+        F: Fn(&V) -> bool + Send + Sync + 'static,
+    {
+        let hash = self.base.hash(&key);
+        let key = Arc::new(key);
+        self.get_or_insert_with_hash_and_fun(key, hash, init, Some(replace_if))
+            .await
     }
 
     /// Try to ensure the value of the key exists by inserting an `Ok` output of the
@@ -830,9 +842,12 @@ where
         key: Arc<K>,
         hash: u64,
         init: impl Future<Output = V>,
+        replace_if: Option<impl Fn(&V) -> bool>,
     ) -> V {
-        if let Some(v) = self.base.get_with_hash(&key, hash) {
-            return v;
+        match (self.base.get_with_hash(&key, hash), replace_if) {
+            (Some(v), None) => return v,
+            (Some(v), Some(cond)) if !cond(&v) => return v,
+            _ => (),
         }
 
         match self
@@ -1673,6 +1688,129 @@ mod tests {
         };
 
         futures_util::join!(task1, task2, task3, task4, task5);
+    }
+
+    #[tokio::test]
+    async fn get_with_if() {
+        let cache = Cache::new(100);
+        const KEY: u32 = 0;
+
+        // This test will run seven async tasks:
+        //
+        // Task1 will be the first task to call `get_with_if` for a key, so
+        // its async block will be evaluated and then a &str value "task1" will be
+        // inserted to the cache.
+        let task1 = {
+            let cache1 = cache.clone();
+            async move {
+                // Call `get_with_if` immediately.
+                let v = cache1
+                    .get_with_if(
+                        KEY,
+                        async {
+                            // Wait for 300 ms and return a &str value.
+                            Timer::after(Duration::from_millis(300)).await;
+                            "task1"
+                        },
+                        |_v| unreachable!(),
+                    )
+                    .await;
+                assert_eq!(v, "task1");
+            }
+        };
+
+        // Task2 will be the second task to call `get_with_if` for the same
+        // key, so its async block will not be evaluated. Once task1's async block
+        // finishes, it will get the value inserted by task1's async block.
+        let task2 = {
+            let cache2 = cache.clone();
+            async move {
+                // Wait for 100 ms before calling `get_with_if`.
+                Timer::after(Duration::from_millis(100)).await;
+                let v = cache2
+                    .get_with_if(KEY, async { unreachable!() }, |_v| unreachable!())
+                    .await;
+                assert_eq!(v, "task1");
+            }
+        };
+
+        // Task3 will be the third task to call `get_with_if` for the same
+        // key. By the time it calls, task1's async block should have finished
+        // already and the value should be already inserted to the cache.
+        // Also task3's `replace_if` closure returns `false`. So its async block
+        // will not be evaluated and will get the value insert by task1's async
+        // block immediately.
+        let task3 = {
+            let cache3 = cache.clone();
+            async move {
+                // Wait for 400 ms before calling `get_with_if`.
+                Timer::after(Duration::from_millis(350)).await;
+                let v = cache3
+                    .get_with_if(KEY, async { unreachable!() }, |v| {
+                        assert_eq!(v, &"task1");
+                        false
+                    })
+                    .await;
+                assert_eq!(v, "task1");
+            }
+        };
+
+        // Task4 will be the fourth task to call `get_with_if` for the same
+        // key. The value should have been already inserted to the cache by task1.
+        // However task4's `replace_if` closure returns `true`. So its async block
+        // will be evaluated to replace the current value.
+        let task4 = {
+            let cache4 = cache.clone();
+            async move {
+                // Wait for 400 ms before calling `get_with_if`.
+                Timer::after(Duration::from_millis(400)).await;
+                let v = cache4
+                    .get_with_if(KEY, async { "task4" }, |v| {
+                        assert_eq!(v, &"task1");
+                        true
+                    })
+                    .await;
+                assert_eq!(v, "task4");
+            }
+        };
+
+        // Task5 will call `get` for the same key. It will call when task1's async
+        // block is still running, so it will get none for the key.
+        let task5 = {
+            let cache5 = cache.clone();
+            async move {
+                // Wait for 200 ms before calling `get`.
+                Timer::after(Duration::from_millis(200)).await;
+                let maybe_v = cache5.get(&KEY);
+                assert!(maybe_v.is_none());
+            }
+        };
+
+        // Task6 will call `get` for the same key. It will call after task1's async
+        // block finished, so it will get the value insert by task1's async block.
+        let task6 = {
+            let cache6 = cache.clone();
+            async move {
+                // Wait for 350 ms before calling `get`.
+                Timer::after(Duration::from_millis(350)).await;
+                let maybe_v = cache6.get(&KEY);
+                assert_eq!(maybe_v, Some("task1"));
+            }
+        };
+
+        // Task7 will call `get` for the same key. It will call after task4's async
+        // block finished, so it will get the value insert by task4's async block.
+        let task7 = {
+            let cache7 = cache.clone();
+            async move {
+                // Wait for 450 ms before calling `get`.
+                Timer::after(Duration::from_millis(450)).await;
+                let maybe_v = cache7.get(&KEY);
+                assert_eq!(maybe_v, Some("task4"));
+            }
+        };
+
+        futures_util::join!(task1, task2, task3, task4, task5, task6, task7);
     }
 
     #[tokio::test]

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -502,10 +502,12 @@ where
             .await
     }
 
-    pub async fn get_with_if<F>(&self, key: K, init: impl Future<Output = V>, replace_if: F) -> V
-    where
-        F: Fn(&V) -> bool + Send + Sync + 'static,
-    {
+    pub async fn get_with_if(
+        &self,
+        key: K,
+        init: impl Future<Output = V>,
+        replace_if: impl Fn(&V) -> bool,
+    ) -> V {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
         self.get_or_insert_with_hash_and_fun(key, hash, init, Some(replace_if))

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -378,12 +378,12 @@ where
         self.try_get_with(key, init)
     }
 
-    /// Ensures the value of the key exists by inserting the result of the init
-    /// function if not exist, and returns a _clone_ of the value.
+    /// Ensures the value of the key exists by inserting the output of the `init`
+    /// closure if not exist, and returns a _clone_ of the value.
     ///
-    /// This method prevents to evaluate the init closure multiple times on the same
-    /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its closure, and other calls wait for that closure to
+    /// This method prevents to evaluate the `init` closure multiple times on the
+    /// same key even if the method is concurrently called by many threads; only one
+    /// of the calls evaluates its closure, and other calls wait for that closure to
     /// complete.
     ///
     /// # Example
@@ -458,11 +458,19 @@ where
         self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if)
     }
 
+    /// Works like [`get_with`](#method.get_with), but takes an additional
+    /// `replace_if` closure.
+    ///
+    /// This method will evaluate the `init` closure and insert the output to the
+    /// cache when:
+    ///
+    /// - The key does not exist.
+    /// - Or, `replace_if` closure returns `true`.
     pub fn get_with_if(
         &self,
         key: K,
         init: impl FnOnce() -> V,
-        replace_if: impl Fn(&V) -> bool,
+        replace_if: impl FnMut(&V) -> bool,
     ) -> V {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
@@ -474,11 +482,15 @@ where
         key: Arc<K>,
         hash: u64,
         init: impl FnOnce() -> V,
-        replace_if: Option<impl Fn(&V) -> bool>,
+        mut replace_if: Option<impl FnMut(&V) -> bool>,
     ) -> V {
-        match (self.base.get_with_hash(&key, hash), replace_if) {
+        match (self.base.get_with_hash(&key, hash), &mut replace_if) {
             (Some(v), None) => return v,
-            (Some(v), Some(cond)) if !cond(&v) => return v,
+            (Some(v), Some(cond)) => {
+                if !cond(&v) {
+                    return v;
+                }
+            }
             _ => (),
         }
 
@@ -1444,9 +1456,9 @@ mod tests {
 
         // This test will run five threads:
         //
-        // Thread1 will be the first thread to call `get_with` for a key, so
-        // its init closure will be evaluated and then a &str value "thread1" will be
-        // inserted to the cache.
+        // Thread1 will be the first thread to call `get_with` for a key, so its init
+        // closure will be evaluated and then a &str value "thread1" will be inserted
+        // to the cache.
         let thread1 = {
             let cache1 = cache.clone();
             spawn(move || {
@@ -1460,8 +1472,8 @@ mod tests {
             })
         };
 
-        // Thread2 will be the second thread to call `get_with` for the same
-        // key, so its init closure will not be evaluated. Once thread1's init closure
+        // Thread2 will be the second thread to call `get_with` for the same key, so
+        // its init closure will not be evaluated. Once thread1's init closure
         // finishes, it will get the value inserted by thread1's init closure.
         let thread2 = {
             let cache2 = cache.clone();
@@ -1473,11 +1485,11 @@ mod tests {
             })
         };
 
-        // Thread3 will be the third thread to call `get_with` for the same
-        // key. By the time it calls, thread1's init closure should have finished
-        // already and the value should be already inserted to the cache. So its
-        // init closure will not be evaluated and will get the value insert by thread1's
-        // init closure immediately.
+        // Thread3 will be the third thread to call `get_with` for the same key. By
+        // the time it calls, thread1's init closure should have finished already and
+        // the value should be already inserted to the cache. So its init closure
+        // will not be evaluated and will get the value insert by thread1's init
+        // closure immediately.
         let thread3 = {
             let cache3 = cache.clone();
             spawn(move || {
@@ -1488,8 +1500,8 @@ mod tests {
             })
         };
 
-        // Thread4 will call `get` for the same key. It will call when thread1's async
-        // block is still running, so it will get none for the key.
+        // Thread4 will call `get` for the same key. It will call when thread1's init
+        // closure is still running, so it will get none for the key.
         let thread4 = {
             let cache4 = cache.clone();
             spawn(move || {
@@ -1500,8 +1512,8 @@ mod tests {
             })
         };
 
-        // Thread5 will call `get` for the same key. It will call after thread1's async
-        // block finished, so it will get the value insert by thread1's init closure.
+        // Thread5 will call `get` for the same key. It will call after thread1's init
+        // closure finished, so it will get the value insert by thread1's init closure.
         let thread5 = {
             let cache5 = cache.clone();
             spawn(move || {
@@ -1526,8 +1538,8 @@ mod tests {
 
         // This test will run seven threads:
         //
-        // Thread1 will be the first thread to call `get_with_if` for a key, so
-        // its init closure will be evaluated and then a &str value "thread1" will be
+        // Thread1 will be the first thread to call `get_with_if` for a key, so its
+        // init closure will be evaluated and then a &str value "thread1" will be
         // inserted to the cache.
         let thread1 = {
             let cache1 = cache.clone();
@@ -1546,8 +1558,8 @@ mod tests {
             })
         };
 
-        // Thread2 will be the second thread to call `get_with_if` for the same
-        // key, so its init closure will not be evaluated. Once thread1's init closure
+        // Thread2 will be the second thread to call `get_with_if` for the same key,
+        // so its init closure will not be evaluated. Once thread1's init closure
         // finishes, it will get the value inserted by thread1's init closure.
         let thread2 = {
             let cache2 = cache.clone();
@@ -1561,9 +1573,10 @@ mod tests {
 
         // Thread3 will be the third thread to call `get_with_if` for the same
         // key. By the time it calls, thread1's init closure should have finished
-        // already and the value should be already inserted to the cache. So its
-        // init closure will not be evaluated and will get the value insert by thread1's
-        // init closure immediately.
+        // already and the value should be already inserted to the cache. Also
+        // thread3's `replace_if` closure returns `false`. So its init closure will
+        // not be evaluated and will get the value inserted by thread1's init closure
+        // immediately.
         let thread3 = {
             let cache3 = cache.clone();
             spawn(move || {
@@ -1581,11 +1594,10 @@ mod tests {
             })
         };
 
-        // Thread4 will be the third thread to call `get_with_if` for the same
-        // key. By the time it calls, thread1's init closure should have finished
-        // already and the value should be already inserted to the cache. So its
-        // init closure will not be evaluated and will get the value insert by thread1's
-        // init closure immediately.
+        // Thread4 will be the fourth thread to call `get_with_if` for the same
+        // key. The value should have been already inserted to the cache by
+        // thread1. However thread4's `replace_if` closure returns `true`. So its
+        // init closure will be evaluated to replace the current value.
         let thread4 = {
             let cache4 = cache.clone();
             spawn(move || {
@@ -1603,8 +1615,8 @@ mod tests {
             })
         };
 
-        // Thread5 will call `get` for the same key. It will call when thread1's async
-        // block is still running, so it will get none for the key.
+        // Thread5 will call `get` for the same key. It will call when thread1's init
+        // closure is still running, so it will get none for the key.
         let thread5 = {
             let cache5 = cache.clone();
             spawn(move || {
@@ -1615,24 +1627,24 @@ mod tests {
             })
         };
 
-        // Thread6 will call `get` for the same key. It will call when thread1's async
-        // block is still running, so it will get none for the key.
+        // Thread6 will call `get` for the same key. It will call when thread1's init
+        // closure is still running, so it will get none for the key.
         let thread6 = {
             let cache6 = cache.clone();
             spawn(move || {
-                // Wait for 200 ms before calling `get`.
+                // Wait for 350 ms before calling `get`.
                 sleep(Duration::from_millis(350));
                 let maybe_v = cache6.get(&KEY);
                 assert_eq!(maybe_v, Some("thread1"));
             })
         };
 
-        // Thread7 will call `get` for the same key. It will call after thread1's async
-        // block finished, so it will get the value insert by thread1's init closure.
+        // Thread7 will call `get` for the same key. It will call after thread1's init
+        // closure finished, so it will get the value insert by thread1's init closure.
         let thread7 = {
             let cache7 = cache.clone();
             spawn(move || {
-                // Wait for 400 ms before calling `get`.
+                // Wait for 450 ms before calling `get`.
                 sleep(Duration::from_millis(450));
                 let maybe_v = cache7.get(&KEY);
                 assert_eq!(maybe_v, Some("thread4"));
@@ -1653,8 +1665,8 @@ mod tests {
             thread::{sleep, spawn},
         };
 
-        // Note that MyError does not implement std::error::Error trait
-        // like anyhow::Error.
+        // Note that MyError does not implement std::error::Error trait like
+        // anyhow::Error.
         #[derive(Debug)]
         pub struct MyError(String);
 
@@ -1663,11 +1675,11 @@ mod tests {
         let cache = Cache::new(100);
         const KEY: u32 = 0;
 
-        // This test will run eight async threads:
+        // This test will run eight threads:
         //
-        // Thread1 will be the first thread to call `try_get_with` for a key, so
-        // its init closure will be evaluated and then an error will be returned.
-        // Nothing will be inserted to the cache.
+        // Thread1 will be the first thread to call `try_get_with` for a key, so its
+        // init closure will be evaluated and then an error will be returned. Nothing
+        // will be inserted to the cache.
         let thread1 = {
             let cache1 = cache.clone();
             spawn(move || {
@@ -1681,10 +1693,10 @@ mod tests {
             })
         };
 
-        // Thread2 will be the second thread to call `try_get_with` for the same
-        // key, so its init closure will not be evaluated. Once thread1's init closure
-        // finishes, it will get the same error value returned by thread1's async
-        // block.
+        // Thread2 will be the second thread to call `try_get_with` for the same key,
+        // so its init closure will not be evaluated. Once thread1's init closure
+        // finishes, it will get the same error value returned by thread1's init
+        // closure.
         let thread2 = {
             let cache2 = cache.clone();
             spawn(move || {
@@ -1695,11 +1707,11 @@ mod tests {
             })
         };
 
-        // Thread3 will be the third thread to call `get_with` for the same
-        // key. By the time it calls, thread1's init closure should have finished
-        // already, but the key still does not exist in the cache. So its init closure
-        // will be evaluated and then an okay &str value will be returned. That value
-        // will be inserted to the cache.
+        // Thread3 will be the third thread to call `get_with` for the same key. By
+        // the time it calls, thread1's init closure should have finished already,
+        // but the key still does not exist in the cache. So its init closure will be
+        // evaluated and then an okay &str value will be returned. That value will be
+        // inserted to the cache.
         let thread3 = {
             let cache3 = cache.clone();
             spawn(move || {
@@ -1715,8 +1727,8 @@ mod tests {
         };
 
         // thread4 will be the fourth thread to call `try_get_with` for the same
-        // key. So its init closure will not be evaluated. Once thread3's init closure
-        // finishes, it will get the same okay &str value.
+        // key. So its init closure will not be evaluated. Once thread3's init
+        // closure finishes, it will get the same okay &str value.
         let thread4 = {
             let cache4 = cache.clone();
             spawn(move || {
@@ -1729,9 +1741,9 @@ mod tests {
 
         // Thread5 will be the fifth thread to call `try_get_with` for the same
         // key. So its init closure will not be evaluated. By the time it calls,
-        // thread3's init closure should have finished already, so its init closure will
-        // not be evaluated and will get the value insert by thread3's init closure
-        // immediately.
+        // thread3's init closure should have finished already, so its init closure
+        // will not be evaluated and will get the value insert by thread3's init
+        // closure immediately.
         let thread5 = {
             let cache5 = cache.clone();
             spawn(move || {
@@ -1742,8 +1754,8 @@ mod tests {
             })
         };
 
-        // Thread6 will call `get` for the same key. It will call when thread1's async
-        // block is still running, so it will get none for the key.
+        // Thread6 will call `get` for the same key. It will call when thread1's init
+        // closure is still running, so it will get none for the key.
         let thread6 = {
             let cache6 = cache.clone();
             spawn(move || {
@@ -1754,8 +1766,8 @@ mod tests {
             })
         };
 
-        // Thread7 will call `get` for the same key. It will call after thread1's async
-        // block finished with an error. So it will get none for the key.
+        // Thread7 will call `get` for the same key. It will call after thread1's init
+        // closure finished with an error. So it will get none for the key.
         let thread7 = {
             let cache7 = cache.clone();
             spawn(move || {
@@ -1766,8 +1778,8 @@ mod tests {
             })
         };
 
-        // Thread8 will call `get` for the same key. It will call after thread3's async
-        // block finished, so it will get the value insert by thread3's init closure.
+        // Thread8 will call `get` for the same key. It will call after thread3's init
+        // closure finished, so it will get the value insert by thread3's init closure.
         let thread8 = {
             let cache8 = cache.clone();
             spawn(move || {

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -192,9 +192,23 @@ where
     pub fn get_with(&self, key: K, init: impl FnOnce() -> V) -> V {
         let hash = self.inner.hash(&key);
         let key = Arc::new(key);
+        let replace_if = None as Option<fn(&V) -> bool>;
         self.inner
             .select(hash)
-            .get_or_insert_with_hash_and_fun(key, hash, init)
+            .get_or_insert_with_hash_and_fun(key, hash, init, replace_if)
+    }
+
+    pub fn get_with_if(
+        &self,
+        key: K,
+        init: impl FnOnce() -> V,
+        replace_if: impl Fn(&V) -> bool,
+    ) -> V {
+        let hash = self.inner.hash(&key);
+        let key = Arc::new(key);
+        self.inner
+            .select(hash)
+            .get_or_insert_with_hash_and_fun(key, hash, init, Some(replace_if))
     }
 
     /// Try to ensure the value of the key exists by inserting an `Ok` result of the
@@ -1006,7 +1020,7 @@ mod tests {
         // This test will run five threads:
         //
         // Thread1 will be the first thread to call `get_with` for a key, so
-        // its async block will be evaluated and then a &str value "thread1" will be
+        // its init closure will be evaluated and then a &str value "thread1" will be
         // inserted to the cache.
         let thread1 = {
             let cache1 = cache.clone();
@@ -1022,8 +1036,8 @@ mod tests {
         };
 
         // Thread2 will be the second thread to call `get_with` for the same
-        // key, so its async block will not be evaluated. Once thread1's async block
-        // finishes, it will get the value inserted by thread1's async block.
+        // key, so its init closure will not be evaluated. Once thread1's init closure
+        // finishes, it will get the value inserted by thread1's init closure.
         let thread2 = {
             let cache2 = cache.clone();
             spawn(move || {
@@ -1035,10 +1049,10 @@ mod tests {
         };
 
         // Thread3 will be the third thread to call `get_with` for the same
-        // key. By the time it calls, thread1's async block should have finished
+        // key. By the time it calls, thread1's init closure should have finished
         // already and the value should be already inserted to the cache. So its
-        // async block will not be evaluated and will get the value insert by thread1's
-        // async block immediately.
+        // init closure will not be evaluated and will get the value insert by thread1's
+        // init closure immediately.
         let thread3 = {
             let cache3 = cache.clone();
             spawn(move || {
@@ -1062,7 +1076,7 @@ mod tests {
         };
 
         // Thread5 will call `get` for the same key. It will call after thread1's async
-        // block finished, so it will get the value insert by thread1's async block.
+        // block finished, so it will get the value insert by thread1's init closure.
         let thread5 = {
             let cache5 = cache.clone();
             spawn(move || {
@@ -1074,6 +1088,135 @@ mod tests {
         };
 
         for t in vec![thread1, thread2, thread3, thread4, thread5] {
+            t.join().expect("Failed to join");
+        }
+    }
+
+    #[test]
+    fn get_with_if() {
+        use std::thread::{sleep, spawn};
+
+        let cache = SegmentedCache::new(100, 4);
+        const KEY: u32 = 0;
+
+        // This test will run seven threads:
+        //
+        // Thread1 will be the first thread to call `get_with_if` for a key, so
+        // its init closure will be evaluated and then a &str value "thread1" will be
+        // inserted to the cache.
+        let thread1 = {
+            let cache1 = cache.clone();
+            spawn(move || {
+                // Call `get_with` immediately.
+                let v = cache1.get_with_if(
+                    KEY,
+                    || {
+                        // Wait for 300 ms and return a &str value.
+                        sleep(Duration::from_millis(300));
+                        "thread1"
+                    },
+                    |_v| unreachable!(),
+                );
+                assert_eq!(v, "thread1");
+            })
+        };
+
+        // Thread2 will be the second thread to call `get_with_if` for the same
+        // key, so its init closure will not be evaluated. Once thread1's init closure
+        // finishes, it will get the value inserted by thread1's init closure.
+        let thread2 = {
+            let cache2 = cache.clone();
+            spawn(move || {
+                // Wait for 100 ms before calling `get_with`.
+                sleep(Duration::from_millis(100));
+                let v = cache2.get_with_if(KEY, || unreachable!(), |_v| unreachable!());
+                assert_eq!(v, "thread1");
+            })
+        };
+
+        // Thread3 will be the third thread to call `get_with_if` for the same
+        // key. By the time it calls, thread1's init closure should have finished
+        // already and the value should be already inserted to the cache. So its
+        // init closure will not be evaluated and will get the value insert by thread1's
+        // init closure immediately.
+        let thread3 = {
+            let cache3 = cache.clone();
+            spawn(move || {
+                // Wait for 350 ms before calling `get_with_if`.
+                sleep(Duration::from_millis(350));
+                let v = cache3.get_with_if(
+                    KEY,
+                    || unreachable!(),
+                    |v| {
+                        assert_eq!(v, &"thread1");
+                        false
+                    },
+                );
+                assert_eq!(v, "thread1");
+            })
+        };
+
+        // Thread4 will be the third thread to call `get_with_if` for the same
+        // key. By the time it calls, thread1's init closure should have finished
+        // already and the value should be already inserted to the cache. So its
+        // init closure will not be evaluated and will get the value insert by thread1's
+        // init closure immediately.
+        let thread4 = {
+            let cache4 = cache.clone();
+            spawn(move || {
+                // Wait for 400 ms before calling `get_with_if`.
+                sleep(Duration::from_millis(400));
+                let v = cache4.get_with_if(
+                    KEY,
+                    || "thread4",
+                    |v| {
+                        assert_eq!(v, &"thread1");
+                        true
+                    },
+                );
+                assert_eq!(v, "thread4");
+            })
+        };
+
+        // Thread5 will call `get` for the same key. It will call when thread1's async
+        // block is still running, so it will get none for the key.
+        let thread5 = {
+            let cache5 = cache.clone();
+            spawn(move || {
+                // Wait for 200 ms before calling `get`.
+                sleep(Duration::from_millis(200));
+                let maybe_v = cache5.get(&KEY);
+                assert!(maybe_v.is_none());
+            })
+        };
+
+        // Thread6 will call `get` for the same key. It will call when thread1's async
+        // block is still running, so it will get none for the key.
+        let thread6 = {
+            let cache6 = cache.clone();
+            spawn(move || {
+                // Wait for 200 ms before calling `get`.
+                sleep(Duration::from_millis(350));
+                let maybe_v = cache6.get(&KEY);
+                assert_eq!(maybe_v, Some("thread1"));
+            })
+        };
+
+        // Thread7 will call `get` for the same key. It will call after thread1's async
+        // block finished, so it will get the value insert by thread1's init closure.
+        let thread7 = {
+            let cache7 = cache.clone();
+            spawn(move || {
+                // Wait for 400 ms before calling `get`.
+                sleep(Duration::from_millis(450));
+                let maybe_v = cache7.get(&KEY);
+                assert_eq!(maybe_v, Some("thread4"));
+            })
+        };
+
+        for t in vec![
+            thread1, thread2, thread3, thread4, thread5, thread6, thread7,
+        ] {
             t.join().expect("Failed to join");
         }
     }
@@ -1097,7 +1240,7 @@ mod tests {
         // This test will run eight async threads:
         //
         // Thread1 will be the first thread to call `get_with` for a key, so
-        // its async block will be evaluated and then an error will be returned.
+        // its init closure will be evaluated and then an error will be returned.
         // Nothing will be inserted to the cache.
         let thread1 = {
             let cache1 = cache.clone();
@@ -1113,7 +1256,7 @@ mod tests {
         };
 
         // Thread2 will be the second thread to call `get_with` for the same
-        // key, so its async block will not be evaluated. Once thread1's async block
+        // key, so its init closure will not be evaluated. Once thread1's init closure
         // finishes, it will get the same error value returned by thread1's async
         // block.
         let thread2 = {
@@ -1127,8 +1270,8 @@ mod tests {
         };
 
         // Thread3 will be the third thread to call `get_with` for the same
-        // key. By the time it calls, thread1's async block should have finished
-        // already, but the key still does not exist in the cache. So its async block
+        // key. By the time it calls, thread1's init closure should have finished
+        // already, but the key still does not exist in the cache. So its init closure
         // will be evaluated and then an okay &str value will be returned. That value
         // will be inserted to the cache.
         let thread3 = {
@@ -1146,7 +1289,7 @@ mod tests {
         };
 
         // thread4 will be the fourth thread to call `get_with` for the same
-        // key. So its async block will not be evaluated. Once thread3's async block
+        // key. So its init closure will not be evaluated. Once thread3's init closure
         // finishes, it will get the same okay &str value.
         let thread4 = {
             let cache4 = cache.clone();
@@ -1159,9 +1302,9 @@ mod tests {
         };
 
         // Thread5 will be the fifth thread to call `get_with` for the same
-        // key. So its async block will not be evaluated. By the time it calls,
-        // thread3's async block should have finished already, so its async block will
-        // not be evaluated and will get the value insert by thread3's async block
+        // key. So its init closure will not be evaluated. By the time it calls,
+        // thread3's init closure should have finished already, so its init closure will
+        // not be evaluated and will get the value insert by thread3's init closure
         // immediately.
         let thread5 = {
             let cache5 = cache.clone();
@@ -1198,7 +1341,7 @@ mod tests {
         };
 
         // Thread8 will call `get` for the same key. It will call after thread3's async
-        // block finished, so it will get the value insert by thread3's async block.
+        // block finished, so it will get the value insert by thread3's init closure.
         let thread8 = {
             let cache8 = cache.clone();
             spawn(move || {


### PR DESCRIPTION
This adds `get_with_if` method requested by #123 to the following caches:

- `sync::Cache`
- `sync::SegmentedCache`
- `future::Cache`
 
* * *
Fixes #123 