### PR TITLE
Fix async integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,13 +54,15 @@ jobs:
 
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
-        # Avoid hashbrown >= v0.12, which requires Rust 2021 edition.
-        # Avoid native-tls >= v0.2.9, which requires more recent Rust version.
+        # hashbrown >= v0.12 requires Rust 2021 edition.
+        # native-tls >= v0.2.9 requires more recent Rust version.
+        # async-global-executor >= 2.1 requires Rust 2021 edition.
         run: |
           cargo update -p dashmap --precise 5.2.0
           cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
           cargo update -p native-tls --precise 0.2.8
+          cargo update -p async-global-executor --precise 2.0.4
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -54,13 +54,15 @@ jobs:
 
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
-        # Avoid hashbrown >= v0.12, which requires Rust 2021 edition.
-        # Avoid native-tls >= v0.2.9, which requires more recent Rust version.
+        # hashbrown >= v0.12 requires Rust 2021 edition.
+        # native-tls >= v0.2.9 requires more recent Rust version.
+        # async-global-executor >= 2.1 requires Rust 2021 edition.
         run: |
           cargo update -p dashmap --precise 5.2.0
           cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
           cargo update -p native-tls --precise 0.2.8
+          cargo update -p async-global-executor --precise 2.0.4
 
       - name: Build (no quanta feature)
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,12 @@ async-lock = { version = "2.4", optional = true }
 futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
-actix-rt = { version = "2", default-features = false }
-async-std = { version = "1", default-features = false, features = ["attributes"] }
+actix-rt = { version = "2.7", default-features = false }
+async-std = { version = "1.11", features = ["attributes"] }
 getrandom = "0.2"
 reqwest = "0.11"
 skeptic = "0.13"
-tokio = { version = "1.16", features = ["rt-multi-thread", "macros", "sync", "time" ] }
+tokio = { version = "1.19", features = ["rt-multi-thread", "macros", "sync", "time" ] }
 
 [target.'cfg(trybuild)'.dev-dependencies]
 trybuild = "1.0"

--- a/tests/runtime_async_std.rs
+++ b/tests/runtime_async_std.rs
@@ -1,8 +1,8 @@
-#![cfg(features = "future")]
+#![cfg(all(test, feature = "future"))]
 
 use moka::future::Cache;
 
-#[async_std::main]
+#[async_std::test]
 async fn main() {
     const NUM_TASKS: usize = 16;
     const NUM_KEYS_PER_TASK: usize = 64;
@@ -27,7 +27,7 @@ async fn main() {
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
                     if key % 8 == 0 {
-                        my_cache.blocking_insert(key, value(key));
+                        my_cache.blocking().insert(key, value(key));
                     } else {
                         // insert() is an async method, so await it
                         my_cache.insert(key, value(key)).await;
@@ -39,7 +39,7 @@ async fn main() {
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
                     if key % 8 == 0 {
-                        my_cache.blocking_invalidate(&key).await;
+                        my_cache.blocking().invalidate(&key);
                     } else {
                         // invalidate() is an async method, so await it
                         my_cache.invalidate(&key).await;

--- a/tests/runtime_tokio.rs
+++ b/tests/runtime_tokio.rs
@@ -1,8 +1,8 @@
-#![cfg(features = "future")]
+#![cfg(all(test, feature = "future"))]
 
 use moka::future::Cache;
 
-#[tokio::main]
+#[tokio::test]
 async fn main() {
     const NUM_TASKS: usize = 16;
     const NUM_KEYS_PER_TASK: usize = 64;
@@ -27,7 +27,7 @@ async fn main() {
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
                     if key % 8 == 0 {
-                        my_cache.blocking_insert(key, value(key));
+                        my_cache.blocking().insert(key, value(key));
                     } else {
                         // insert() is an async method, so await it
                         my_cache.insert(key, value(key)).await;
@@ -39,7 +39,7 @@ async fn main() {
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
                     if key % 8 == 0 {
-                        my_cache.blocking_invalidate(&key).await;
+                        my_cache.blocking().invalidate(&key);
                     } else {
                         // invalidate() is an async method, so await it
                         my_cache.invalidate(&key).await;


### PR DESCRIPTION
The all async integration tests under the tests folder were not running as they were ignored by the test runner. Fix the issue by correcting the attributes on the modules and functions.