### PR TITLE
Change the trait bound `Arc<K>: Borrow<Q>` to `K: Borrow<Q>` (`sync` and `future` caches)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "deqs",
         "Deque",
         "Deques",
+        "docsrs",
         "Einziger",
         "else's",
         "Eytan",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.9.1
+
+### Fixed (Changed)
+
+- Relax the too restrictive requirement `Arc<K>: Borrow<Q>` to `K: Borrow<Q>` for the
+  `contains_key`, `get` and `invalidate` methods of the following caches, so that
+  they will accept `&[u8]` as the key when `K` is `Vec<u8>`: ([#167][gh-pull-0167])
+    - `sync::Cache`
+    - `sync::SegmentedCache`
+    - `future::Cache`
+
+
 ## Version 0.9.0
 
 ### Added
 
 - Add support for eviction listener to the following caches ([#145][gh-pull-0145]).
   Eviction listener is a callback function that will be called when an entry is
-  removed from the cache.
+  removed from the cache:
     - `sync::Cache`
     - `sync::SegmentedCache`
     - `future::Cache`
@@ -412,6 +424,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0167]: https://github.com/moka-rs/moka/pull/167/
 [gh-pull-0159]: https://github.com/moka-rs/moka/pull/159/
 [gh-pull-0145]: https://github.com/moka-rs/moka/pull/145/
 [gh-pull-0143]: https://github.com/moka-rs/moka/pull/143/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 rust-version = "1.51"
 

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -124,7 +124,9 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
                 return ProbeLoopAction::Return(Shared::null());
             };
 
-            if !eq(&this_bucket_ref.key) {
+            let this_key = &this_bucket_ref.key;
+
+            if !eq(this_key) {
                 // Different key. Try next bucket.
                 return ProbeLoopAction::Continue;
             }
@@ -136,7 +138,7 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
 
             let this_value = unsafe { &*this_bucket_ref.maybe_value.as_ptr() };
 
-            if !condition(&this_bucket_ref.key, this_value) {
+            if !condition(this_key, this_value) {
                 // Found but the condition is false. Do not remove.
                 return ProbeLoopAction::Return(Shared::null());
             }
@@ -180,8 +182,7 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
             let state = maybe_state.take().unwrap();
 
             if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() } {
-                let this_key: &K = &this_bucket_ref.key;
-                if this_key != state.key() {
+                if &this_bucket_ref.key != state.key() {
                     // Different key. Try next bucket.
                     maybe_state = Some(state);
                     return ProbeLoopAction::Continue;
@@ -239,7 +240,7 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
 
             let (new_bucket, maybe_insert_value) =
                 if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() } {
-                    let this_key: &K = &this_bucket_ref.key;
+                    let this_key = &this_bucket_ref.key;
 
                     if this_key != state.key() {
                         // Different key. Try next bucket.

--- a/src/cht/map/bucket_array_ref.rs
+++ b/src/cht/map/bucket_array_ref.rs
@@ -1,12 +1,8 @@
 use super::bucket::{self, Bucket, BucketArray, InsertOrModifyState, RehashOp};
 
 use std::{
-    borrow::Borrow,
     hash::{BuildHasher, Hash},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use crossbeam_epoch::{Atomic, CompareAndSetError, Guard, Owned, Shared};
@@ -22,17 +18,12 @@ where
     K: Hash + Eq,
     S: BuildHasher,
 {
-    pub(crate) fn get_key_value_and_then<Q, F, T>(
+    pub(crate) fn get_key_value_and_then<T>(
         &self,
-        key: &Q,
         hash: u64,
-        with_entry: F,
-    ) -> Option<T>
-    where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
-        F: FnOnce(&Arc<K>, &V) -> Option<T>,
-    {
+        mut eq: impl FnMut(&K) -> bool,
+        with_entry: impl FnOnce(&K, &V) -> Option<T>,
+    ) -> Option<T> {
         let guard = &crossbeam_epoch::pin();
         let current_ref = self.get(guard);
         let mut bucket_array_ref = current_ref;
@@ -41,7 +32,7 @@ where
 
         loop {
             match bucket_array_ref
-                .get(guard, hash, key)
+                .get(guard, hash, &mut eq)
                 .map(|p| unsafe { p.as_ref() })
             {
                 Ok(Some(Bucket {
@@ -67,19 +58,13 @@ where
         result
     }
 
-    pub(crate) fn remove_entry_if_and<Q, F, G, T>(
+    pub(crate) fn remove_entry_if_and<T>(
         &self,
-        key: &Q,
         hash: u64,
-        mut condition: F,
-        with_previous_entry: G,
-    ) -> Option<T>
-    where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
-        F: FnMut(&K, &V) -> bool,
-        G: FnOnce(&Arc<K>, &V) -> T,
-    {
+        mut eq: impl FnMut(&K) -> bool,
+        mut condition: impl FnMut(&K, &V) -> bool,
+        with_previous_entry: impl FnOnce(&K, &V) -> T,
+    ) -> Option<T> {
         let guard = &crossbeam_epoch::pin();
         let current_ref = self.get(guard);
         let mut bucket_array_ref = current_ref;
@@ -99,7 +84,7 @@ where
                 bucket_array_ref = bucket_array_ref.rehash(guard, self.build_hasher, rehash_op);
             }
 
-            match bucket_array_ref.remove_if(guard, hash, key, condition) {
+            match bucket_array_ref.remove_if(guard, hash, &mut eq, condition) {
                 Ok(previous_bucket_ptr) => {
                     if let Some(previous_bucket_ref) = unsafe { previous_bucket_ptr.as_ref() } {
                         let Bucket {
@@ -132,17 +117,13 @@ where
         result
     }
 
-    pub(crate) fn insert_if_not_present_and<F, G, T>(
+    pub(crate) fn insert_if_not_present_and<T>(
         &self,
-        key: Arc<K>,
+        key: K,
         hash: u64,
-        on_insert: F,
-        with_existing_entry: G,
-    ) -> Option<T>
-    where
-        F: FnOnce() -> V,
-        G: FnOnce(&K, &V) -> T,
-    {
+        on_insert: impl FnOnce() -> V,
+        with_existing_entry: impl FnOnce(&K, &V) -> T,
+    ) -> Option<T> {
         use bucket::InsertionResult;
 
         let guard = &crossbeam_epoch::pin();
@@ -201,19 +182,14 @@ where
         result
     }
 
-    pub(crate) fn insert_with_or_modify_entry_and<T, F, G, H>(
+    pub(crate) fn insert_with_or_modify_entry_and<T>(
         &self,
-        key: Arc<K>,
+        key: K,
         hash: u64,
-        on_insert: F,
-        mut on_modify: G,
-        with_old_entry: H,
-    ) -> Option<T>
-    where
-        F: FnOnce() -> V,
-        G: FnMut(&K, &V) -> V,
-        H: FnOnce(&K, &V) -> T,
-    {
+        on_insert: impl FnOnce() -> V,
+        mut on_modify: impl FnMut(&K, &V) -> V,
+        with_old_entry: impl FnOnce(&K, &V) -> T,
+    ) -> Option<T> {
         let guard = &crossbeam_epoch::pin();
         let current_ref = self.get(guard);
         let mut bucket_array_ref = current_ref;
@@ -270,10 +246,7 @@ where
         result
     }
 
-    pub(crate) fn keys<F, T>(&self, mut with_key: F) -> Vec<T>
-    where
-        F: FnMut(&Arc<K>) -> T,
-    {
+    pub(crate) fn keys<T>(&self, mut with_key: impl FnMut(&K) -> T) -> Vec<T> {
         let guard = &crossbeam_epoch::pin();
         let current_ref = self.get(guard);
         let mut bucket_array_ref = current_ref;

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -39,10 +39,7 @@ use std::{
     borrow::Borrow,
     hash::{BuildHasher, Hash},
     ptr,
-    sync::{
-        atomic::{self, AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{self, AtomicUsize, Ordering},
 };
 
 use crossbeam_epoch::Atomic;
@@ -253,65 +250,37 @@ impl<K, V, S> HashMap<K, V, S> {
 
 impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// Returns a clone of the value corresponding to the key.
-    ///
-    /// The key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the key type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     #[inline]
-    pub(crate) fn get<Q>(&self, key: &Q, hash: u64) -> Option<V>
+    pub(crate) fn get(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<V>
     where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
         V: Clone,
     {
-        self.get_key_value_and(key, hash, |_, v| v.clone())
+        self.get_key_value_and(hash, eq, |_, v| v.clone())
     }
 
     /// Returns the result of invoking a function with a reference to the
     /// key-value pair corresponding to the supplied key.
-    ///
-    /// The supplied key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for the key
-    /// type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     #[inline]
-    pub(crate) fn get_key_value_and<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
-    where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
-        F: FnOnce(&Arc<K>, &V) -> T,
-    {
-        self.get_key_value_and_then(key, hash, |k, v| Some(with_entry(k, v)))
-    }
-
-    /// Returns the result of invoking a function with a reference to the
-    /// key-value pair corresponding to the supplied key.
-    ///
-    /// The supplied key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for the key
-    /// type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
-    #[inline]
-    pub(crate) fn get_key_value_and_then<Q, F, T>(
+    pub(crate) fn get_key_value_and<T>(
         &self,
-        key: &Q,
         hash: u64,
-        with_entry: F,
-    ) -> Option<T>
-    where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
-        F: FnOnce(&Arc<K>, &V) -> Option<T>,
-    {
+        eq: impl FnMut(&K) -> bool,
+        with_entry: impl FnOnce(&K, &V) -> T,
+    ) -> Option<T> {
+        self.get_key_value_and_then(hash, eq, |k, v| Some(with_entry(k, v)))
+    }
+
+    /// Returns the result of invoking a function with a reference to the
+    /// key-value pair corresponding to the supplied key.
+    #[inline]
+    pub(crate) fn get_key_value_and_then<T>(
+        &self,
+        hash: u64,
+        eq: impl FnMut(&K) -> bool,
+        with_entry: impl FnOnce(&K, &V) -> Option<T>,
+    ) -> Option<T> {
         self.bucket_array_ref(hash)
-            .get_key_value_and_then(key, hash, with_entry)
+            .get_key_value_and_then(hash, eq, with_entry)
     }
 
     /// Inserts a key-value pair into the map, returning the result of invoking
@@ -322,16 +291,15 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// updated.
     #[cfg(test)]
     #[inline]
-    pub fn insert_entry_and<F, T>(
+    pub fn insert_entry_and<T>(
         &self,
-        key: Arc<K>,
+        key: K,
         hash: u64,
         value: V,
-        with_previous_entry: F,
+        with_previous_entry: impl FnOnce(&K, &V) -> T,
     ) -> Option<T>
     where
         V: Clone,
-        F: FnOnce(&K, &V) -> T,
     {
         let result = self
             .bucket_array_ref(hash)
@@ -353,40 +321,23 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
 
     /// Removes a key from the map, returning a clone of the value previously
     /// corresponding to the key.
-    ///
-    /// The key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the key type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     #[inline]
-    pub(crate) fn remove<Q>(&self, key: &Q, hash: u64) -> Option<V>
+    pub(crate) fn remove(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<V>
     where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
         V: Clone,
     {
-        self.remove_entry_if_and(key, hash, |_, _| true, |_, v| v.clone())
+        self.remove_entry_if_and(hash, eq, |_, _| true, |_, v| v.clone())
     }
 
     /// Removes a key from the map, returning a clone of the key-value pair
     /// previously corresponding to the key.
-    ///
-    /// The key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the key type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     #[inline]
-    pub(crate) fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<(Arc<K>, V)>
+    pub(crate) fn remove_entry(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<(K, V)>
     where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
+        K: Clone,
         V: Clone,
     {
-        self.remove_entry_if_and(key, hash, |_, _| true, |k, v| (k.clone(), v.clone()))
+        self.remove_entry_if_and(hash, eq, |_, _| true, |k, v| (k.clone(), v.clone()))
     }
 
     /// Removes a key from the map if a condition is met, returning a clone of
@@ -395,22 +346,18 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// `condition` will be invoked at least once if [`Some`] is returned. It
     /// may also be invoked one or more times if [`None`] is returned.
     ///
-    /// The key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the key type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
-    pub(crate) fn remove_if<Q, F>(&self, key: &Q, hash: u64, condition: F) -> Option<V>
+    pub(crate) fn remove_if(
+        &self,
+        hash: u64,
+        eq: impl FnMut(&K) -> bool,
+        condition: impl FnMut(&K, &V) -> bool,
+    ) -> Option<V>
     where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
         V: Clone,
-        F: FnMut(&K, &V) -> bool,
     {
-        self.remove_entry_if_and(key, hash, condition, move |_, v| v.clone())
+        self.remove_entry_if_and(hash, eq, condition, move |_, v| v.clone())
     }
 
     /// Removes a key from the map if a condition is met, returning the result
@@ -420,30 +367,18 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// `condition` will be invoked at least once if [`Some`] is returned. It
     /// may also be invoked one or more times if [`None`] is returned.
     ///
-    /// The key may be any borrowed form of the map's key type, but
-    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
-    /// the key type.
-    ///
-    /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
-    /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     #[inline]
-    pub(crate) fn remove_entry_if_and<Q, F, G, T>(
+    pub(crate) fn remove_entry_if_and<T>(
         &self,
-        key: &Q,
         hash: u64,
-        condition: F,
-        with_previous_entry: G,
-    ) -> Option<T>
-    where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
-        F: FnMut(&K, &V) -> bool,
-        G: FnOnce(&Arc<K>, &V) -> T,
-    {
+        eq: impl FnMut(&K) -> bool,
+        condition: impl FnMut(&K, &V) -> bool,
+        with_previous_entry: impl FnOnce(&K, &V) -> T,
+    ) -> Option<T> {
         self.bucket_array_ref(hash)
-            .remove_entry_if_and(key, hash, condition, move |k, v| {
+            .remove_entry_if_and(hash, eq, condition, move |k, v| {
                 self.len.fetch_sub(1, Ordering::Relaxed);
 
                 with_previous_entry(k, v)
@@ -462,17 +397,15 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     #[inline]
-    pub(crate) fn insert_with_or_modify<F, G>(
+    pub(crate) fn insert_with_or_modify(
         &self,
-        key: Arc<K>,
+        key: K,
         hash: u64,
-        on_insert: F,
-        on_modify: G,
+        on_insert: impl FnOnce() -> V,
+        on_modify: impl FnMut(&K, &V) -> V,
     ) -> Option<V>
     where
         V: Clone,
-        F: FnOnce() -> V,
-        G: FnMut(&K, &V) -> V,
     {
         self.insert_with_or_modify_entry_and(key, hash, on_insert, on_modify, |_, v| v.clone())
     }
@@ -490,19 +423,14 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     #[inline]
-    pub(crate) fn insert_with_or_modify_entry_and<F, G, H, T>(
+    pub(crate) fn insert_with_or_modify_entry_and<T>(
         &self,
-        key: Arc<K>,
+        key: K,
         hash: u64,
-        on_insert: F,
-        on_modify: G,
-        with_old_entry: H,
-    ) -> Option<T>
-    where
-        F: FnOnce() -> V,
-        G: FnMut(&K, &V) -> V,
-        H: FnOnce(&K, &V) -> T,
-    {
+        on_insert: impl FnOnce() -> V,
+        on_modify: impl FnMut(&K, &V) -> V,
+        with_old_entry: impl FnOnce(&K, &V) -> T,
+    ) -> Option<T> {
         let result = self.bucket_array_ref(hash).insert_with_or_modify_entry_and(
             key,
             hash,
@@ -519,7 +447,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     }
 
     #[inline]
-    pub(crate) fn insert_if_not_present(&self, key: Arc<K>, hash: u64, value: V) -> Option<V>
+    pub(crate) fn insert_if_not_present(&self, key: K, hash: u64, value: V) -> Option<V>
     where
         V: Clone,
     {
@@ -537,10 +465,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
         result
     }
 
-    pub(crate) fn keys<F, T>(&self, segment: usize, with_key: F) -> Option<Vec<T>>
-    where
-        F: FnMut(&Arc<K>) -> T,
-    {
+    pub(crate) fn keys<T>(&self, segment: usize, with_key: impl FnMut(&K) -> T) -> Option<Vec<T>> {
         if segment >= self.segments.len() {
             return None;
         }
@@ -668,16 +593,13 @@ mod tests {
         let key = "key1";
         let hash = map.hash(key);
 
-        assert_eq!(
-            map.insert_entry_and(Arc::new(key), hash, 5, |_, v| *v),
-            None
-        );
-        assert_eq!(map.get(key, hash), Some(5));
+        assert_eq!(map.insert_entry_and(key, hash, 5, |_, v| *v), None);
+        assert_eq!(map.get(hash, |k| k == &key), Some(5));
 
         assert!(!map.is_empty());
         assert_eq!(map.len(), 1);
 
-        assert_eq!(map.remove(key, hash), Some(5));
+        assert_eq!(map.remove(hash, |k| k == &key), Some(5));
         assert!(map.is_empty());
         assert_eq!(map.len(), 0);
 
@@ -692,18 +614,18 @@ mod tests {
         let key = "key1";
         let hash = map.hash(key);
 
-        assert_eq!(map.insert_if_not_present(Arc::new(key), hash, 5), None);
-        assert_eq!(map.get(key, hash), Some(5));
+        assert_eq!(map.insert_if_not_present(key, hash, 5), None);
+        assert_eq!(map.get(hash, |k| k == &key), Some(5));
 
-        assert_eq!(map.insert_if_not_present(Arc::new(key), hash, 6), Some(5));
-        assert_eq!(map.get(key, hash), Some(5));
+        assert_eq!(map.insert_if_not_present(key, hash, 6), Some(5));
+        assert_eq!(map.get(hash, |k| k == &key), Some(5));
 
-        assert_eq!(map.remove(key, hash), Some(5));
+        assert_eq!(map.remove(hash, |k| k == &key), Some(5));
 
-        assert_eq!(map.insert_if_not_present(Arc::new(key), hash, 7), None);
-        assert_eq!(map.get(key, hash), Some(7));
+        assert_eq!(map.insert_if_not_present(key, hash, 7), None);
+        assert_eq!(map.get(hash, |k| k == &key), Some(7));
 
-        assert_eq!(map.remove(key, hash), Some(7));
+        assert_eq!(map.remove(hash, |k| k == &key), Some(7));
         assert!(map.is_empty());
         assert_eq!(map.len(), 0);
 
@@ -731,7 +653,6 @@ mod tests {
 
                     for key in 0..MAX_VALUE {
                         let hash = hashmap.hash(&key);
-                        let key = Arc::new(key);
                         let result = hashmap.insert_if_not_present(key, hash, thread_id);
                         if result.is_none() {
                             success_count += 1;
@@ -771,7 +692,7 @@ mod tests {
         // Get all entries from the cht MashMap.
         for key in 0..MAX_VALUE {
             let hash = hashmap.hash(&key);
-            if let Some(thread_id) = hashmap.get(&key, hash) {
+            if let Some(thread_id) = hashmap.get(hash, |&k| k == key) {
                 let count = results2.get_mut(&thread_id).unwrap();
                 *count += 1;
             }
@@ -790,21 +711,19 @@ mod tests {
         let map = HashMap::with_capacity(MAX_VALUE as usize);
 
         for i in 0..MAX_VALUE {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
 
             assert!(!map.is_empty());
             assert_eq!(map.len(), (i + 1) as usize);
 
             for j in 0..=i {
                 let hash = map.hash(&j);
-                assert_eq!(map.get(&j, hash), Some(j));
-                let key = Arc::new(j);
-                assert_eq!(map.insert_entry_and(key, hash, j, |_, v| *v), Some(j));
+                assert_eq!(map.get(hash, |&k| k == j), Some(j));
+                assert_eq!(map.insert_entry_and(j, hash, j, |_, v| *v), Some(j));
             }
 
-            for k in i + 1..MAX_VALUE {
-                assert_eq!(map.get(&k, map.hash(&k)), None);
+            for l in i + 1..MAX_VALUE {
+                assert_eq!(map.get(map.hash(&l), |&k| k == l), None);
             }
         }
 
@@ -818,21 +737,19 @@ mod tests {
         let map = HashMap::with_capacity(0);
 
         for i in 0..MAX_VALUE {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
 
             assert!(!map.is_empty());
             assert_eq!(map.len(), (i + 1) as usize);
 
             for j in 0..=i {
                 let hash = map.hash(&j);
-                assert_eq!(map.get(&j, hash), Some(j));
-                let key = Arc::new(j);
-                assert_eq!(map.insert_entry_and(key, hash, j, |_, v| *v), Some(j));
+                assert_eq!(map.get(hash, |&k| k == j), Some(j));
+                assert_eq!(map.insert_entry_and(j, hash, j, |_, v| *v), Some(j));
             }
 
-            for k in i + 1..MAX_VALUE {
-                assert_eq!(map.get(&k, map.hash(&k)), None);
+            for l in i + 1..MAX_VALUE {
+                assert_eq!(map.get(map.hash(&l), |&k| k == l), None);
             }
         }
 
@@ -864,8 +781,7 @@ mod tests {
                     barrier.wait();
 
                     for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
-                        let key = Arc::new(j);
-                        assert_eq!(map.insert_entry_and(key, map.hash(&j), j, |_, v| *v), None);
+                        assert_eq!(map.insert_entry_and(j, map.hash(&j), j, |_, v| *v), None);
                     }
                 })
             })
@@ -879,7 +795,7 @@ mod tests {
         assert_eq!(map.len(), MAX_INSERTED_VALUE as usize);
 
         for i in 0..MAX_INSERTED_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         run_deferred();
@@ -905,8 +821,7 @@ mod tests {
                     barrier.wait();
 
                     for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
-                        let key = Arc::new(j);
-                        assert_eq!(map.insert_entry_and(key, map.hash(&j), j, |_, v| *v), None);
+                        assert_eq!(map.insert_entry_and(j, map.hash(&j), j, |_, v| *v), None);
                     }
                 })
             })
@@ -920,7 +835,7 @@ mod tests {
         assert_eq!(map.len(), MAX_INSERTED_VALUE as usize);
 
         for i in 0..MAX_INSERTED_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         run_deferred();
@@ -933,19 +848,18 @@ mod tests {
         let map = HashMap::with_capacity(MAX_VALUE as usize);
 
         for i in 0..MAX_VALUE {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
         }
 
         for i in 0..MAX_VALUE {
-            assert_eq!(map.remove(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.remove(map.hash(&i), |&k| k == i), Some(i));
         }
 
         assert!(map.is_empty());
         assert_eq!(map.len(), 0);
 
         for i in 0..MAX_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), None);
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), None);
         }
 
         run_deferred();
@@ -961,8 +875,7 @@ mod tests {
         let map = HashMap::with_capacity(MAX_INSERTED_VALUE as usize);
 
         for i in 0..MAX_INSERTED_VALUE {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
         }
 
         let map = Arc::new(map);
@@ -978,7 +891,7 @@ mod tests {
                     barrier.wait();
 
                     for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
-                        assert_eq!(map.remove(&j, map.hash(&j)), Some(j));
+                        assert_eq!(map.remove(map.hash(&j), |&k| k == j), Some(j));
                     }
                 })
             })
@@ -991,7 +904,7 @@ mod tests {
         assert_eq!(map.len(), 0);
 
         for i in 0..MAX_INSERTED_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), None);
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), None);
         }
 
         run_deferred();
@@ -1008,8 +921,7 @@ mod tests {
         let map = HashMap::with_capacity(MAX_INSERTED_VALUE as usize);
 
         for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
         }
 
         let map = Arc::new(map);
@@ -1025,8 +937,7 @@ mod tests {
                     barrier.wait();
 
                     for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
-                        let key = Arc::new(j);
-                        assert_eq!(map.insert_entry_and(key, map.hash(&j), j, |_, v| *v), None);
+                        assert_eq!(map.insert_entry_and(j, map.hash(&j), j, |_, v| *v), None);
                     }
                 })
             })
@@ -1043,7 +954,7 @@ mod tests {
 
                     for j in (0..MAX_VALUE).map(|j| INSERTED_MIDPOINT + j + (i as i32 * MAX_VALUE))
                     {
-                        assert_eq!(map.remove(&j, map.hash(&j)), Some(j));
+                        assert_eq!(map.remove(map.hash(&j), |&k| k == j), Some(j));
                     }
                 })
             })
@@ -1061,11 +972,11 @@ mod tests {
         assert_eq!(map.len(), INSERTED_MIDPOINT as usize);
 
         for i in 0..INSERTED_MIDPOINT {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), None);
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), None);
         }
 
         run_deferred();
@@ -1082,8 +993,7 @@ mod tests {
         let map = HashMap::with_capacity(INSERTED_MIDPOINT as usize);
 
         for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
         }
 
         let map = Arc::new(map);
@@ -1099,8 +1009,7 @@ mod tests {
                     barrier.wait();
 
                     for j in (0..MAX_VALUE).map(|j| j + (i as i32 * MAX_VALUE)) {
-                        let key = Arc::new(j);
-                        assert_eq!(map.insert_entry_and(key, map.hash(&j), j, |_, v| *v), None);
+                        assert_eq!(map.insert_entry_and(j, map.hash(&j), j, |_, v| *v), None);
                     }
                 })
             })
@@ -1117,7 +1026,7 @@ mod tests {
 
                     for j in (0..MAX_VALUE).map(|j| INSERTED_MIDPOINT + j + (i as i32 * MAX_VALUE))
                     {
-                        assert_eq!(map.remove(&j, map.hash(&j)), Some(j));
+                        assert_eq!(map.remove(map.hash(&j), |&k| k == j), Some(j));
                     }
                 })
             })
@@ -1135,11 +1044,11 @@ mod tests {
         assert_eq!(map.len(), INSERTED_MIDPOINT as usize);
 
         for i in 0..INSERTED_MIDPOINT {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         for i in INSERTED_MIDPOINT..MAX_INSERTED_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), None);
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), None);
         }
 
         run_deferred();
@@ -1153,16 +1062,16 @@ mod tests {
         let hash = map.hash(&key);
 
         assert_eq!(
-            map.insert_with_or_modify(Arc::new(key), hash, || 1, |_, x| x + 1),
+            map.insert_with_or_modify(key, hash, || 1, |_, x| x + 1),
             None
         );
-        assert_eq!(map.get(key, hash), Some(1));
+        assert_eq!(map.get(hash, |&k| k == key), Some(1));
 
         assert_eq!(
-            map.insert_with_or_modify(Arc::new(key), hash, || 1, |_, x| x + 1),
+            map.insert_with_or_modify(key, hash, || 1, |_, x| x + 1),
             Some(1)
         );
-        assert_eq!(map.get(key, hash), Some(2));
+        assert_eq!(map.get(hash, |&k| k == key), Some(2));
 
         run_deferred();
     }
@@ -1186,8 +1095,7 @@ mod tests {
                     barrier.wait();
 
                     for j in 0..MAX_VALUE {
-                        let key = Arc::new(j);
-                        map.insert_with_or_modify(key, map.hash(&j), || 1, |_, x| x + 1);
+                        map.insert_with_or_modify(j, map.hash(&j), || 1, |_, x| x + 1);
                     }
                 })
             })
@@ -1200,7 +1108,7 @@ mod tests {
         assert_eq!(map.len(), MAX_VALUE as usize);
 
         for i in 0..MAX_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(NUM_THREADS as i32));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(NUM_THREADS as i32));
         }
 
         run_deferred();
@@ -1225,8 +1133,7 @@ mod tests {
                     barrier.wait();
 
                     for j in 0..MAX_VALUE {
-                        let key = Arc::new(j);
-                        map.insert_entry_and(key, map.hash(&j), j, |_, v| *v);
+                        map.insert_entry_and(j, map.hash(&j), j, |_, v| *v);
                     }
                 })
             })
@@ -1239,7 +1146,7 @@ mod tests {
         assert_eq!(map.len(), MAX_VALUE as usize);
 
         for i in 0..MAX_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         run_deferred();
@@ -1274,8 +1181,7 @@ mod tests {
                     barrier.wait();
 
                     for j in 0..MAX_VALUE {
-                        let key = Arc::new(j);
-                        map.insert_entry_and(key, map.hash(&j), j, |_, v| *v);
+                        map.insert_entry_and(j, map.hash(&j), j, |_, v| *v);
                     }
                 })
             })
@@ -1288,7 +1194,7 @@ mod tests {
         assert_eq!(map.len(), MAX_VALUE as usize);
 
         for i in 0..MAX_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         run_deferred();
@@ -1303,8 +1209,7 @@ mod tests {
         let map = HashMap::with_capacity(MAX_VALUE as usize);
 
         for i in 0..MAX_VALUE {
-            let key = Arc::new(i);
-            map.insert_entry_and(key, map.hash(&i), i, |_, v| *v);
+            map.insert_entry_and(i, map.hash(&i), i, |_, v| *v);
         }
 
         let map = Arc::new(map);
@@ -1320,7 +1225,7 @@ mod tests {
                     barrier.wait();
 
                     for j in 0..MAX_VALUE {
-                        let prev_value = map.remove(&j, map.hash(&j));
+                        let prev_value = map.remove(map.hash(&j), |&k| k == j);
 
                         if let Some(v) = prev_value {
                             assert_eq!(v, j);
@@ -1338,7 +1243,7 @@ mod tests {
         assert_eq!(map.len(), 0);
 
         for i in 0..MAX_VALUE {
-            assert_eq!(map.get(&i, map.hash(&i)), None);
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), None);
         }
 
         run_deferred();
@@ -1355,7 +1260,7 @@ mod tests {
 
             assert_eq!(
                 map.insert_entry_and(
-                    Arc::new(NoisyDropper::new(Arc::clone(&key_parent), 0)),
+                    NoisyDropper::new(Arc::clone(&key_parent), 0),
                     hash,
                     NoisyDropper::new(Arc::clone(&value_parent), 0),
                     |_, _| ()
@@ -1364,12 +1269,12 @@ mod tests {
             );
             assert!(!map.is_empty());
             assert_eq!(map.len(), 1);
-            map.get_key_value_and(&0, hash, |_k, v| assert_eq!(v, &0));
+            map.get_key_value_and(hash, |k| k == &0, |_k, v| assert_eq!(v, &0));
 
-            map.remove_entry_if_and(&0, hash, |_, _| true, |_k, v| assert_eq!(v, &0));
+            map.remove_entry_if_and(hash, |k| k == &0, |_, _| true, |_k, v| assert_eq!(v, &0));
             assert!(map.is_empty());
             assert_eq!(map.len(), 0);
-            assert_eq!(map.get_key_value_and(&0, hash, |_, _| ()), None);
+            assert_eq!(map.get_key_value_and(hash, |k| k == &0, |_, _| ()), None);
 
             run_deferred();
 
@@ -1404,7 +1309,7 @@ mod tests {
             {
                 assert_eq!(
                     map.insert_entry_and(
-                        Arc::new(NoisyDropper::new(Arc::clone(this_key_parent), i)),
+                        NoisyDropper::new(Arc::clone(this_key_parent), i),
                         map.hash(&i),
                         NoisyDropper::new(Arc::clone(this_value_parent), i),
                         |_, _| ()
@@ -1418,10 +1323,14 @@ mod tests {
 
             for i in 0..NUM_VALUES {
                 assert_eq!(
-                    map.get_key_value_and(&i, map.hash(&i), |k, v| {
-                        assert_eq!(**k, i);
-                        assert_eq!(*v, i);
-                    }),
+                    map.get_key_value_and(
+                        map.hash(&i),
+                        |k| k == &i,
+                        |k, v| {
+                            assert_eq!(**k, i);
+                            assert_eq!(*v, i);
+                        }
+                    ),
                     Some(())
                 );
             }
@@ -1429,8 +1338,8 @@ mod tests {
             for i in 0..NUM_VALUES {
                 assert_eq!(
                     map.remove_entry_if_and(
-                        &i,
                         map.hash(&i),
+                        |k| k == &i,
                         |_, _| true,
                         |k, v| {
                             assert_eq!(**k, i);
@@ -1461,7 +1370,10 @@ mod tests {
             }
 
             for i in 0..NUM_VALUES {
-                assert_eq!(map.get_key_value_and(&i, map.hash(&i), |_, _| ()), None);
+                assert_eq!(
+                    map.get_key_value_and(map.hash(&i), |k| k == &i, |_, _| ()),
+                    None
+                );
             }
         }
 
@@ -1526,10 +1438,7 @@ mod tests {
 
                             assert_eq!(
                                 map.insert_entry_and(
-                                    Arc::new(NoisyDropper::new(
-                                        Arc::clone(this_key_parent),
-                                        key_value
-                                    )),
+                                    NoisyDropper::new(Arc::clone(this_key_parent), key_value),
                                     hash,
                                     NoisyDropper::new(Arc::clone(this_value_parent), key_value),
                                     |_, _| ()
@@ -1560,10 +1469,14 @@ mod tests {
 
             for i in (0..NUM_VALUES).map(|i| i as i32) {
                 assert_eq!(
-                    map.get_key_value_and(&i, map.hash(&i), |k, v| {
-                        assert_eq!(**k, i);
-                        assert_eq!(*v, i);
-                    }),
+                    map.get_key_value_and(
+                        map.hash(&i),
+                        |k| k == &i,
+                        |k, v| {
+                            assert_eq!(**k, i);
+                            assert_eq!(*v, i);
+                        }
+                    ),
                     Some(())
                 );
             }
@@ -1582,8 +1495,8 @@ mod tests {
 
                             assert_eq!(
                                 map.remove_entry_if_and(
-                                    &key_value,
                                     map.hash(&key_value),
+                                    |k| k == &key_value,
                                     |_, _| true,
                                     |k, v| {
                                         assert_eq!(**k, key_value);
@@ -1617,7 +1530,10 @@ mod tests {
             }
 
             for i in (0..NUM_VALUES).map(|i| i as i32) {
-                assert_eq!(map.get_key_value_and(&i, map.hash(&i), |_, _| ()), None);
+                assert_eq!(
+                    map.get_key_value_and(map.hash(&i), |k| k == &i, |_, _| ()),
+                    None
+                );
             }
         }
 
@@ -1641,24 +1557,23 @@ mod tests {
         let map = HashMap::with_capacity(0);
 
         for i in 0..NUM_VALUES {
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, map.hash(&i), i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, map.hash(&i), i, |_, v| *v), None);
         }
 
         for i in 0..NUM_VALUES {
             if is_even(&i, &i) {
-                assert_eq!(map.remove_if(&i, map.hash(&i), is_even), Some(i));
+                assert_eq!(map.remove_if(map.hash(&i), |&k| k == i, is_even), Some(i));
             } else {
-                assert_eq!(map.remove_if(&i, map.hash(&i), is_even), None);
+                assert_eq!(map.remove_if(map.hash(&i), |&k| k == i, is_even), None);
             }
         }
 
         for i in (0..NUM_VALUES).filter(|i| i % 2 == 0) {
-            assert_eq!(map.get(&i, map.hash(&i)), None);
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), None);
         }
 
         for i in (0..NUM_VALUES).filter(|i| i % 2 != 0) {
-            assert_eq!(map.get(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.get(map.hash(&i), |&k| k == i), Some(i));
         }
 
         run_deferred();
@@ -1676,34 +1591,33 @@ mod tests {
 
         for i in 0..NUM_KEYS {
             let hash = map.hash(&i);
-            let key = Arc::new(i);
-            assert_eq!(map.insert_entry_and(key, hash, i, |_, v| *v), None);
+            assert_eq!(map.insert_entry_and(i, hash, i, |_, v| *v), None);
         }
 
         assert!(!map.is_empty());
         assert_eq!(map.len(), NUM_KEYS);
 
-        let mut keys = map.keys(0, |k| Arc::clone(k)).unwrap();
+        let mut keys = map.keys(0, |k| *k).unwrap();
         assert_eq!(keys.len(), NUM_KEYS);
         keys.sort_unstable();
 
         for (i, key) in keys.into_iter().enumerate() {
-            assert_eq!(i, *key);
+            assert_eq!(i, key);
         }
 
         for i in (0..NUM_KEYS).step_by(2) {
-            assert_eq!(map.remove(&i, map.hash(&i)), Some(i));
+            assert_eq!(map.remove(map.hash(&i), |&k| k == i), Some(i));
         }
 
         assert!(!map.is_empty());
         assert_eq!(map.len(), NUM_KEYS / 2);
 
-        let mut keys = map.keys(0, |k| Arc::clone(k)).unwrap();
+        let mut keys = map.keys(0, |k| *k).unwrap();
         assert_eq!(keys.len(), NUM_KEYS / 2);
         keys.sort_unstable();
 
         for (i, key) in keys.into_iter().enumerate() {
-            assert_eq!(i, *key / 2);
+            assert_eq!(i, key / 2);
         }
 
         run_deferred();

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -719,7 +719,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.base.contains_key_with_hash(key, self.base.hash(key))
@@ -737,7 +737,7 @@ where
     /// [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
     pub fn get<Q>(&self, key: &Q) -> Option<V>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.base.get_with_hash(key, self.base.hash(key))
@@ -992,7 +992,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub async fn invalidate<Q>(&self, key: &Q)
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.base.hash(key);
@@ -1010,7 +1010,7 @@ where
 
     fn do_blocking_invalidate<Q>(&self, key: &Q)
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.base.hash(key);
@@ -1347,7 +1347,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn invalidate<Q>(&self, key: &Q)
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.0.do_blocking_invalidate(key)
@@ -2724,7 +2724,7 @@ mod tests {
         expected.push((Arc::new("alice"), "a0", RemovalCause::Replaced));
         cache.sync();
 
-        // Insert an okay value. This will replace the previsous
+        // Insert an okay value. This will replace the previous
         // value "panic now!" so the eviction listener will panic.
         cache.insert("alice", "a2").await;
         cache.sync();
@@ -2735,6 +2735,31 @@ mod tests {
         cache.sync();
 
         verify_notification_vec(&cache, actual, &expected);
+    }
+
+    // This test ensures that the `contains_key`, `get` and `invalidate` can use
+    // borrowed form `&[u8]` for key with type `Vec<u8>`.
+    // https://github.com/moka-rs/moka/issues/166
+    #[tokio::test]
+    async fn borrowed_forms_of_key() {
+        let cache: Cache<Vec<u8>, ()> = Cache::new(1);
+
+        let key = vec![1_u8];
+        cache.insert(key.clone(), ()).await;
+
+        // key as &Vec<u8>
+        let key_v: &Vec<u8> = &key;
+        assert!(cache.contains_key(key_v));
+        assert_eq!(cache.get(key_v), Some(()));
+        cache.invalidate(key_v).await;
+
+        cache.insert(key, ()).await;
+
+        // key as &[u8]
+        let key_s: &[u8] = [1_u8].as_slice();
+        assert!(cache.contains_key(key_s));
+        assert_eq!(cache.get(key_s), Some(()));
+        cache.invalidate(key_s).await;
     }
 
     #[tokio::test]

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -2756,7 +2756,7 @@ mod tests {
         cache.insert(key, ()).await;
 
         // key as &[u8]
-        let key_s: &[u8] = [1_u8].as_slice();
+        let key_s: &[u8] = &[1_u8];
         assert!(cache.contains_key(key_s));
         assert_eq!(cache.get(key_s), Some(()));
         cache.invalidate(key_s).await;

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -32,7 +32,7 @@ struct WaiterGuard<'a, K, V, S>
 // NOTE: We usually do not attach trait bounds to here at the struct definition, but
 // the Drop trait requires these bounds here.
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     V: Clone,
     S: BuildHasher,
 {
@@ -45,7 +45,7 @@ where
 
 impl<'a, K, V, S> WaiterGuard<'a, K, V, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     V: Clone,
     S: BuildHasher,
 {
@@ -72,7 +72,7 @@ where
 
 impl<'a, K, V, S> Drop for WaiterGuard<'a, K, V, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     V: Clone,
     S: BuildHasher,
 {
@@ -98,7 +98,7 @@ pub(crate) struct ValueInitializer<K, V, S> {
 
 impl<K, V, S> ValueInitializer<K, V, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     V: Clone,
     S: BuildHasher,
 {
@@ -257,10 +257,10 @@ where
     }
 
     #[inline]
-    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
+    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> (Arc<(Arc<K>, TypeId)>, u64) {
         let cht_key = (Arc::clone(key), type_id);
         let hash = self.waiters.hash(&cht_key);
-        (cht_key, hash)
+        (Arc::new(cht_key), hash)
     }
 }
 

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -241,7 +241,7 @@ where
     #[inline]
     pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
         let (cht_key, hash) = self.cht_key_hash(key, type_id);
-        self.waiters.remove(&cht_key, hash);
+        self.waiters.remove(hash, |k| k == &cht_key);
     }
 
     #[inline]
@@ -257,10 +257,10 @@ where
     }
 
     #[inline]
-    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> (Arc<(Arc<K>, TypeId)>, u64) {
+    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
         let cht_key = (Arc::clone(key), type_id);
         let hash = self.waiters.hash(&cht_key);
-        (Arc::new(cht_key), hash)
+        (cht_key, hash)
     }
 }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -873,7 +873,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.base.contains_key_with_hash(key, self.base.hash(key))
@@ -881,7 +881,7 @@ where
 
     pub(crate) fn contains_key_with_hash<Q>(&self, key: &Q, hash: u64) -> bool
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.base.contains_key_with_hash(key, hash)
@@ -899,7 +899,7 @@ where
     /// [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
     pub fn get<Q>(&self, key: &Q) -> Option<V>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.base.get_with_hash(key, self.base.hash(key))
@@ -907,7 +907,7 @@ where
 
     pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<V>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.base.get_with_hash(key, hash)
@@ -1200,7 +1200,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn invalidate<Q>(&self, key: &Q)
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.base.hash(key);
@@ -1209,7 +1209,7 @@ where
 
     pub(crate) fn invalidate_with_hash<Q>(&self, key: &Q, hash: u64)
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         // Lock the key for removal if blocking removal notification is enabled.
@@ -2931,7 +2931,7 @@ mod tests {
             expected.push((Arc::new("alice"), "a0", RemovalCause::Replaced));
             cache.sync();
 
-            // Insert an okay value. This will replace the previsous
+            // Insert an okay value. This will replace the previous
             // value "panic now!" so the eviction listener will panic.
             cache.insert("alice", "a2");
             cache.sync();
@@ -2943,6 +2943,31 @@ mod tests {
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
         }
+    }
+
+    // This test ensures that the `contains_key`, `get` and `invalidate` can use
+    // borrowed form `&[u8]` for key with type `Vec<u8>`.
+    // https://github.com/moka-rs/moka/issues/166
+    #[test]
+    fn borrowed_forms_of_key() {
+        let cache: Cache<Vec<u8>, ()> = Cache::new(1);
+
+        let key = vec![1_u8];
+        cache.insert(key.clone(), ());
+
+        // key as &Vec<u8>
+        let key_v: &Vec<u8> = &key;
+        assert!(cache.contains_key(key_v));
+        assert_eq!(cache.get(key_v), Some(()));
+        cache.invalidate(key_v);
+
+        cache.insert(key, ());
+
+        // key as &[u8]
+        let key_s: &[u8] = [1_u8].as_slice();
+        assert!(cache.contains_key(key_s));
+        assert_eq!(cache.get(key_s), Some(()));
+        cache.invalidate(key_s);
     }
 
     #[test]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2964,7 +2964,7 @@ mod tests {
         cache.insert(key, ());
 
         // key as &[u8]
-        let key_s: &[u8] = [1_u8].as_slice();
+        let key_s: &[u8] = &[1_u8];
         assert!(cache.contains_key(key_s));
         assert_eq!(cache.get(key_s), Some(()));
         cache.invalidate(key_s);

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1599,7 +1599,7 @@ mod tests {
         cache.insert(key, ());
 
         // key as &[u8]
-        let key_s: &[u8] = [1_u8].as_slice();
+        let key_s: &[u8] = &[1_u8];
         assert!(cache.contains_key(key_s));
         assert_eq!(cache.get(key_s), Some(()));
         cache.invalidate(key_s);

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -152,7 +152,7 @@ where
     #[inline]
     pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
         let (cht_key, hash) = self.cht_key_hash(key, type_id);
-        self.waiters.remove(&cht_key, hash);
+        self.waiters.remove(hash, |k| k == &cht_key);
     }
 
     #[inline]
@@ -168,8 +168,8 @@ where
     }
 
     #[inline]
-    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> (Arc<(Arc<K>, TypeId)>, u64) {
-        let cht_key = Arc::new((Arc::clone(key), type_id));
+    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
+        let cht_key = (Arc::clone(key), type_id);
         let hash = self.waiters.hash(&cht_key);
         (cht_key, hash)
     }

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -28,7 +28,7 @@ pub(crate) struct ValueInitializer<K, V, S> {
 
 impl<K, V, S> ValueInitializer<K, V, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     V: Clone,
     S: BuildHasher,
 {
@@ -168,8 +168,8 @@ where
     }
 
     #[inline]
-    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
-        let cht_key = (Arc::clone(key), type_id);
+    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> (Arc<(Arc<K>, TypeId)>, u64) {
+        let cht_key = Arc::new((Arc::clone(key), type_id));
         let hash = self.waiters.hash(&cht_key);
         (cht_key, hash)
     }

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -967,7 +967,7 @@ where
     S: BuildHasher,
 {
     fn get_value_entry(&self, key: &Arc<K>, hash: u64) -> Option<TrioArc<ValueEntry<K, V>>> {
-        self.cache.get(hash, |k| (k.borrow() as &Arc<K>) == key)
+        self.cache.get(hash, |k| k == key)
     }
 
     fn remove_key_value_if(
@@ -984,9 +984,7 @@ where
         let kl = self.maybe_key_lock(key);
         let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-        let maybe_entry = self
-            .cache
-            .remove_if(hash, |k| (k.borrow() as &Arc<K>) == key, condition);
+        let maybe_entry = self.cache.remove_if(hash, |k| k == key, condition);
         if let Some(entry) = &maybe_entry {
             if self.is_removal_notifier_enabled() {
                 self.notify_single_removal(Arc::clone(key), entry, RemovalCause::Explicit);

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -661,7 +661,7 @@ enum AdmissionResult<K> {
     },
 }
 
-type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<K, TrioArc<ValueEntry<K, V>>, S>;
+type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
 
 pub(crate) struct Inner<K, V, S> {
     name: Option<String>,
@@ -897,7 +897,8 @@ where
         Q: Hash + Eq + ?Sized,
         F: FnOnce(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> T,
     {
-        self.cache.get_key_value_and(key, hash, with_entry)
+        self.cache
+            .get_key_value_and(hash, |k| (k as &K).borrow() == key, with_entry)
     }
 
     #[inline]
@@ -907,7 +908,8 @@ where
         Q: Hash + Eq + ?Sized,
         F: FnOnce(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> Option<T>,
     {
-        self.cache.get_key_value_and_then(key, hash, with_entry)
+        self.cache
+            .get_key_value_and_then(hash, |k| (k as &K).borrow() == key, with_entry)
     }
 
     #[inline]
@@ -917,7 +919,7 @@ where
         Q: Hash + Eq + ?Sized,
     {
         self.cache
-            .remove_entry(key, hash)
+            .remove_entry(hash, |k| (k as &K).borrow() == key)
             .map(|(key, entry)| KvEntry::new(key, entry))
     }
 
@@ -965,25 +967,26 @@ where
     S: BuildHasher,
 {
     fn get_value_entry(&self, key: &Arc<K>, hash: u64) -> Option<TrioArc<ValueEntry<K, V>>> {
-        self.cache.get(key, hash)
+        self.cache.get(hash, |k| (k.borrow() as &Arc<K>) == key)
     }
 
-    fn remove_key_value_if<F>(
+    fn remove_key_value_if(
         &self,
         key: &Arc<K>,
         hash: u64,
-        condition: F,
+        condition: impl FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool,
     ) -> Option<TrioArc<ValueEntry<K, V>>>
     where
         K: Send + Sync + 'static,
         V: Clone + Send + Sync + 'static,
-        F: FnMut(&K, &TrioArc<ValueEntry<K, V>>) -> bool,
     {
         // Lock the key for removal if blocking removal notification is enabled.
         let kl = self.maybe_key_lock(key);
         let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-        let maybe_entry = self.cache.remove_if(key, hash, condition);
+        let maybe_entry = self
+            .cache
+            .remove_if(hash, |k| (k.borrow() as &Arc<K>) == key, condition);
         if let Some(entry) = &maybe_entry {
             if self.is_removal_notifier_enabled() {
                 self.notify_single_removal(Arc::clone(key), entry, RemovalCause::Explicit);
@@ -1253,7 +1256,7 @@ where
                 let kl = self.maybe_key_lock(&kh.key);
                 let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-                let removed = self.cache.remove(&Arc::clone(&kh.key), kh.hash);
+                let removed = self.cache.remove(kh.hash, |k| k == &kh.key);
                 if let Some(entry) = removed {
                     if eviction_state.is_notifier_enabled() {
                         let key = Arc::clone(&kh.key);
@@ -1282,8 +1285,9 @@ where
                     let kl = self.maybe_key_lock(element.key());
                     let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-                    if let Some((vic_key, vic_entry)) =
-                        self.cache.remove_entry(element.key(), element.hash())
+                    if let Some((vic_key, vic_entry)) = self
+                        .cache
+                        .remove_entry(element.hash(), |k| k == element.key())
                     {
                         if eviction_state.is_notifier_enabled() {
                             eviction_state.add_removed_entry(
@@ -1315,7 +1319,7 @@ where
 
                 // Remove the candidate from the cache (hash map).
                 let key = Arc::clone(&kh.key);
-                self.cache.remove(&key, kh.hash);
+                self.cache.remove(kh.hash, |k| k == &key);
                 if eviction_state.is_notifier_enabled() {
                     eviction_state.add_removed_entry(key, &entry, RemovalCause::Size);
                 }
@@ -1372,7 +1376,7 @@ where
                 next_victim = victim.next_node();
                 let vic_elem = &victim.element;
 
-                if let Some(vic_entry) = cache.get(vic_elem.key(), vic_elem.hash()) {
+                if let Some(vic_entry) = cache.get(vic_elem.hash(), |k| k == vic_elem.key()) {
                     victims.add_policy_weight(vic_entry.policy_weight());
                     victims.add_frequency(freq, vic_elem.hash());
                     victim_nodes.push(NonNull::from(victim));
@@ -1544,9 +1548,11 @@ where
             // expired. This check is needed because it is possible that the entry in
             // the map has been updated or deleted but its deque node we checked
             // above has not been updated yet.
-            let maybe_entry = self
-                .cache
-                .remove_if(key, hash, |_, v| is_expired_entry_ao(tti, va, v, now));
+            let maybe_entry = self.cache.remove_if(
+                hash,
+                |k| k == key,
+                |_, v| is_expired_entry_ao(tti, va, v, now),
+            );
 
             if let Some(entry) = maybe_entry {
                 if eviction_state.is_notifier_enabled() {
@@ -1575,7 +1581,7 @@ where
         deq: &mut Deque<KeyHashDate<K>>,
         write_order_deq: &mut Deque<KeyDate<K>>,
     ) -> bool {
-        if let Some(entry) = self.cache.get(key, hash) {
+        if let Some(entry) = self.cache.get(hash, |k| (k.borrow() as &K) == key) {
             if entry.is_dirty() {
                 // The key exists and the entry has been updated.
                 Deques::move_to_back_ao_in_deque(deq_name, deq, &entry);
@@ -1631,9 +1637,11 @@ where
             let kl = self.maybe_key_lock(key);
             let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-            let maybe_entry = self
-                .cache
-                .remove_if(key, hash, |_, v| is_expired_entry_wo(ttl, va, v, now));
+            let maybe_entry = self.cache.remove_if(
+                hash,
+                |k| k == key,
+                |_, v| is_expired_entry_wo(ttl, va, v, now),
+            );
 
             if let Some(entry) = maybe_entry {
                 if eviction_state.is_notifier_enabled() {
@@ -1641,7 +1649,7 @@ where
                     eviction_state.add_removed_entry(key, &entry, *cause);
                 }
                 Self::handle_remove(deqs, entry, &mut eviction_state.counters);
-            } else if let Some(entry) = self.cache.get(key, hash) {
+            } else if let Some(entry) = self.cache.get(hash, |k| k == key) {
                 if entry.last_modified().is_none() {
                     deqs.move_to_back_ao(&entry);
                     deqs.move_to_back_wo(&entry);
@@ -1786,13 +1794,17 @@ where
             let kl = self.maybe_key_lock(&key);
             let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-            let maybe_entry = self.cache.remove_if(&key, hash, |_, v| {
-                if let Some(lm) = v.last_modified() {
-                    lm == ts
-                } else {
-                    false
-                }
-            });
+            let maybe_entry = self.cache.remove_if(
+                hash,
+                |k| k == &key,
+                |_, v| {
+                    if let Some(lm) = v.last_modified() {
+                        lm == ts
+                    } else {
+                        false
+                    }
+                },
+            );
 
             if let Some(entry) = maybe_entry {
                 if eviction_state.is_notifier_enabled() {

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -188,7 +188,7 @@ where
     #[inline]
     pub(crate) fn hash<Q>(&self, key: &Q) -> u64
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.inner.hash(key)
@@ -196,7 +196,7 @@ where
 
     pub(crate) fn contains_key_with_hash<Q>(&self, key: &Q, hash: u64) -> bool
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.inner
@@ -214,7 +214,7 @@ where
 
     pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<V>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         // Define a closure to record a read op.
@@ -252,7 +252,7 @@ where
     #[cfg(feature = "sync")]
     pub(crate) fn get_key_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<Arc<K>>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.inner
@@ -262,7 +262,7 @@ where
     #[inline]
     pub(crate) fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<KvEntry<K, V>>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.inner.remove_entry(key, hash)
@@ -661,7 +661,7 @@ enum AdmissionResult<K> {
     },
 }
 
-type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
+type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<K, TrioArc<ValueEntry<K, V>>, S>;
 
 pub(crate) struct Inner<K, V, S> {
     name: Option<String>,
@@ -882,7 +882,7 @@ where
     #[inline]
     fn hash<Q>(&self, key: &Q) -> u64
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let mut hasher = self.build_hasher.build_hasher();
@@ -893,7 +893,7 @@ where
     #[inline]
     fn get_key_value_and<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
         F: FnOnce(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> T,
     {
@@ -903,7 +903,7 @@ where
     #[inline]
     fn get_key_value_and_then<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
         F: FnOnce(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> Option<T>,
     {
@@ -913,7 +913,7 @@ where
     #[inline]
     fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<KvEntry<K, V>>
     where
-        Arc<K>: Borrow<Q>,
+        K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.cache
@@ -977,7 +977,7 @@ where
     where
         K: Send + Sync + 'static,
         V: Clone + Send + Sync + 'static,
-        F: FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool,
+        F: FnMut(&K, &TrioArc<ValueEntry<K, V>>) -> bool,
     {
         // Lock the key for removal if blocking removal notification is enabled.
         let kl = self.maybe_key_lock(key);

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -32,16 +32,15 @@ pub(crate) type PredicateFun<K, V> = Arc<dyn Fn(&K, &V) -> bool + Send + Sync + 
 pub(crate) trait GetOrRemoveEntry<K, V> {
     fn get_value_entry(&self, key: &Arc<K>, hash: u64) -> Option<TrioArc<ValueEntry<K, V>>>;
 
-    fn remove_key_value_if<F>(
+    fn remove_key_value_if(
         &self,
         key: &Arc<K>,
         hash: u64,
-        condition: F,
+        condition: impl FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool,
     ) -> Option<TrioArc<ValueEntry<K, V>>>
     where
         K: Send + Sync + 'static,
-        V: Clone + Send + Sync + 'static,
-        F: FnMut(&K, &TrioArc<ValueEntry<K, V>>) -> bool;
+        V: Clone + Send + Sync + 'static;
 }
 
 pub(crate) struct KeyDateLite<K> {

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -41,7 +41,7 @@ pub(crate) trait GetOrRemoveEntry<K, V> {
     where
         K: Send + Sync + 'static,
         V: Clone + Send + Sync + 'static,
-        F: FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool;
+        F: FnMut(&K, &TrioArc<ValueEntry<K, V>>) -> bool;
 }
 
 pub(crate) struct KeyDateLite<K> {

--- a/src/sync_base/key_lock.rs
+++ b/src/sync_base/key_lock.rs
@@ -10,13 +10,15 @@ use triomphe::Arc as TrioArc;
 
 const LOCK_MAP_NUM_SEGMENTS: usize = 64;
 
+type LockMap<K, S> = SegmentedHashMap<Arc<K>, TrioArc<Mutex<()>>, S>;
+
 // We need the `where` clause here because of the Drop impl.
 pub(crate) struct KeyLock<'a, K, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    map: &'a SegmentedHashMap<K, TrioArc<Mutex<()>>, S>,
+    map: &'a LockMap<K, S>,
     key: Arc<K>,
     hash: u64,
     lock: TrioArc<Mutex<()>>,
@@ -29,8 +31,11 @@ where
 {
     fn drop(&mut self) {
         if TrioArc::count(&self.lock) <= 1 {
-            self.map
-                .remove_if(&self.key, self.hash, |_k, v| TrioArc::count(v) <= 1);
+            self.map.remove_if(
+                self.hash,
+                |k| k == &self.key,
+                |_k, v| TrioArc::count(v) <= 1,
+            );
         }
     }
 }
@@ -53,8 +58,6 @@ where
         self.lock.lock()
     }
 }
-
-type LockMap<K, S> = SegmentedHashMap<K, TrioArc<Mutex<()>>, S>;
 
 pub(crate) struct KeyLockMap<K, S> {
     locks: LockMap<K, S>,

--- a/src/sync_base/key_lock.rs
+++ b/src/sync_base/key_lock.rs
@@ -13,10 +13,10 @@ const LOCK_MAP_NUM_SEGMENTS: usize = 64;
 // We need the `where` clause here because of the Drop impl.
 pub(crate) struct KeyLock<'a, K, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     S: BuildHasher,
 {
-    map: &'a SegmentedHashMap<Arc<K>, TrioArc<Mutex<()>>, S>,
+    map: &'a SegmentedHashMap<K, TrioArc<Mutex<()>>, S>,
     key: Arc<K>,
     hash: u64,
     lock: TrioArc<Mutex<()>>,
@@ -24,7 +24,7 @@ where
 
 impl<'a, K, S> Drop for KeyLock<'a, K, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     S: BuildHasher,
 {
     fn drop(&mut self) {
@@ -37,7 +37,7 @@ where
 
 impl<'a, K, S> KeyLock<'a, K, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     S: BuildHasher,
 {
     fn new(map: &'a LockMap<K, S>, key: &Arc<K>, hash: u64, lock: TrioArc<Mutex<()>>) -> Self {
@@ -54,7 +54,7 @@ where
     }
 }
 
-type LockMap<K, S> = SegmentedHashMap<Arc<K>, TrioArc<Mutex<()>>, S>;
+type LockMap<K, S> = SegmentedHashMap<K, TrioArc<Mutex<()>>, S>;
 
 pub(crate) struct KeyLockMap<K, S> {
     locks: LockMap<K, S>,
@@ -62,7 +62,7 @@ pub(crate) struct KeyLockMap<K, S> {
 
 impl<K, S> KeyLockMap<K, S>
 where
-    Arc<K>: Eq + Hash,
+    K: Eq + Hash,
     S: BuildHasher,
 {
     pub(crate) fn with_hasher(hasher: S) -> Self {


### PR DESCRIPTION
This PR changes the trait bound `Arc<K>: Borrow<Q>` to `K: Borrow<Q>` for the following methods of `sync` and `future` caches.

- `contains_key`
- `get`
- `invalidate`

This fixes #163 for `sync` and `future` caches. Now their methods will accept `&[u8]` as the key `&Q` when `K` is `Vec<u8>`.