### PR TITLE
CI: Pin once_cell to v1.14.0 for the MSRV

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,7 @@ linux_arm64_task:
       cargo update -p native-tls --precise 0.2.8
       cargo update -p async-global-executor --precise 2.0.4
       cargo update -p pulldown-cmark --precise 0.9.1
+      cargo update -p once_cell --precise 1.14.0
     else
       echo 'Skipped'
     fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,7 @@ jobs:
         # native-tls >= v0.2.9 requires more recent Rust version.
         # async-global-executor >= 2.1 requires Rust 2021 edition.
         # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
+        # once_cell >= 1.15.0 requires Rust 2021 edition.
         run: |
           cargo update -p dashmap --precise 5.2.0
           cargo update -p indexmap --precise 1.8.2
@@ -65,6 +66,7 @@ jobs:
           cargo update -p native-tls --precise 0.2.8
           cargo update -p async-global-executor --precise 2.0.4
           cargo update -p pulldown-cmark --precise 0.9.1
+          cargo update -p once_cell --precise 1.14.0
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -58,6 +58,7 @@ jobs:
         # native-tls >= v0.2.9 requires more recent Rust version.
         # async-global-executor >= 2.1 requires Rust 2021 edition.
         # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
+        # once_cell >= 1.15.0 requires Rust 2021 edition.
         run: |
           cargo update -p dashmap --precise 5.2.0
           cargo update -p indexmap --precise 1.8.2
@@ -65,6 +66,7 @@ jobs:
           cargo update -p native-tls --precise 0.2.8
           cargo update -p async-global-executor --precise 2.0.4
           cargo update -p pulldown-cmark --precise 0.9.1
+          cargo update -p once_cell --precise 1.14.0
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
once_cell v1.15.0 or newer requires Rust 2021 edition, which is not supported by the MSRV.