### PR TITLE
Follow up the `js` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,15 @@ logging = ["log"]
 # https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 atomic64 = []
 
+# This is an **experimental** feature to make `unsync` and `sync` caches to compile
+# for `wasm32-unknown-unknown` target. Note that we have not tested if these caches
+# work correctly in wasm32 environment.
+js = ["uuid/js"]
+
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns
 # counters of internal object construction and destruction. It will have some
 # performance impacts and is intended for debugging purpose.
 unstable-debug-counters = ["future"]
-
-# js = ["getrandom?/js","uuid/js"]
-js = ["getrandom/js","uuid/js"]
 
 [dependencies]
 crossbeam-channel = "0.5.5"
@@ -80,15 +82,12 @@ futures-util = { version = "0.3", optional = true }
 # Optional dependencies (logging)
 log = { version = "0.4", optional = true }
 
-# Required for testing (can not reside in dev-dependencies 
-# on stable due to platform compatibility issues
-getrandom = { version = "0.2", optional = true }
-
 [dev-dependencies]
 actix-rt = { version = "2.7", default-features = false }
 anyhow = "1.0.19"
 async-std = { version = "1.11", features = ["attributes"] }
 env_logger = "0.9"
+getrandom = "0.2"
 reqwest = "0.11.11"
 skeptic = "0.13"
 tokio = { version = "1.19", features = ["fs", "macros", "rt-multi-thread", "sync", "time" ] }


### PR DESCRIPTION
Move `getrandom` back to under the dev-dependencies.

Fixes the unit test broken by #173.