### PR TITLE
Address multi-platform issues with getrandom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ atomic64 = []
 # performance impacts and is intended for debugging purpose.
 unstable-debug-counters = ["future"]
 
+js = ["getrandom/js","uuid/js"]
+
 [dependencies]
 crossbeam-channel = "0.5.5"
 crossbeam-utils = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ atomic64 = []
 # performance impacts and is intended for debugging purpose.
 unstable-debug-counters = ["future"]
 
+# js = ["getrandom?/js","uuid/js"]
 js = ["getrandom/js","uuid/js"]
 
 [dependencies]
@@ -79,12 +80,15 @@ futures-util = { version = "0.3", optional = true }
 # Optional dependencies (logging)
 log = { version = "0.4", optional = true }
 
+# Required for testing (can not reside in dev-dependencies 
+# on stable due to platform compatibility issues
+getrandom = { version = "0.2", optional = true }
+
 [dev-dependencies]
 actix-rt = { version = "2.7", default-features = false }
 anyhow = "1.0.19"
 async-std = { version = "1.11", features = ["attributes"] }
 env_logger = "0.9"
-getrandom = "0.2"
 reqwest = "0.11.11"
 skeptic = "0.13"
 tokio = { version = "1.19", features = ["fs", "macros", "rt-multi-thread", "sync", "time" ] }


### PR DESCRIPTION
With regards to the closed https://github.com/moka-rs/moka/pull/172

This is the best solution I have been able to come up with.  I will give this example to cargo developers.  In the meantime, the way to address this would be to migrate `getrandom` from `dev-dependencies` to regular `dependencies`.  It will be eliminated away by the compiler and linker as it is not used anyways.  In the meantime it allows one to use `js` feature.

Once again, to clarify, `js` features is needed for wasm but you can not specify sub-crate features for `dev-dependencies` as in release mode cargo errors out with `no such dependency found for feature 'js'`...  

I've tried using `js = ["getrandom?/js"]` syntax, but optional dependencies (`?`) are available only on the nightly channel and that would require to set `getrandom = { optional = true ... }` and then use another feature like 'testing' to trigger its inclusion, which is complex and doesn't make much sense anyways.  Relocating this crate from `dev-dependencies` is the cleanest and most elegant solution for the time being.