### PR TITLE
Optionally disable thread pools in `sync::Cache`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,6 +78,18 @@ jobs:
           command: test
           args: --features sync
 
+      - name: Run tests (debug, sync feature, thread-pool test for sync::Cache)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+      - name: Run tests (debug, sync feature, thread-pool test for sync::SegmentCache)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
       - name: Run tests (release, sync feature)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,12 +57,14 @@ jobs:
         # hashbrown >= v0.12 requires Rust 2021 edition.
         # native-tls >= v0.2.9 requires more recent Rust version.
         # async-global-executor >= 2.1 requires Rust 2021 edition.
+        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
         run: |
           cargo update -p dashmap --precise 5.2.0
           cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
           cargo update -p native-tls --precise 0.2.8
           cargo update -p async-global-executor --precise 2.0.4
+          cargo update -p pulldown-cmark --precise 0.9.1
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -57,12 +57,14 @@ jobs:
         # hashbrown >= v0.12 requires Rust 2021 edition.
         # native-tls >= v0.2.9 requires more recent Rust version.
         # async-global-executor >= 2.1 requires Rust 2021 edition.
+        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
         run: |
           cargo update -p dashmap --precise 5.2.0
           cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
           cargo update -p native-tls --precise 0.2.8
           cargo update -p async-global-executor --precise 2.0.4
+          cargo update -p pulldown-cmark --precise 0.9.1
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 0.9.3
 
+### Added
+
+- Add a configuration option to the following caches to avoid to start the global
+  thread pools ([#165][gh-pull-0165]):
+    - `sync::Cache`
+    - `sync::SegmentedCache`
+
 ### Fixed
 
 - Ensure that the following caches will drop the value of evicted entries immediately
@@ -463,6 +470,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 
 [gh-pull-0169]: https://github.com/moka-rs/moka/pull/169/
 [gh-pull-0167]: https://github.com/moka-rs/moka/pull/167/
+[gh-pull-0165]: https://github.com/moka-rs/moka/pull/165/
 [gh-pull-0159]: https://github.com/moka-rs/moka/pull/159/
 [gh-pull-0157]: https://github.com/moka-rs/moka/pull/157/
 [gh-pull-0145]: https://github.com/moka-rs/moka/pull/145/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 actix-rt = { version = "2.7", default-features = false }
-anyhow = "1.0"
+anyhow = "1.0.19"
 async-std = { version = "1.11", features = ["attributes"] }
 env_logger = "0.9"
 getrandom = "0.2"

--- a/src/common/builder_utils.rs
+++ b/src/common/builder_utils.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
 
+#[cfg(any(feature = "sync", feature = "future"))]
+use super::concurrent::housekeeper;
+
 const YEAR_SECONDS: u64 = 365 * 24 * 3600;
 
 pub(crate) fn ensure_expirations_or_panic(
@@ -12,5 +15,14 @@ pub(crate) fn ensure_expirations_or_panic(
     }
     if let Some(d) = time_to_idle {
         assert!(d <= max_duration, "time_to_idle is longer than 1000 years");
+    }
+}
+
+#[cfg(any(feature = "sync", feature = "future"))]
+pub(crate) fn housekeeper_conf(thread_pool_enabled: bool) -> housekeeper::Configuration {
+    if thread_pool_enabled {
+        housekeeper::Configuration::new_thread_pool(true)
+    } else {
+        housekeeper::Configuration::new_blocking()
     }
 }

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -30,6 +30,7 @@ use std::{
 pub(crate) trait InnerSync {
     fn sync(&self, max_sync_repeats: usize) -> Option<SyncPace>;
 
+    #[cfg(any(feature = "sync", feature = "future"))]
     fn now(&self) -> Instant;
 }
 
@@ -150,8 +151,11 @@ impl BlockingHousekeeper {
             Ordering::Relaxed,
         ) {
             Ok(_) => {
-                let now = cache.now();
-                self.sync_after.set_instant(Self::sync_after(now));
+                #[cfg(any(feature = "sync", feature = "future"))]
+                {
+                    let now = cache.now();
+                    self.sync_after.set_instant(Self::sync_after(now));
+                }
 
                 cache.sync(MAX_SYNC_REPEATS);
 

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -33,6 +33,24 @@ pub(crate) struct ThreadPool {
     // pub(crate) num_threads: usize,
 }
 
+impl ThreadPool {
+    fn new(name: PoolName, num_threads: usize) -> Self {
+        // println!("Created pool: {:?}", name);
+        let pool = ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);
+        Self {
+            name,
+            pool,
+            // num_threads,
+        }
+    }
+}
+
+// impl Drop for ThreadPool {
+//     fn drop(&mut self) {
+//         println!("Dropped pool: {:?}", self.name)
+//     }
+// }
+
 pub(crate) struct ThreadPoolRegistry {
     pools: RwLock<HashMap<PoolName, Arc<ThreadPool>>>,
 }
@@ -64,14 +82,8 @@ impl ThreadPoolRegistry {
                     // https://github.com/moka-rs/moka/pull/39#issuecomment-916888859
                     // https://github.com/seanmonstar/num_cpus/issues/69
                     let num_threads = num_cpus::get().max(1);
-                    let pool =
-                        ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);
-                    let t_pool = ThreadPool {
-                        name,
-                        pool,
-                        // num_threads,
-                    };
-                    Arc::new(t_pool)
+                    let pool = ThreadPool::new(name, num_threads);
+                    Arc::new(pool)
                 });
             }
         }

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -35,7 +35,6 @@ pub(crate) struct ThreadPool {
 
 impl ThreadPool {
     fn new(name: PoolName, num_threads: usize) -> Self {
-        // println!("Created pool: {:?}", name);
         let pool = ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);
         Self {
             name,
@@ -44,12 +43,6 @@ impl ThreadPool {
         }
     }
 }
-
-// impl Drop for ThreadPool {
-//     fn drop(&mut self) {
-//         println!("Dropped pool: {:?}", self.name)
-//     }
-// }
 
 pub(crate) struct ThreadPoolRegistry {
     pools: RwLock<HashMap<PoolName, Arc<ThreadPool>>>,

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 
 static REGISTRY: Lazy<ThreadPoolRegistry> = Lazy::new(ThreadPoolRegistry::default);
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(any(feature = "sync", feature = "future"), derive(Debug))]
 pub(crate) enum PoolName {
     Housekeeper,
@@ -101,5 +101,12 @@ impl ThreadPoolRegistry {
                 }
             }
         }
+    }
+
+    #[cfg(all(test, feature = "sync"))]
+    pub(crate) fn enabled_pools() -> Vec<PoolName> {
+        let mut names: Vec<_> = REGISTRY.pools.read().keys().cloned().collect();
+        names.sort_unstable();
+        names
     }
 }

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -706,6 +706,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "sync", feature = "future"))]
     fn now(&self) -> Instant {
         unreachable!()
     }

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -349,12 +349,12 @@ where
 
     #[inline]
     fn should_apply_reads(ch_len: usize) -> bool {
-        ch_len >= READ_LOG_FLUSH_POINT / 8
+        ch_len >= READ_LOG_FLUSH_POINT
     }
 
     #[inline]
     fn should_apply_writes(ch_len: usize) -> bool {
-        ch_len >= WRITE_LOG_FLUSH_POINT / 8
+        ch_len >= WRITE_LOG_FLUSH_POINT
     }
 }
 

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -705,6 +705,10 @@ where
             None
         }
     }
+
+    fn now(&self) -> Instant {
+        unreachable!()
+    }
 }
 
 //

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -122,6 +122,7 @@ where
             self.time_to_live,
             self.time_to_idle,
             self.invalidator_enabled,
+            builder_utils::housekeeper_conf(true),
         )
     }
 
@@ -148,6 +149,7 @@ where
             self.time_to_live,
             self.time_to_idle,
             self.invalidator_enabled,
+            builder_utils::housekeeper_conf(true),
         )
     }
 }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     common::concurrent::{
         constants::{MAX_SYNC_REPEATS, WRITE_RETRY_INTERVAL_MICROS},
-        housekeeper::InnerSync,
+        housekeeper::{self, InnerSync},
         Weigher, WriteOp,
     },
     notification::{self, EvictionListener},
@@ -660,6 +660,7 @@ where
             None,
             None,
             false,
+            housekeeper::Configuration::new_thread_pool(true),
         )
     }
 
@@ -691,6 +692,7 @@ where
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
         invalidator_enabled: bool,
+        housekeeper_conf: housekeeper::Configuration,
     ) -> Self {
         Self {
             base: BaseCache::new(
@@ -704,6 +706,7 @@ where
                 time_to_live,
                 time_to_idle,
                 invalidator_enabled,
+                housekeeper_conf,
             ),
             value_initializer: Arc::new(ValueInitializer::with_hasher(build_hasher)),
         }
@@ -834,10 +837,10 @@ where
     ///
     /// # Panics
     ///
-    /// This method panics when the `init` future has been panicked. When it happens,
-    /// only the caller whose `init` future panicked will get the panic (e.g. only
-    /// task 3 in the above sample). If there are other calls in progress (e.g. task
-    /// 0, 1 and 2 above), this method will restart and resolve one of the remaining
+    /// This method panics when the `init` future has panicked. When it happens, only
+    /// the caller whose `init` future panicked will get the panic (e.g. only task 3
+    /// in the above sample). If there are other calls in progress (e.g. task 0, 1
+    /// and 2 above), this method will restart and resolve one of the remaining
     /// `init` futures.
     ///
     pub async fn get_with(&self, key: K, init: impl Future<Output = V>) -> V {
@@ -952,10 +955,10 @@ where
     ///
     /// # Panics
     ///
-    /// This method panics when the `init` future has been panicked. When it happens,
-    /// only the caller whose `init` future panicked will get the panic (e.g. only
-    /// task 2 in the above sample). If there are other calls in progress (e.g. task
-    /// 0, 1 and 3 above), this method will restart and resolve one of the remaining
+    /// This method panics when the `init` future has panicked. When it happens, only
+    /// the caller whose `init` future panicked will get the panic (e.g. only task 2
+    /// in the above sample). If there are other calls in progress (e.g. task 0, 1
+    /// and 3 above), this method will restart and resolve one of the remaining
     /// `init` futures.
     ///
     pub async fn try_get_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
@@ -983,7 +986,8 @@ where
         let key = Arc::new(key);
         let op = self.base.do_insert_with_hash(key, hash, value);
         let hk = self.base.housekeeper.as_ref();
-        Self::blocking_schedule_write_op(&self.base.write_op_ch, op, hk).expect("Failed to insert");
+        Self::blocking_schedule_write_op(self.base.inner.as_ref(), &self.base.write_op_ch, op, hk)
+            .expect("Failed to insert");
     }
 
     /// Discards any cached value for the key.
@@ -1002,7 +1006,7 @@ where
             }
             let op = WriteOp::Remove(kv);
             let hk = self.base.housekeeper.as_ref();
-            Self::schedule_write_op(&self.base.write_op_ch, op, hk)
+            Self::schedule_write_op(self.base.inner.as_ref(), &self.base.write_op_ch, op, hk)
                 .await
                 .expect("Failed to remove");
         }
@@ -1017,8 +1021,13 @@ where
         if let Some(kv) = self.base.remove_entry(key, hash) {
             let op = WriteOp::Remove(kv);
             let hk = self.base.housekeeper.as_ref();
-            Self::blocking_schedule_write_op(&self.base.write_op_ch, op, hk)
-                .expect("Failed to remove");
+            Self::blocking_schedule_write_op(
+                self.base.inner.as_ref(),
+                &self.base.write_op_ch,
+                op,
+                hk,
+            )
+            .expect("Failed to remove");
         }
     }
 
@@ -1243,13 +1252,14 @@ where
     async fn insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) {
         let op = self.base.do_insert_with_hash(key, hash, value);
         let hk = self.base.housekeeper.as_ref();
-        Self::schedule_write_op(&self.base.write_op_ch, op, hk)
+        Self::schedule_write_op(self.base.inner.as_ref(), &self.base.write_op_ch, op, hk)
             .await
             .expect("Failed to insert");
     }
 
     #[inline]
     async fn schedule_write_op(
+        inner: &impl InnerSync,
         ch: &Sender<WriteOp<K, V>>,
         op: WriteOp<K, V>,
         housekeeper: Option<&HouseKeeperArc<K, V, S>>,
@@ -1259,7 +1269,7 @@ where
         // TODO: Try to replace the timer with an async event listener to see if it
         // can provide better performance.
         loop {
-            BaseCache::apply_reads_writes_if_needed(ch, housekeeper);
+            BaseCache::apply_reads_writes_if_needed(inner, ch, housekeeper);
             match ch.try_send(op) {
                 Ok(()) => break,
                 Err(TrySendError::Full(op1)) => {
@@ -1275,6 +1285,7 @@ where
 
     #[inline]
     fn blocking_schedule_write_op(
+        inner: &impl InnerSync,
         ch: &Sender<WriteOp<K, V>>,
         op: WriteOp<K, V>,
         housekeeper: Option<&HouseKeeperArc<K, V, S>>,
@@ -1282,7 +1293,7 @@ where
         let mut op = op;
 
         loop {
-            BaseCache::apply_reads_writes_if_needed(ch, housekeeper);
+            BaseCache::apply_reads_writes_if_needed(inner, ch, housekeeper);
             match ch.try_send(op) {
                 Ok(()) => break,
                 Err(TrySendError::Full(op1)) => {

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -389,11 +389,15 @@ impl<K, V, C> CacheBuilder<K, V, C> {
         }
     }
 
-    /// Specify whether or not to enable thread pool for housekeeping tasks, such as
-    /// ... `true` to enable and `false` to disable.
+    /// Specify whether or not to enable the thread pool for housekeeping tasks.
+    /// These tasks include removing expired entries and updating the LRU queue and
+    /// LFU filter. `true` to enable and `false` to disable. (Default: `true`)
+    /// 
+    /// If disabled, the housekeeping tasks will be executed by a client thread when
+    /// necessary.
     ///
-    /// The thread pool is enabled by default in current version of Moka but the
-    /// default will be changed to disabled in future version.
+    /// NOTE: The default value will be changed to `false` in a future release
+    /// (v0.10.0 or v0.11.0).
     pub fn thread_pool_enabled(self, v: bool) -> Self {
         Self {
             thread_pool_enabled: v,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -56,6 +56,7 @@ pub struct CacheBuilder<K, V, C> {
     time_to_live: Option<Duration>,
     time_to_idle: Option<Duration>,
     invalidator_enabled: bool,
+    thread_pool_enabled: bool,
     cache_type: PhantomData<C>,
 }
 
@@ -76,6 +77,8 @@ where
             time_to_live: None,
             time_to_idle: None,
             invalidator_enabled: false,
+            // TODO: Change this to `false` in Moka 0.10.0.
+            thread_pool_enabled: true,
             cache_type: Default::default(),
         }
     }
@@ -117,6 +120,7 @@ where
             time_to_live: self.time_to_live,
             time_to_idle: self.time_to_idle,
             invalidator_enabled: self.invalidator_enabled,
+            thread_pool_enabled: self.thread_pool_enabled,
             cache_type: PhantomData::default(),
         }
     }
@@ -145,6 +149,7 @@ where
             self.time_to_live,
             self.time_to_idle,
             self.invalidator_enabled,
+            builder_utils::housekeeper_conf(self.thread_pool_enabled),
         )
     }
 
@@ -174,6 +179,7 @@ where
             self.time_to_live,
             self.time_to_idle,
             self.invalidator_enabled,
+            builder_utils::housekeeper_conf(self.thread_pool_enabled),
         )
     }
 }
@@ -208,6 +214,7 @@ where
             self.time_to_live,
             self.time_to_idle,
             self.invalidator_enabled,
+            builder_utils::housekeeper_conf(self.thread_pool_enabled),
         )
     }
 
@@ -238,6 +245,7 @@ where
             self.time_to_live,
             self.time_to_idle,
             self.invalidator_enabled,
+            builder_utils::housekeeper_conf(true),
         )
     }
 }
@@ -377,6 +385,18 @@ impl<K, V, C> CacheBuilder<K, V, C> {
     pub fn support_invalidation_closures(self) -> Self {
         Self {
             invalidator_enabled: true,
+            ..self
+        }
+    }
+
+    /// Specify whether or not to enable thread pool for housekeeping tasks, such as
+    /// ... `true` to enable and `false` to disable.
+    ///
+    /// The thread pool is enabled by default in current version of Moka but the
+    /// default will be changed to disabled in future version.
+    pub fn thread_pool_enabled(self, v: bool) -> Self {
+        Self {
+            thread_pool_enabled: v,
             ..self
         }
     }

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -392,7 +392,7 @@ impl<K, V, C> CacheBuilder<K, V, C> {
     /// Specify whether or not to enable the thread pool for housekeeping tasks.
     /// These tasks include removing expired entries and updating the LRU queue and
     /// LFU filter. `true` to enable and `false` to disable. (Default: `true`)
-    /// 
+    ///
     /// If disabled, the housekeeping tasks will be executed by a client thread when
     /// necessary.
     ///

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -3064,7 +3064,7 @@ mod tests {
     // Ignored by default. This test cannot run in parallel with other tests.
     #[test]
     #[ignore]
-    fn enabled_thread_pools() {
+    fn enabling_and_disabling_thread_pools() {
         use crate::common::concurrent::thread_pool::{PoolName::*, ThreadPoolRegistry};
 
         // Enable the housekeeper pool.

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1,6 +1,6 @@
 use super::{cache::Cache, CacheBuilder, ConcurrentCacheExt};
 use crate::{
-    common::concurrent::Weigher,
+    common::concurrent::{housekeeper, Weigher},
     notification::{self, EvictionListener},
     sync_base::iter::{Iter, ScanningGet},
     Policy, PredicateError,
@@ -107,6 +107,7 @@ where
             None,
             None,
             false,
+            housekeeper::Configuration::new_thread_pool(true),
         )
     }
 
@@ -216,6 +217,7 @@ where
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
         invalidator_enabled: bool,
+        housekeeper_conf: housekeeper::Configuration,
     ) -> Self {
         Self {
             inner: Arc::new(Inner::new(
@@ -230,6 +232,7 @@ where
                 time_to_live,
                 time_to_idle,
                 invalidator_enabled,
+                housekeeper_conf,
             )),
         }
     }
@@ -597,6 +600,7 @@ where
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,
         invalidator_enabled: bool,
+        housekeeper_conf: housekeeper::Configuration,
     ) -> Self {
         assert!(num_segments > 0);
 
@@ -620,6 +624,7 @@ where
                     time_to_live,
                     time_to_idle,
                     invalidator_enabled,
+                    housekeeper_conf.clone(),
                 )
             })
             .collect::<Vec<_>>();

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1668,6 +1668,76 @@ mod tests {
         assert_eq!(counters.value_dropped(), KEYS, "value_dropped");
     }
 
+    // Ignored by default. This test cannot run in parallel with other tests.
+    #[test]
+    #[ignore]
+    fn enabled_thread_pools() {
+        use crate::common::concurrent::thread_pool::{PoolName::*, ThreadPoolRegistry};
+
+        const NUM_SEGMENTS: usize = 4;
+
+        // Enable the housekeeper pool.
+        {
+            let cache = SegmentedCache::builder(NUM_SEGMENTS)
+                .thread_pool_enabled(true)
+                .build();
+            cache.insert('a', "a");
+            let enabled_pools = ThreadPoolRegistry::enabled_pools();
+            assert_eq!(enabled_pools, &[Housekeeper]);
+        }
+
+        // Enable the housekeeper and invalidator pools.
+        {
+            let cache = SegmentedCache::builder(NUM_SEGMENTS)
+                .thread_pool_enabled(true)
+                .support_invalidation_closures()
+                .build();
+            cache.insert('a', "a");
+            let enabled_pools = ThreadPoolRegistry::enabled_pools();
+            assert_eq!(enabled_pools, &[Housekeeper, Invalidator]);
+        }
+
+        // Queued delivery mode: Enable the housekeeper and removal notifier pools.
+        {
+            let listener = |_k, _v, _cause| {};
+            let listener_conf = notification::Configuration::builder()
+                .delivery_mode(DeliveryMode::Queued)
+                .build();
+            let cache = SegmentedCache::builder(NUM_SEGMENTS)
+                .thread_pool_enabled(true)
+                .eviction_listener_with_conf(listener, listener_conf)
+                .build();
+            cache.insert('a', "a");
+            let enabled_pools = ThreadPoolRegistry::enabled_pools();
+            assert_eq!(enabled_pools, &[Housekeeper, RemovalNotifier]);
+        }
+
+        // Immediate delivery mode: Enable only the housekeeper pool.
+        {
+            let listener = |_k, _v, _cause| {};
+            let listener_conf = notification::Configuration::builder()
+                .delivery_mode(DeliveryMode::Immediate)
+                .build();
+            let cache = SegmentedCache::builder(NUM_SEGMENTS)
+                .thread_pool_enabled(true)
+                .eviction_listener_with_conf(listener, listener_conf)
+                .build();
+            cache.insert('a', "a");
+            let enabled_pools = ThreadPoolRegistry::enabled_pools();
+            assert_eq!(enabled_pools, &[Housekeeper]);
+        }
+
+        // Disable all pools.
+        {
+            let cache = SegmentedCache::builder(NUM_SEGMENTS)
+                .thread_pool_enabled(false)
+                .build();
+            cache.insert('a', "a");
+            let enabled_pools = ThreadPoolRegistry::enabled_pools();
+            assert!(enabled_pools.is_empty());
+        }
+    }
+
     #[test]
     fn test_debug_format() {
         let cache = SegmentedCache::new(10, 4);

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1671,7 +1671,7 @@ mod tests {
     // Ignored by default. This test cannot run in parallel with other tests.
     #[test]
     #[ignore]
-    fn enabled_thread_pools() {
+    fn enabling_and_disabling_thread_pools() {
         use crate::common::concurrent::thread_pool::{PoolName::*, ThreadPoolRegistry};
 
         const NUM_SEGMENTS: usize = 4;

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1116,6 +1116,10 @@ where
             None
         }
     }
+
+    fn now(&self) -> Instant {
+        self.current_time_from_expiration_clock()
+    }
 }
 
 //

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -277,9 +277,9 @@ where
     ) {
         let w_len = ch.len();
 
-        if Self::should_apply_writes(w_len) {
-            if let Some(h) = housekeeper {
-                h.try_sync(inner);
+        if let Some(hk) = housekeeper {
+            if Self::should_apply_writes(hk, w_len) {
+                hk.try_sync(inner);
             }
         }
     }
@@ -487,21 +487,21 @@ where
     fn apply_reads_if_needed(&self, inner: &Inner<K, V, S>) {
         let len = self.read_op_ch.len();
 
-        if Self::should_apply_reads(len) {
-            if let Some(h) = &self.housekeeper {
-                h.try_sync(inner);
+        if let Some(hk) = &self.housekeeper {
+            if Self::should_apply_reads(hk, len) {
+                hk.try_sync(inner);
             }
         }
     }
 
     #[inline]
-    fn should_apply_reads(ch_len: usize) -> bool {
-        ch_len >= READ_LOG_FLUSH_POINT / 8
+    fn should_apply_reads(hk: &HouseKeeperArc<K, V, S>, ch_len: usize) -> bool {
+        hk.should_apply_reads(ch_len)
     }
 
     #[inline]
-    fn should_apply_writes(ch_len: usize) -> bool {
-        ch_len >= WRITE_LOG_FLUSH_POINT / 8
+    fn should_apply_writes(hk: &HouseKeeperArc<K, V, S>, ch_len: usize) -> bool {
+        hk.should_apply_writes(ch_len)
     }
 }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1117,6 +1117,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "sync", feature = "future"))]
     fn now(&self) -> Instant {
         self.current_time_from_expiration_clock()
     }


### PR DESCRIPTION
## Changes

### API Changes

- Add `thread_pool_enabled` method with a `bool` parameter to `sync::CacheBuilder`.
    - If called with `false`, it will disable the thread pool for the housekeeper for the cache being built.

### Internal Changes

- Rename current thread-pool based `Housekeeper` to `ThreadPoolHousekeeper`.
- Add `BlockingHousekeeper`.
