### PR TITLE
Fix the CI for MSRV by pinning the versions of indexmap and native-tls

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,9 +55,18 @@ jobs:
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
         # Avoid hashbrown >= v0.12, which requires Rust 2021 edition.
+        # Avoid native-tls >= v0.2.9, which requires more recent Rust version.
         run: |
           cargo update -p dashmap --precise 5.2.0
+          cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
+          cargo update -p native-tls --precise 0.2.8
+
+      - name: Show cargo tree
+        uses: actions-rs/cargo@v1
+        with:
+          command: tree
+          args: --features 'future, dash'
 
       - name: Build (no features)
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -55,9 +55,12 @@ jobs:
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
         # Avoid hashbrown >= v0.12, which requires Rust 2021 edition.
+        # Avoid native-tls >= v0.2.9, which requires more recent Rust version.
         run: |
           cargo update -p dashmap --precise 5.2.0
+          cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
+          cargo update -p native-tls --precise 0.2.8
 
       - name: Build (no quanta feature)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
- To avoid compile errors when testing MSRV (1.51.0), run the following commands for MSRV CI to pin the versions of indexmap and native-tls crates:
    - `cargo update -p indexmap --precise 1.8.2`
    - `cargo update -p native-tls --precise 0.2.8`
- Run `cargo tree --features 'future, dash'` on the main CI.