### PR TITLE
Fix CI failures for Rust 1.62 and Clippy beta 0.1.63

### DIFF
--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -95,29 +95,44 @@ impl AccessTime for EntryInfo {
 mod test {
     use super::EntryInfo;
 
-    // Ignore this test by default as struct size may change in the future.
+    // Note: the size of the struct may change in a future version of Rust.
     // #[ignore]
     #[test]
     fn check_struct_size() {
         use std::mem::size_of;
 
-        // As of Rust 1.61.
-        let size = if cfg!(target_pointer_width = "64") {
-            if cfg!(feature = "quanta") {
-                24
-            } else {
-                72
-            }
-        } else if cfg!(target_pointer_width = "32") {
-            if cfg!(feature = "quanta") {
-                24
-            } else {
-                40
-            }
-        } else {
-            // ignore
-            return;
-        };
+        // Rust 1.62:
+        //
+        // | pointer width | quanta | no quanta |
+        // | ------------- | ------ | --------- |
+        // | 64-bit        |   24   |     72    |
+        // | 32-bit        |   24   |     72    |
+
+        let size = if cfg!(feature = "quanta") { 24 } else { 72 };
+
+        // Rust 1.61 or older:
+        //
+        // | pointer width | quanta | no quanta |
+        // | ------------- | ------ | --------- |
+        // | 64-bit        |   24   |     72    |
+        // | 32-bit        |   24   |     40    |
+        //
+        // let size = if cfg!(target_pointer_width = "64") {
+        //     if cfg!(feature = "quanta") {
+        //         24
+        //     } else {
+        //         72
+        //     }
+        // } else if cfg!(target_pointer_width = "32") {
+        //     if cfg!(feature = "quanta") {
+        //         24
+        //     } else {
+        //         40
+        //     }
+        // } else {
+        //     // ignore
+        //     return;
+        // };
 
         assert_eq!(size_of::<EntryInfo>(), size);
     }

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -230,7 +230,6 @@ impl<K, V, S> BaseCache<K, V, S> {
         let i = &self.inner;
         let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
         let now = i.current_time_from_expiration_clock();
-        let entry = &*entry;
 
         is_expired_entry_wo(ttl, va, entry, now) || is_expired_entry_ao(tti, va, entry, now)
     }
@@ -1060,7 +1059,7 @@ where
             // Peek the front node of the deque and check if it is expired.
             let key = deq.peek_front().and_then(|node| {
                 // TODO: Skip the entry if it is dirty. See `evict_lru_entries` method as an example.
-                if is_expired_entry_ao(tti, va, &*node, now) {
+                if is_expired_entry_ao(tti, va, node, now) {
                     Some(Arc::clone(node.element.key()))
                 } else {
                     None
@@ -1133,7 +1132,7 @@ where
         for _ in 0..batch_size {
             let key = deqs.write_order.peek_front().and_then(|node| {
                 // TODO: Skip the entry if it is dirty. See `evict_lru_entries` method as an example.
-                if is_expired_entry_wo(ttl, va, &*node, now) {
+                if is_expired_entry_wo(ttl, va, node, now) {
                     Some(Arc::clone(node.element.key()))
                 } else {
                     None

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1243,7 +1243,7 @@ where
             // Peek the front node of the deque and check if it is expired.
             let key_hash = deq.peek_front().and_then(|node| {
                 // TODO: Skip the entry if it is dirty. See `evict_lru_entries` method as an example.
-                if is_expired_entry_ao(tti, va, &*node, now) {
+                if is_expired_entry_ao(tti, va, node, now) {
                     Some((Arc::clone(node.element.key()), node.element.hash()))
                 } else {
                     None
@@ -1317,7 +1317,7 @@ where
         for _ in 0..batch_size {
             let key = deqs.write_order.peek_front().and_then(|node| {
                 // TODO: Skip the entry if it is dirty. See `evict_lru_entries` method as an example.
-                if is_expired_entry_wo(ttl, va, &*node, now) {
+                if is_expired_entry_wo(ttl, va, node, now) {
                     Some(Arc::clone(node.element.key()))
                 } else {
                     None

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -868,7 +868,7 @@ where
             let key = deq
                 .peek_front()
                 .and_then(|node| {
-                    if Self::is_expired_entry_ao(time_to_idle, &*node, now) {
+                    if Self::is_expired_entry_ao(time_to_idle, node, now) {
                         Some(Some(Rc::clone(&node.element.key)))
                     } else {
                         None
@@ -909,7 +909,7 @@ where
                 .write_order
                 .peek_front()
                 .and_then(|node| {
-                    if Self::is_expired_entry_wo(time_to_live, &*node, now) {
+                    if Self::is_expired_entry_wo(time_to_live, node, now) {
                         Some(Some(Rc::clone(&node.element.key)))
                     } else {
                         None


### PR DESCRIPTION
- Update `check_struct_size` of `EntryInfo` struct as the size of the struct changed in Rust 1.62 for 32 bit platforms.
    - `EntryInfo` on some 32 bit platform has a field with `RwLock`.
- Fix Clippy warnings. (Clippy beta 0.1.63, 6c1f1428998 2022-06-28)