### PR TITLE
Remove ptr-int transmute by converting UnsafeWeakPointer from usize to *mut T

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ unstable-debug-counters = ["future"]
 
 [dependencies]
 crossbeam-channel = "0.5.4"
-crossbeam-epoch = "0.9"
+crossbeam-epoch = "0.8.2"
 crossbeam-utils = "0.8"
 num_cpus = "1.13"
 once_cell = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ unstable-debug-counters = ["future"]
 
 [dependencies]
 crossbeam-channel = "0.5.4"
-crossbeam-epoch = "0.8.2"
+crossbeam-epoch = "0.9"
 crossbeam-utils = "0.8"
 num_cpus = "1.13"
 once_cell = "1.7"

--- a/src/sync/housekeeper.rs
+++ b/src/sync/housekeeper.rs
@@ -78,7 +78,10 @@ impl<T> Drop for Housekeeper<T> {
 }
 
 // functions/methods used by Cache
-impl<T: InnerSync> Housekeeper<T> where T: 'static {
+impl<T: InnerSync> Housekeeper<T>
+where
+    T: 'static,
+{
     pub(crate) fn new(inner: Weak<T>) -> Self {
         use crate::common::thread_pool::PoolName;
 

--- a/src/sync/housekeeper.rs
+++ b/src/sync/housekeeper.rs
@@ -39,7 +39,7 @@ pub(crate) trait InnerSync {
 }
 
 pub(crate) struct Housekeeper<T> {
-    inner: Arc<Mutex<UnsafeWeakPointer>>,
+    inner: Arc<Mutex<UnsafeWeakPointer<T>>>,
     thread_pool: Arc<ThreadPool>,
     is_shutting_down: Arc<AtomicBool>,
     periodical_sync_job: Mutex<Option<JobHandle>>,
@@ -73,12 +73,12 @@ impl<T> Drop for Housekeeper<T> {
 
         // All sync jobs should have been finished by now. Clean other stuff up.
         ThreadPoolRegistry::release_pool(&self.thread_pool);
-        std::mem::drop(unsafe { self.inner.lock().as_weak_arc::<T>() });
+        std::mem::drop(unsafe { self.inner.lock().as_weak_arc() });
     }
 }
 
 // functions/methods used by Cache
-impl<T: InnerSync> Housekeeper<T> {
+impl<T: InnerSync> Housekeeper<T> where T: 'static {
     pub(crate) fn new(inner: Weak<T>) -> Self {
         use crate::common::thread_pool::PoolName;
 
@@ -107,7 +107,7 @@ impl<T: InnerSync> Housekeeper<T> {
 
     fn start_periodical_sync_job(
         thread_pool: &Arc<ThreadPool>,
-        unsafe_weak_ptr: Arc<Mutex<UnsafeWeakPointer>>,
+        unsafe_weak_ptr: Arc<Mutex<UnsafeWeakPointer<T>>>,
         is_shutting_down: Arc<AtomicBool>,
         periodical_sync_running: Arc<Mutex<()>>,
     ) -> JobHandle {
@@ -173,10 +173,10 @@ impl<T: InnerSync> Housekeeper<T> {
 
 // private functions/methods
 impl<T: InnerSync> Housekeeper<T> {
-    fn call_sync(unsafe_weak_ptr: &Arc<Mutex<UnsafeWeakPointer>>) -> Option<SyncPace> {
+    fn call_sync(unsafe_weak_ptr: &Arc<Mutex<UnsafeWeakPointer<T>>>) -> Option<SyncPace> {
         let lock = unsafe_weak_ptr.lock();
         // Restore the Weak pointer to Inner<K, V, S>.
-        let weak = unsafe { lock.as_weak_arc::<T>() };
+        let weak = unsafe { lock.as_weak_arc() };
         if let Some(inner) = weak.upgrade() {
             // TODO: Protect this call with catch_unwind().
             let sync_pace = inner.sync(MAX_SYNC_REPEATS);

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -288,7 +288,7 @@ impl<K, V, S> Invalidator<K, V, S> {
 
 struct ScanContext<K, V, S> {
     predicates: Mutex<Vec<Predicate<K, V>>>,
-    cache: Mutex<UnsafeWeakPointer>,
+    cache: Mutex<UnsafeWeakPointer<Inner<K, V, S>>>,
     result: Mutex<Option<ScanResult<K, V>>>,
     is_running: AtomicBool,
     is_shutting_down: AtomicBool,
@@ -373,7 +373,7 @@ where
         let cache_lock = self.scan_context.cache.lock();
 
         // Restore the Weak pointer to Inner<K, V, S>.
-        let weak = unsafe { cache_lock.as_weak_arc::<Inner<K, V, S>>() };
+        let weak = unsafe { cache_lock.as_weak_arc() };
         if let Some(inner_cache) = weak.upgrade() {
             // TODO: Protect this call with catch_unwind().
             *self.scan_context.result.lock() = Some(self.do_execute(&inner_cache));


### PR DESCRIPTION
This transmute from a `Weak<T>` to a `usize` is shockingly common in both the ecosystem and the standard library. It's doubly bad because `Weak<T>` is a `repr(Rust)` type, so without manually inspecting its layout at runtime it is a mistake to assume it has any particular layout. But primarily, this is a round-trip of a pointer through an integer type via transmute, and it's pretty clear Rust cannot have a sound memory model that permits these alongside the usual suite of compiler optimizations (casts are different, they're annoying but possible to support).

If you're looking for other examples of this approach, `rayon` does a very similar thing to get pointers between threads: https://github.com/rayon-rs/rayon/blob/5b6adbbf5c6944ec42b54530820ee8c0ad0e35a9/src/lib.rs#L123-L147