### PR TITLE
Add features for wasm32-unknown-unknown target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ atomic64 = []
 # performance impacts and is intended for debugging purpose.
 unstable-debug-counters = ["future"]
 
+js = ["getrandom/js","uuid/js"]
+
 [dependencies]
 crossbeam-channel = "0.5.5"
 crossbeam-utils = "0.8"


### PR DESCRIPTION
Add new `js` feature that enables `getrandom/js` and `uuid/js` features (`uuid` already relays it to its own `getrandom` dependency) in order to be able to build moka for `wasm32-unknown-unknown` target (i.e. for in-browser execution using builders such as `wasm-pack`).

`getrandom` has platform-specific implementations for the random number generator and the crate requires an explicit selection of this feature for `wasm32` target when the target OS is `unknown`, which is the case of the browser targets. If not specified, the build triggers the following error: https://github.com/rust-random/getrandom/blob/master/src/lib.rs#L244.  This is just a feature relay that has no effect on the moka codebase.