### PR TITLE
Prevent segmentation fault in `sync` and `future` caches, and also upgrade crossbeam-epoch to v0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.9.2
+
+### Fixed
+
+- Fix segmentation faults in `sync` and `future` caches under heavy loads on
+  many-core machine ([#34][gh-issue-0034]):
+    - NOTE: Although this issue was found in our testing environment 10 months ago
+      (v0.5.1), no user reported that they had the same issue.
+    - NOTE: In [v0.8.4](#version-084), we added a mitigation to reduce the chance of
+      the segfaults occurring.
+
+### Changed
+
+- Upgrade crossbeam-epoch from v0.8.2 to v0.9.9 ([#157][gh-pull-0157]).
+
+
 ## Version 0.9.1
 
 ### Fixed
@@ -427,6 +443,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 
 [gh-pull-0167]: https://github.com/moka-rs/moka/pull/167/
 [gh-pull-0159]: https://github.com/moka-rs/moka/pull/159/
+[gh-pull-0157]: https://github.com/moka-rs/moka/pull/157/
 [gh-pull-0145]: https://github.com/moka-rs/moka/pull/145/
 [gh-pull-0143]: https://github.com/moka-rs/moka/pull/143/
 [gh-pull-0138]: https://github.com/moka-rs/moka/pull/138/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ atomic64 = []
 unstable-debug-counters = ["future"]
 
 [dependencies]
-crossbeam-channel = "0.5.4"
+crossbeam-channel = "0.5.5"
+crossbeam-epoch = "0.9.9"
 crossbeam-utils = "0.8"
 num_cpus = "1.13"
 once_cell = "1.7"
@@ -48,11 +49,6 @@ smallvec = "1.8"
 tagptr = "0.2"
 thiserror = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
-
-# Although v0.8.2 is not the current version (v0.9.x), we will keep using it until
-# we perform enough tests to get conformable with memory safety.
-# See: https://github.com/moka-rs/moka/issues/34
-crossbeam-epoch = "0.8.2"
 
 # Opt-out serde and stable_deref_trait features
 # https://github.com/Manishearth/triomphe/pull/5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2018"
 rust-version = "1.51"
 

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -2,7 +2,10 @@ use std::{
     hash::{BuildHasher, Hash, Hasher},
     mem::{self, MaybeUninit},
     ptr,
-    sync::atomic::{self, AtomicUsize, Ordering},
+    sync::{
+        atomic::{self, AtomicUsize, Ordering},
+        Arc, Mutex, TryLockError,
+    },
 };
 
 #[cfg(feature = "unstable-debug-counters")]
@@ -16,6 +19,7 @@ pub(crate) struct BucketArray<K, V> {
     pub(crate) buckets: Box<[Atomic<Bucket<K, V>>]>,
     pub(crate) next: Atomic<BucketArray<K, V>>,
     pub(crate) epoch: usize,
+    pub(crate) rehash_lock: Arc<Mutex<()>>,
     pub(crate) tombstone_count: AtomicUsize,
 }
 
@@ -49,6 +53,7 @@ impl<K, V> BucketArray<K, V> {
             buckets,
             next: Atomic::null(),
             epoch,
+            rehash_lock: Arc::new(Mutex::new(())),
             tombstone_count: Default::default(),
         }
     }
@@ -147,10 +152,10 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
 
             let new_bucket_ptr = this_bucket_ptr.with_tag(TOMBSTONE_TAG);
 
-            match this_bucket.compare_exchange(
+            match this_bucket.compare_exchange_weak(
                 this_bucket_ptr,
                 new_bucket_ptr,
-                Ordering::Release,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
                 guard,
             ) {
@@ -201,10 +206,10 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
 
             let new_bucket = state.into_insert_bucket();
 
-            if let Err(CompareExchangeError { new, .. }) = this_bucket.compare_exchange(
+            if let Err(CompareExchangeError { new, .. }) = this_bucket.compare_exchange_weak(
                 this_bucket_ptr,
                 new_bucket,
-                Ordering::Release,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
                 guard,
             ) {
@@ -267,10 +272,10 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
                     (state.into_insert_bucket(), None)
                 };
 
-            if let Err(CompareExchangeError { new, .. }) = this_bucket.compare_exchange(
+            if let Err(CompareExchangeError { new, .. }) = this_bucket.compare_exchange_weak(
                 this_bucket_ptr,
                 new_bucket,
-                Ordering::Release,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
                 guard,
             ) {
@@ -317,10 +322,10 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
             if this_bucket_ptr.is_null() && is_tombstone(bucket_ptr) {
                 ProbeLoopAction::Return(None)
             } else if this_bucket
-                .compare_exchange(
+                .compare_exchange_weak(
                     this_bucket_ptr,
                     bucket_ptr,
-                    Ordering::Release,
+                    Ordering::AcqRel,
                     Ordering::Relaxed,
                     guard,
                 )
@@ -398,11 +403,24 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
         guard: &'g Guard,
         build_hasher: &H,
         rehash_op: RehashOp,
-    ) -> &'g BucketArray<K, V>
+    ) -> Option<&'g BucketArray<K, V>>
     where
         K: Hash + Eq,
         H: BuildHasher,
     {
+        // Ensure that the rehashing is not performed concurrently.
+        let lock;
+        match self.rehash_lock.try_lock() {
+            Ok(lk) => lock = lk,
+            Err(TryLockError::WouldBlock) => {
+                // Wait until the lock become available.
+                std::mem::drop(self.rehash_lock.lock());
+                // We need to return here to see if rehashing is still needed.
+                return None;
+            }
+            Err(e @ TryLockError::Poisoned(_)) => panic!("{:?}", e),
+        };
+
         let next_array = self.next_array(guard, rehash_op);
 
         for this_bucket in self.buckets.iter() {
@@ -424,10 +442,10 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
 
                     while is_borrowed(next_bucket_ptr)
                         && next_bucket
-                            .compare_exchange(
+                            .compare_exchange_weak(
                                 next_bucket_ptr,
                                 to_put_ptr,
-                                Ordering::Release,
+                                Ordering::AcqRel,
                                 Ordering::Relaxed,
                                 guard,
                             )
@@ -445,10 +463,10 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
                 }
 
                 if this_bucket
-                    .compare_exchange(
+                    .compare_exchange_weak(
                         this_bucket_ptr,
                         Shared::null().with_tag(SENTINEL_TAG),
-                        Ordering::Release,
+                        Ordering::AcqRel,
                         Ordering::Relaxed,
                         guard,
                     )
@@ -466,8 +484,9 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
                 }
             }
         }
+        std::mem::drop(lock);
 
-        next_array
+        Some(next_array)
     }
 
     fn next_array(&self, guard: &'g Guard, rehash_op: RehashOp) -> &'g BucketArray<K, V> {
@@ -485,10 +504,10 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
                 Owned::new(BucketArray::with_length(self.epoch + 1, new_length))
             });
 
-            match self.next.compare_exchange(
+            match self.next.compare_exchange_weak(
                 Shared::null(),
                 new_next,
-                Ordering::Release,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
                 guard,
             ) {

--- a/src/cht/map/bucket_array_ref.rs
+++ b/src/cht/map/bucket_array_ref.rs
@@ -47,8 +47,11 @@ where
                     break;
                 }
                 Err(_) => {
-                    bucket_array_ref =
-                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand);
+                    if let Some(r) =
+                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand)
+                    {
+                        bucket_array_ref = r;
+                    }
                 }
             }
         }
@@ -81,7 +84,9 @@ where
                 if rehash_op.is_skip() {
                     break;
                 }
-                bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op);
+                if let Some(r) = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op) {
+                    bucket_array_ref = r;
+                }
             }
 
             match bucket_array_ref.remove_if(guard, hash, &mut eq, condition) {
@@ -106,8 +111,11 @@ where
                 }
                 Err(c) => {
                     condition = c;
-                    bucket_array_ref =
-                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand);
+                    if let Some(r) =
+                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand)
+                    {
+                        bucket_array_ref = r;
+                    }
                 }
             }
         }
@@ -143,7 +151,9 @@ where
                 if rehash_op.is_skip() {
                     break;
                 }
-                bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op);
+                if let Some(r) = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op) {
+                    bucket_array_ref = r;
+                }
             }
 
             match bucket_array_ref.insert_if_not_present(guard, hash, state) {
@@ -171,8 +181,11 @@ where
                 }
                 Err(s) => {
                     state = s;
-                    bucket_array_ref =
-                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand);
+                    if let Some(r) =
+                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand)
+                    {
+                        bucket_array_ref = r;
+                    }
                 }
             }
         }
@@ -207,7 +220,9 @@ where
                 if rehash_op.is_skip() {
                     break;
                 }
-                bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op);
+                if let Some(r) = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op) {
+                    bucket_array_ref = r;
+                }
             }
 
             match bucket_array_ref.insert_or_modify(guard, hash, state, on_modify) {
@@ -235,8 +250,11 @@ where
                 Err((s, f)) => {
                     state = s;
                     on_modify = f;
-                    bucket_array_ref =
-                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand);
+                    if let Some(r) =
+                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand)
+                    {
+                        bucket_array_ref = r;
+                    }
                 }
             }
         }
@@ -260,8 +278,11 @@ where
                     break;
                 }
                 Err(_) => {
-                    bucket_array_ref =
-                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand);
+                    if let Some(r) =
+                        bucket_array_ref.rehash(guard, self.build_hasher, RehashOp::Expand)
+                    {
+                        bucket_array_ref = r;
+                    }
                 }
             }
         }
@@ -286,10 +307,10 @@ impl<'a, 'g, K, V, S> BucketArrayRef<'a, K, V, S> {
             let new_bucket_array =
                 maybe_new_bucket_array.unwrap_or_else(|| Owned::new(BucketArray::default()));
 
-            match self.bucket_array.compare_exchange(
+            match self.bucket_array.compare_exchange_weak(
                 Shared::null(),
                 new_bucket_array,
-                Ordering::Release,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
                 guard,
             ) {
@@ -315,10 +336,10 @@ impl<'a, 'g, K, V, S> BucketArrayRef<'a, K, V, S> {
                 return;
             }
 
-            match self.bucket_array.compare_exchange(
+            match self.bucket_array.compare_exchange_weak(
                 current_ptr,
                 min_ptr,
-                Ordering::Release,
+                Ordering::AcqRel,
                 Ordering::Relaxed,
                 guard,
             ) {


### PR DESCRIPTION
(Rewritten on July 19, 2022)

## Changes

Prevent segmentation fault (use-after-free) in `sync` and `future` caches. (Fixes #34):

- It was caused by race-conditions when many threads are concurrently rehashing (extending or shrinking) an internal hash table `moka::cht`:
    - Although the creator of the original `cht` designed the rehashing to work fine in such situation, it is not working as expected.
    - To fix it, add a lock to the rehash function to ensure only one thread can participate rehashing at a time.
- To prevent potential inconsistency issues in non x86 based systems, strengthen the memory ordering used for `compare_exchange_weak`.
    - Before: `Ordering::Release`, meaning read: relaxed, write: release.
    - After: `Ordering::AcqRel`, meaning read: acquire, write: release.

Upgrade crossbeam-epoch from v0.8.2 to v0.9.9:

- Upgrade crossbeam-epoch dependency in Cargo.toml from v0.8.2 to v0.9.9.
- Replace deprecated `compare_and_set_weak` with `compare_exchange_weak`.

## Testing

Ran mokabench with the following arguments several times and no segmentation fault occurred.

```console
$ cargo run --release -- --insert-once --repeat 20
```

Notes:
- For testing purpose, Modified Moka's code to reduce the number of internal segments of `cht` from 64 to 1.
    - This will make segfault to occur more often. e.g., without the fix, it occurred within 30 seconds on the Linux x86_64 environment below.
    - The above test took about 30 minutes on the same Linux x86_64 environment, and it no longer occurred after the fix.

Testing environment:

- Linux x86_64 (WSL 2) on Intel Core i7-12700F CPU (20 logical cores)
- macOS arm64 on Apple M1 chip (8 cores)