### PR TITLE
Enable Cargo Audit on the CI

### DIFF
--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -1,0 +1,47 @@
+name: Cargo Audit
+
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    # https://crontab.guru/
+    - cron: '5 20 * * 5'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Moka
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain (Nightly)
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo clean
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+
+      - name: Check for known security vulnerabilities (Latest versions)
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Downgrade dependencies to minimal versions
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+          args: -Z minimal-versions
+
+      - name: Check for known security vulnerabilities (Minimal versions)
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ on:
     - '.vscode/**'
   schedule:
     # Run against the last commit on the default branch on Friday at 8pm (UTC?)
-    - cron:  '0 20 * * 5'
+    - cron: '0 20 * * 5'
 
 jobs:
   test:

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -13,7 +13,7 @@ on:
     - '.vscode/**'
   schedule:
     # Run against the last commit on the default branch on Friday at 8pm (UTC?)
-    - cron:  '0 20 * * 5'
+    - cron: '0 20 * * 5'
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ futures-util = { version = "0.3", optional = true }
 actix-rt = { version = "2.7", default-features = false }
 async-std = { version = "1.11", features = ["attributes"] }
 getrandom = "0.2"
-reqwest = "0.11"
+reqwest = "0.11.11"
 skeptic = "0.13"
 tokio = { version = "1.19", features = ["rt-multi-thread", "macros", "sync", "time" ] }
 


### PR DESCRIPTION
- Enable Cargo Audit on the CI
- Raise the minimum version for reqwest (dev dependency) to v0.11.11 to avoid the following Hyper issues
  - https://rustsec.org/advisories/RUSTSEC-2021-0078
  - https://rustsec.org/advisories/RUSTSEC-2021-0079
  - https://rustsec.org/advisories/RUSTSEC-2021-0020