### PR TITLE
Add `logging` feature to enable optional `log` crate dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,11 +88,11 @@ jobs:
           command: test
           args: --no-default-features --features 'future, atomic64, quanta'
 
-      - name: Run tests (future and sync features)
+      - name: Run tests (future, sync and logging features)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features 'future, sync'
+          args: --features 'future, sync, logging'
 
       - name: Run tests (dash feature, but no sync feature)
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -82,11 +82,11 @@ jobs:
           command: test
           args: --no-default-features --features 'future, atomic64'
 
-      - name: Run tests (future feature, but no quanta feature)
+      - name: Run tests (future, sync and logging features, but no quanta feature)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features 'sync, future, atomic64'
+          args: --no-default-features --features 'sync, future, atomic64, logging'
 
       - name: Run tests (dash feature, but no quanta and sync features)
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ future = ["crossbeam-epoch", "thiserror", "uuid", "async-io", "async-lock", "fut
 # few releases.
 dash = ["dashmap"]
 
+# Enable this feature to activate optional logging from caches.
+# Currently cache will emit log only when it encounters a panic in user provided
+# callback closure.
+logging = ["log"]
+
 # This feature is enabled by default. Disable it when the target platform does not
 # support `std::sync::atomic::AtomicU64`. (e.g. `armv5te-unknown-linux-musleabi`
 # or `mips-unknown-linux-musl`)
@@ -72,6 +77,9 @@ dashmap = { version = "5.2", optional = true }
 async-io = { version = "1.4", optional = true }
 async-lock = { version = "2.4", optional = true }
 futures-util = { version = "0.3", optional = true }
+
+# Optional dependencies (logging)
+log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 actix-rt = { version = "2.7", default-features = false }


### PR DESCRIPTION
This PR adds `logging` feature, which enables optional dependency to `log` crate. (This feature will be used by the eviction listener #145)
