### PR TITLE
Prepare for v0.9.5 release (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.9.5
+
+### Added
+
+- Add `optional_get_with` method to `sync` and `future` caches ([#187][gh-pull-0187]):
+    - It is similar to `try_get_with` but takes an init closure/future returning an
+      `Option<V>` instead of `Result<V, E>`.
+
+
 ## Version 0.9.4
 
 ### Fixed
@@ -476,6 +485,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0187]: https://github.com/moka-rs/moka/pull/187/
 [gh-pull-0177]: https://github.com/moka-rs/moka/pull/177/
 [gh-pull-0169]: https://github.com/moka-rs/moka/pull/169/
 [gh-pull-0167]: https://github.com/moka-rs/moka/pull/167/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2018"
 rust-version = "1.51"
 


### PR DESCRIPTION
- Bump the version to v0.9.5.
- Update the change log.

[v0.9.5](https://github.com/moka-rs/moka/milestone/27) will have more items later and we will update the change log again (via a separate pull request). 