### PR TITLE
Fix memory leak when dropping a `sync` or `future` cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.9.4
+
+### Fixed
+
+- Fix memory leak after dropping a `sync` or `future` cache ([#177][gh-pull-0177]):
+    - This leaked the value part of the cache entries.
+
+
 ## Version 0.9.3
 
 ### Added
@@ -468,6 +476,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0177]: https://github.com/moka-rs/moka/pull/177/
 [gh-pull-0169]: https://github.com/moka-rs/moka/pull/169/
 [gh-pull-0167]: https://github.com/moka-rs/moka/pull/167/
 [gh-pull-0165]: https://github.com/moka-rs/moka/pull/165/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2018"
 rust-version = "1.51"
 


### PR DESCRIPTION
Fixes #176 

## Problem and Cause

When a `sync` or `future` cache was dropped, value part of cache entries were left allocated (leaked). This was due to a bug in the `Drop::drop` method of `moka::cht::SegmentedHashMap`; it was using `bucket::defer_acquire_destroy` function to drop any entry (a `bucket` struct), but that function only drops the key part of the entry.

## Fix

Fixed the bug by updating the `drop` method of `moka::cht::SegmentedCache` to use the followings:

* For a live `bucket` (having both the key and value), use `bucket::defer_destroy_bucket` function to drop both the key and value.
* For a dead `bucket` (having the tombstone bit set and having only the key), continue using `bucket::defer_acquire_destroy` function to drop only the key.

## Verification

Verified the fix by the following methods:

- Ran the [reproducing code](https://github.com/moka-rs/moka/issues/176#issue-1359114446) using `valgrind` and confirmed that the memory leak was fixed.
    - "definitely lost: 0 bytes in 0 blocks"
    - "indirectly lost: 0 bytes in 0 blocks"
- Added a unit test `moka::cht::segment::test::drop_map_after_concurrent_updates` to ensure that the `drop` method of both the key and value types are called when the map is dropped.