### PR TITLE
CI: Run Linux AArch64 tests on real hardware using Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,66 @@
+nightly_dependency_task:
+  only_if: $RUST_VERSION == 'nightly'
+  script:
+    - cargo update -Z minimal-versions
+
+msrv_dependency_task:
+  only_if: $RUST_VERSION == 'msrv'
+  script:
+    - cargo update -p dashmap --precise 5.2.0
+    - cargo update -p indexmap --precise 1.8.2
+    - cargo update -p hashbrown --precise 0.11.2
+    - cargo update -p native-tls --precise 0.2.8
+    - cargo update -p async-global-executor --precise 2.0.4
+    - cargo update -p pulldown-cmark --precise 0.9.1
+
+arm64_test:
+  arm_container:
+    matrix:
+      - image: rust:slim  # docker's official latest rust stable version
+        env:
+          RUST_VERSION: stable
+      - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
+        env:
+          RUST_VERSION: nightly
+      - image: rust:1.51.0-slim # MSRV
+        env:
+          RUST_VERSION: msrv
+      # no rust-beta image found in dockerhub, won't be tested
+
+  registry_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  target_cache:
+    folder: target
+    fingerprint_script:
+      - rustc --version
+      - cat Cargo.lock
+
+  depends_on:
+    - nightly_dependency_task
+    - msrv_dependency_task
+
+  matrix:
+    - name: Run tests (debug, sync feature)
+      test_script: cargo test --lib --features sync
+
+    - name: Run tests (debug, sync feature, thread-pool test for sync::Cache)
+      test_script: cargo test --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+    - name: Run tests (debug, sync feature, thread-pool test for sync::SegmentCache)
+      test_script: cargo test --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+    - name: Run tests (release, sync feature)
+      test_script: cargo test --release --features sync
+
+    - name: Run tests (future feature, but no sync feature)
+      test_script: cargo test --no-default-features --features 'future, atomic64, quanta'
+
+    - name: Run tests (future, sync and logging features)
+      test_script: cargo test --features 'future, sync, logging'
+
+    - name: Run tests (dash feature, but no sync feature)
+      test_script: --no-default-features --features 'dash, atomic64, quanta'
+
+  before_cache_script:
+    - rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,66 +1,84 @@
-nightly_dependency_task:
-  only_if: $RUST_VERSION == 'nightly'
-  script:
-    - cargo update -Z minimal-versions
+env:
+  # This cfg will prevent to run tests requiring large memory (~8GiB)
+  RUSTFLAGS: --cfg circleci
+  NUM_CPUS: "2"
 
-msrv_dependency_task:
-  only_if: $RUST_VERSION == 'msrv'
-  script:
-    - cargo update -p dashmap --precise 5.2.0
-    - cargo update -p indexmap --precise 1.8.2
-    - cargo update -p hashbrown --precise 0.11.2
-    - cargo update -p native-tls --precise 0.2.8
-    - cargo update -p async-global-executor --precise 2.0.4
-    - cargo update -p pulldown-cmark --precise 0.9.1
-
-arm64_test:
+linux_arm64_task:
   arm_container:
+    cpu: $NUM_CPUS
     matrix:
       - image: rust:slim  # docker's official latest rust stable version
-        env:
-          RUST_VERSION: stable
       - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
-        env:
-          RUST_VERSION: nightly
       - image: rust:1.51.0-slim # MSRV
-        env:
-          RUST_VERSION: msrv
-      # no rust-beta image found in dockerhub, won't be tested
+      # no rust-beta image found in docker hub, won't be tested
 
-  registry_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
-  target_cache:
-    folder: target
-    fingerprint_script:
-      - rustc --version
-      - cat Cargo.lock
+  ## Disable caching as there is no Cargo.lock file in Moka repository.
+  # registry_cache:
+  #   folder: $CARGO_HOME/registry
+  #   fingerprint_script: cat Cargo.lock
+  # target_cache:
+  #   folder: target
+  #   fingerprint_script:
+  #     - rustc --version
+  #     - cat Cargo.lock
 
-  depends_on:
-    - nightly_dependency_task
-    - msrv_dependency_task
+  # Install dependencies (native libraries)
+  setup_script:
+    - apt-get update
+    - apt-get install -y libssl-dev pkg-config
 
-  matrix:
-    - name: Run tests (debug, sync feature)
-      test_script: cargo test --lib --features sync
+  show_cpu_info_script: |
+    nproc
+    lscpu
 
-    - name: Run tests (debug, sync feature, thread-pool test for sync::Cache)
-      test_script: cargo test --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+  # Show Rust version
+  check_version_script: rustc -Vv
 
-    - name: Run tests (debug, sync feature, thread-pool test for sync::SegmentCache)
-      test_script: cargo test --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+  # Downgrade dependencies to minimal versions (Nightly only)
+  downgrade_deps_script: |
+    # The nightly image has no RUST_VERSION set
+    if [ -z "$RUST_VERSION" ]; then
+      echo 'Downgrading dependencies to minimal versions'
+      cargo update -Z minimal-versions
+    else
+      echo 'Skipped'
+    fi
 
-    - name: Run tests (release, sync feature)
-      test_script: cargo test --release --features sync
+  # Pin some dependencies to specific versions (MSRV only)
+  pin_deps_script: |
+    if [ "v$RUST_VERSION" == "v1.51.0" ]; then
+      echo 'Pinning some dependencies to specific versions'
+      cargo update -p dashmap --precise 5.2.0
+      cargo update -p indexmap --precise 1.8.2
+      cargo update -p hashbrown --precise 0.11.2
+      cargo update -p native-tls --precise 0.2.8
+      cargo update -p async-global-executor --precise 2.0.4
+      cargo update -p pulldown-cmark --precise 0.9.1
+    else
+      echo 'Skipped'
+    fi
 
-    - name: Run tests (future feature, but no sync feature)
-      test_script: cargo test --no-default-features --features 'future, atomic64, quanta'
+  test_script:
+    # Run tests (debug, sync feature)
+    - cargo test -j 1 --lib --features sync -- --test-threads=$NUM_CPUS
 
-    - name: Run tests (future, sync and logging features)
-      test_script: cargo test --features 'future, sync, logging'
+    # Run tests (debug, sync feature, thread-pool test for sync::Cache)
+    - cargo test -j 1  --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored --test-threads=$NUM_CPUS
 
-    - name: Run tests (dash feature, but no sync feature)
-      test_script: --no-default-features --features 'dash, atomic64, quanta'
+    # Run tests (debug, sync feature, thread-pool test for sync::SegmentCache)
+    - cargo test -j 1  --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored --test-threads=$NUM_CPUS
 
-  before_cache_script:
-    - rm -rf $CARGO_HOME/registry/index
+    # Run tests (release, sync feature)
+    - cargo test -j 1  --release --features sync -- --test-threads=$NUM_CPUS
+
+    # Run tests (future feature, but no sync feature)
+    - cargo test -j 1  --no-default-features --features 'future, atomic64, quanta' -- --test-threads=$NUM_CPUS
+
+    # Run tests (future, sync and logging features)
+    - cargo test -j 1  --features 'future, sync, logging' -- --test-threads=$NUM_CPUS
+
+    # Run tests (dash feature, but no sync feature)
+    - cargo test -j 1  --no-default-features --features 'dash, atomic64, quanta' -- --test-threads=$NUM_CPUS
+
+  # before_cache_script:
+  #   - rm -rf $CARGO_HOME/registry/index

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 /target/
 Cargo.lock
+
+# intellij cache
+.idea


### PR DESCRIPTION
This PR adds Cirrus CI job to run Linux AArch64 tests on real hardware.