### PR TITLE
Add the "entry" and "entry_by_ref" APIs

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -6,9 +6,11 @@ pub(crate) mod concurrent;
 #[cfg(any(feature = "sync", feature = "future"))]
 pub(crate) mod error;
 
+#[cfg(any(feature = "sync", feature = "future"))]
+pub(crate) mod entry;
+
 pub(crate) mod builder_utils;
 pub(crate) mod deque;
-pub(crate) mod entry;
 pub(crate) mod frequency_sketch;
 pub(crate) mod time;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,6 +8,7 @@ pub(crate) mod error;
 
 pub(crate) mod builder_utils;
 pub(crate) mod deque;
+pub(crate) mod entry;
 pub(crate) mod frequency_sketch;
 pub(crate) mod time;
 

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -71,7 +71,12 @@ impl ThreadPoolRegistry {
                 // and insert a new pool.
                 let mut pools = REGISTRY.pools.write();
                 pools.entry(name).or_insert_with(|| {
-                    // Some platforms may return 0. In that case, use 1.
+                    // TODO: When we upgrade the MSRV to 1.59 (2022-02-24) or newer,
+                    // replace num_cpus crate with `thread::available_parallelism` in
+                    // std.
+                    //
+                    // NOTE: On some platforms, `num_cpus::get` may return 0. In that
+                    // case, use 1.
                     // https://github.com/moka-rs/moka/pull/39#issuecomment-916888859
                     // https://github.com/seanmonstar/num_cpus/issues/69
                     let num_threads = num_cpus::get().max(1);

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -1,5 +1,22 @@
 use std::{fmt::Debug, sync::Arc};
 
+/// A snapshot of a single entry in the cache.
+///
+/// `Entry` is constructed from the methods like `or_insert` on the struct returned
+/// by cache's `entry` or `entry_by_ref` methods. `Entry` holds the cached key and
+/// value at the time it was constructed. It also carries extra information about the
+/// entry; [`is_fresh`](#method.is_fresh) method returns `true` if the value was not
+/// cached and was freshly computed.
+///
+/// See the followings for more information about `entry` and `entry_by_ref` methods:
+///
+/// - `sync::Cache`:
+///     - [`entry`](./sync/struct.Cache.html#method.entry)
+///     - [`entry_by_ref`](./sync/struct.Cache.html#method.entry_by_ref)
+/// - `future::Cache`:
+///     - [`entry`](./future/struct.Cache.html#method.entry)
+///     - [`entry_by_ref`](./future/struct.Cache.html#method.entry_by_ref)
+///
 pub struct Entry<K, V> {
     key: Option<Arc<K>>,
     value: V,
@@ -29,18 +46,29 @@ impl<K, V> Entry<K, V> {
         }
     }
 
+    /// Returns a reference to the wrapped key.
     pub fn key(&self) -> &K {
         self.key.as_ref().expect("Bug: Key is None")
     }
 
+    /// Returns a reference to the wrapped value.
+    ///
+    /// Note that the returned reference is _not_ pointing to the original value in
+    /// the cache. Instead, it is pointing to the cloned value in this `Entry`.
     pub fn value(&self) -> &V {
         &self.value
     }
 
+    /// Consumes this `Entry`, returning the wrapped value.
+    ///
+    /// Note that the returned value is a clone of the original value in the cache.
+    /// It was cloned when this `Entry` was constructed.
     pub fn into_value(self) -> V {
         self.value
     }
 
+    /// Returns `true` if the value in this `Entry` was not cached and was freshly
+    /// computed.
     pub fn is_fresh(&self) -> bool {
         self.is_fresh
     }

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -1,0 +1,47 @@
+use std::{fmt::Debug, sync::Arc};
+
+pub struct Entry<K, V> {
+    key: Option<Arc<K>>,
+    value: V,
+    is_fresh: bool,
+}
+
+impl<K, V> Debug for Entry<K, V>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Entry")
+            .field("key", self.key())
+            .field("value", &self.value)
+            .field("is_fresh", &self.is_fresh)
+            .finish()
+    }
+}
+
+impl<K, V> Entry<K, V> {
+    pub(crate) fn new(key: Option<Arc<K>>, value: V, is_fresh: bool) -> Self {
+        Self {
+            key,
+            value,
+            is_fresh,
+        }
+    }
+
+    pub fn key(&self) -> &K {
+        self.key.as_ref().expect("Bug: Key is None")
+    }
+
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+
+    pub fn into_value(self) -> V {
+        self.value
+    }
+
+    pub fn is_fresh(&self) -> bool {
+        self.is_fresh
+    }
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -7,11 +7,13 @@ use std::{hash::Hash, sync::Arc};
 
 mod builder;
 mod cache;
+mod entry_selector;
 mod value_initializer;
 
 pub use {
     builder::CacheBuilder,
     cache::{BlockingOp, Cache},
+    entry_selector::{OwnedKeyEntrySelector, RefKeyEntrySelector},
 };
 
 /// The type of the unique ID to identify a predicate used by

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1,6 +1,7 @@
 use super::{
     value_initializer::{InitResult, ValueInitializer},
-    CacheBuilder, ConcurrentCacheExt, Iter, PredicateId,
+    CacheBuilder, ConcurrentCacheExt, Iter, OwnedKeyEntrySelector, PredicateId,
+    RefKeyEntrySelector,
 };
 use crate::{
     common::{
@@ -13,7 +14,7 @@ use crate::{
     },
     notification::{self, EvictionListener},
     sync_base::base_cache::{BaseCache, HouseKeeperArc},
-    Policy, PredicateError,
+    Entry, Policy, PredicateError,
 };
 
 #[cfg(feature = "unstable-debug-counters")]
@@ -748,7 +749,26 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.base.get_with_hash(key, self.base.hash(key))
+        self.base
+            .get_with_hash(key, self.base.hash(key), false)
+            .map(Entry::into_value)
+    }
+
+    pub fn entry(&self, key: K) -> OwnedKeyEntrySelector<'_, K, V, S>
+    where
+        K: Hash + Eq,
+    {
+        let hash = self.base.hash(&key);
+        OwnedKeyEntrySelector::new(key, hash, self)
+    }
+
+    pub fn entry_by_ref<'a, Q>(&'a self, key: &'a Q) -> RefKeyEntrySelector<'a, K, Q, V, S>
+    where
+        K: Borrow<Q>,
+        Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+    {
+        let hash = self.base.hash(key);
+        RefKeyEntrySelector::new(key, hash, self)
     }
 
     /// Deprecated, replaced with [`get_with`](#method.get_with)
@@ -852,8 +872,9 @@ where
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
         let replace_if = None as Option<fn(&V) -> bool>;
-        self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if)
+        self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if, false)
             .await
+            .into_value()
     }
 
     /// Similar to [`get_with`](#method.get_with), but instead of passing an owned
@@ -867,18 +888,14 @@ where
         let hash = self.base.hash(key);
         let replace_if = None as Option<fn(&V) -> bool>;
 
-        self.get_or_insert_with_hash_by_ref_and_fun(key, hash, init, replace_if)
+        self.get_or_insert_with_hash_by_ref_and_fun(key, hash, init, replace_if, false)
             .await
+            .into_value()
     }
 
-    /// Works like [`get_with`](#method.get_with), but takes an additional
-    /// `replace_if` closure.
-    ///
-    /// This method will resolve the `init` future and insert the output to the
-    /// cache when:
-    ///
-    /// - The key does not exist.
-    /// - Or, `replace_if` closure returns `true`.
+    /// Deprecated, replaced with [`entry()::or_insert_with_if()`]
+    /// (./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
+    #[deprecated(since = "0.10.0", note = "Replaced with `entry().or_insert_with_if()`")]
     pub async fn get_with_if(
         &self,
         key: K,
@@ -887,29 +904,10 @@ where
     ) -> V {
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
-        self.get_or_insert_with_hash_and_fun(key, hash, init, Some(replace_if))
+        self.get_or_insert_with_hash_and_fun(key, hash, init, Some(replace_if), false)
             .await
+            .into_value()
     }
-
-    // We will provide this API under the new `entry` API.
-    //
-    // /// Similar to [`get_with_if`](#method.get_with_if), but instead of passing an
-    // /// owned key, you can pass a reference to the key. If the key does not exist in
-    // /// the cache, the key will be cloned to create new entry in the cache.
-    // pub async fn get_with_if_by_ref<Q>(
-    //     &self,
-    //     key: &Q,
-    //     init: impl Future<Output = V>,
-    //     replace_if: impl FnMut(&V) -> bool,
-    // ) -> V
-    // where
-    //     K: Borrow<Q>,
-    //     Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
-    // {
-    //     let hash = self.base.hash(key);
-    //     self.get_or_insert_with_hash_by_ref_and_fun(key, hash, init, Some(replace_if))
-    //         .await
-    // }
 
     /// Try to ensure the value of the key exists by inserting an `Ok` output of the
     /// init future if not exist, and returns a _clone_ of the value or the `Err`
@@ -1369,48 +1367,52 @@ where
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
-    async fn get_or_insert_with_hash_and_fun(
+    pub(crate) async fn get_or_insert_with_hash_and_fun(
         &self,
         key: Arc<K>,
         hash: u64,
         init: impl Future<Output = V>,
         mut replace_if: Option<impl FnMut(&V) -> bool>,
-    ) -> V {
-        match (self.base.get_with_hash(&key, hash), &mut replace_if) {
-            (Some(v), None) => return v,
-            (Some(v), Some(cond)) => {
-                if !cond(&v) {
-                    return v;
+        need_key: bool,
+    ) -> Entry<K, V> {
+        match (self.base.get_with_hash(&key, hash, false), &mut replace_if) {
+            (Some(entry), None) => return entry,
+            (Some(entry), Some(cond)) => {
+                if !cond(entry.value()) {
+                    return entry;
                 };
             }
             _ => (),
         }
 
-        self.insert_with_hash_and_fun(key, hash, init).await
+        self.insert_with_hash_and_fun(key, hash, init, need_key)
+            .await
     }
 
-    async fn get_or_insert_with_hash_by_ref_and_fun<Q>(
+    pub(crate) async fn get_or_insert_with_hash_by_ref_and_fun<Q>(
         &self,
         key: &Q,
         hash: u64,
         init: impl Future<Output = V>,
         mut replace_if: Option<impl FnMut(&V) -> bool>,
-    ) -> V
+        need_key: bool,
+    ) -> Entry<K, V>
     where
         K: Borrow<Q>,
         Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
     {
-        match (self.base.get_with_hash(key, hash), &mut replace_if) {
-            (Some(v), None) => return v,
-            (Some(v), Some(cond)) => {
-                if !cond(&v) {
-                    return v;
+        match (self.base.get_with_hash(key, hash, false), &mut replace_if) {
+            (Some(entry), None) => return entry,
+            (Some(entry), Some(cond)) => {
+                if !cond(entry.value()) {
+                    return entry;
                 };
             }
             _ => (),
         }
         let key = Arc::new(key.to_owned());
-        self.insert_with_hash_and_fun(key, hash, init).await
+        self.insert_with_hash_and_fun(key, hash, init, need_key)
+            .await
     }
 
     async fn insert_with_hash_and_fun(
@@ -1418,7 +1420,13 @@ where
         key: Arc<K>,
         hash: u64,
         init: impl Future<Output = V>,
-    ) -> V {
+        need_key: bool,
+    ) -> Entry<K, V> {
+        let k = if need_key {
+            Some(Arc::clone(&key))
+        } else {
+            None
+        };
         match self
             .value_initializer
             .init_or_read(Arc::clone(&key), init)
@@ -1430,10 +1438,49 @@ where
                 self.value_initializer
                     .remove_waiter(&key, TypeId::of::<()>());
                 crossbeam_epoch::pin().flush();
-                v
+                Entry::new(k, v, true)
             }
-            InitResult::ReadExisting(v) => v,
+            InitResult::ReadExisting(v) => Entry::new(k, v, false),
             InitResult::InitErr(_) => unreachable!(),
+        }
+    }
+
+    pub(crate) async fn get_or_insert_with_hash(
+        &self,
+        key: Arc<K>,
+        hash: u64,
+        init: impl FnOnce() -> V,
+    ) -> Entry<K, V> {
+        match self.base.get_with_hash(&key, hash, true) {
+            Some(entry) => entry,
+            None => {
+                let value = init();
+                self.insert_with_hash(Arc::clone(&key), hash, value.clone())
+                    .await;
+                Entry::new(Some(key), value, true)
+            }
+        }
+    }
+
+    pub(crate) async fn get_or_insert_with_hash_by_ref<Q>(
+        &self,
+        key: &Q,
+        hash: u64,
+        init: impl FnOnce() -> V,
+    ) -> Entry<K, V>
+    where
+        K: Borrow<Q>,
+        Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+    {
+        match self.base.get_with_hash(key, hash, true) {
+            Some(entry) => entry,
+            None => {
+                let key = Arc::new(key.to_owned());
+                let value = init();
+                self.insert_with_hash(Arc::clone(&key), hash, value.clone())
+                    .await;
+                Entry::new(Some(key), value, true)
+            }
         }
     }
 
@@ -1447,8 +1494,8 @@ where
         F: Future<Output = Result<V, E>>,
         E: Send + Sync + 'static,
     {
-        if let Some(v) = self.base.get_with_hash(&key, hash) {
-            return Ok(v);
+        if let Some(entry) = self.base.get_with_hash(&key, hash, false) {
+            return Ok(entry.into_value());
         }
 
         self.try_insert_with_hash_and_fun(key, hash, init).await
@@ -1466,8 +1513,8 @@ where
         K: Borrow<Q>,
         Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
     {
-        if let Some(v) = self.base.get_with_hash(key, hash) {
-            return Ok(v);
+        if let Some(entry) = self.base.get_with_hash(key, hash, false) {
+            return Ok(entry.into_value());
         }
         let key = Arc::new(key.to_owned());
         self.try_insert_with_hash_and_fun(key, hash, init).await
@@ -1513,10 +1560,8 @@ where
     where
         F: Future<Output = Option<V>>,
     {
-        let res = self.base.get_with_hash(&key, hash);
-
-        if res.is_some() {
-            return res;
+        if let Some(entry) = self.base.get_with_hash(&key, hash, false) {
+            return Some(entry.into_value());
         }
 
         self.optionally_insert_with_hash_and_fun(key, hash, init)
@@ -1534,11 +1579,10 @@ where
         K: Borrow<Q>,
         Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
     {
-        let res = self.base.get_with_hash(key, hash);
-
-        if res.is_some() {
-            return res;
+        if let Some(entry) = self.base.get_with_hash(key, hash, false) {
+            return Some(entry.into_value());
         }
+
         let key = Arc::new(key.to_owned());
         self.optionally_insert_with_hash_and_fun(key, hash, init)
             .await
@@ -2580,22 +2624,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_with_if() {
+    async fn entry_or_insert_with_if() {
         let cache = Cache::new(100);
         const KEY: u32 = 0;
 
         // This test will run seven async tasks:
         //
-        // Task1 will be the first task to call `get_with_if` for a key, so its async
-        // block will be evaluated and then a &str value "task1" will be inserted to
-        // the cache.
+        // Task1 will be the first task to call `or_insert_with_if` for a key, so its
+        // async block will be evaluated and then a &str value "task1" will be
+        // inserted to the cache.
         let task1 = {
             let cache1 = cache.clone();
             async move {
-                // Call `get_with_if` immediately.
+                // Call `or_insert_with_if` immediately.
                 let v = cache1
-                    .get_with_if(
-                        KEY,
+                    .entry(KEY)
+                    .or_insert_with_if(
                         async {
                             // Wait for 300 ms and return a &str value.
                             Timer::after(Duration::from_millis(300)).await;
@@ -2603,28 +2647,31 @@ mod tests {
                         },
                         |_v| unreachable!(),
                     )
-                    .await;
+                    .await
+                    .into_value();
                 assert_eq!(v, "task1");
             }
         };
 
-        // Task2 will be the second task to call `get_with_if` for the same key, so
-        // its async block will not be evaluated. Once task1's async block finishes,
-        // it will get the value inserted by task1's async block.
+        // Task2 will be the second task to call `or_insert_with_if` for the same
+        // key, so its async block will not be evaluated. Once task1's async block
+        // finishes, it will get the value inserted by task1's async block.
         let task2 = {
             let cache2 = cache.clone();
             async move {
-                // Wait for 100 ms before calling `get_with_if`.
+                // Wait for 100 ms before calling `or_insert_with_if`.
                 Timer::after(Duration::from_millis(100)).await;
                 let v = cache2
-                    .get_with_if(KEY, async { unreachable!() }, |_v| unreachable!())
-                    .await;
+                    .entry(KEY)
+                    .or_insert_with_if(async { unreachable!() }, |_v| unreachable!())
+                    .await
+                    .into_value();
                 assert_eq!(v, "task1");
             }
         };
 
-        // Task3 will be the third task to call `get_with_if` for the same key. By
-        // the time it calls, task1's async block should have finished already and
+        // Task3 will be the third task to call `or_insert_with_if` for the same key.
+        // By the time it calls, task1's async block should have finished already and
         // the value should be already inserted to the cache. Also task3's
         // `replace_if` closure returns `false`. So its async block will not be
         // evaluated and will get the value inserted by task1's async block
@@ -2632,33 +2679,37 @@ mod tests {
         let task3 = {
             let cache3 = cache.clone();
             async move {
-                // Wait for 350 ms before calling `get_with_if`.
+                // Wait for 350 ms before calling `or_insert_with_if`.
                 Timer::after(Duration::from_millis(350)).await;
                 let v = cache3
-                    .get_with_if(KEY, async { unreachable!() }, |v| {
+                    .entry(KEY)
+                    .or_insert_with_if(async { unreachable!() }, |v| {
                         assert_eq!(v, &"task1");
                         false
                     })
-                    .await;
+                    .await
+                    .into_value();
                 assert_eq!(v, "task1");
             }
         };
 
-        // Task4 will be the fourth task to call `get_with_if` for the same key. The
-        // value should have been already inserted to the cache by task1. However
-        // task4's `replace_if` closure returns `true`. So its async block will be
-        // evaluated to replace the current value.
+        // Task4 will be the fourth task to call `or_insert_with_if` for the same
+        // key. The value should have been already inserted to the cache by task1.
+        // However task4's `replace_if` closure returns `true`. So its async block
+        // will be evaluated to replace the current value.
         let task4 = {
             let cache4 = cache.clone();
             async move {
-                // Wait for 400 ms before calling `get_with_if`.
+                // Wait for 400 ms before calling `or_insert_with_if`.
                 Timer::after(Duration::from_millis(400)).await;
                 let v = cache4
-                    .get_with_if(KEY, async { "task4" }, |v| {
+                    .entry(KEY)
+                    .or_insert_with_if(async { "task4" }, |v| {
                         assert_eq!(v, &"task1");
                         true
                     })
-                    .await;
+                    .await
+                    .into_value();
                 assert_eq!(v, "task4");
             }
         };
@@ -2702,128 +2753,135 @@ mod tests {
         futures_util::join!(task1, task2, task3, task4, task5, task6, task7);
     }
 
-    // #[tokio::test]
-    // async fn get_with_if_by_ref() {
-    //     let cache = Cache::new(100);
-    //     const KEY: &u32 = &0;
+    #[tokio::test]
+    async fn entry_by_ref_or_insert_with_if() {
+        let cache = Cache::new(100);
+        const KEY: &u32 = &0;
 
-    //     // This test will run seven async tasks:
-    //     //
-    //     // Task1 will be the first task to call `get_with_if_by_ref` for a key, so its async
-    //     // block will be evaluated and then a &str value "task1" will be inserted to
-    //     // the cache.
-    //     let task1 = {
-    //         let cache1 = cache.clone();
-    //         async move {
-    //             // Call `get_with_if_by_ref` immediately.
-    //             let v = cache1
-    //                 .get_with_if_by_ref(
-    //                     KEY,
-    //                     async {
-    //                         // Wait for 300 ms and return a &str value.
-    //                         Timer::after(Duration::from_millis(300)).await;
-    //                         "task1"
-    //                     },
-    //                     |_v| unreachable!(),
-    //                 )
-    //                 .await;
-    //             assert_eq!(v, "task1");
-    //         }
-    //     };
+        // This test will run seven async tasks:
+        //
+        // Task1 will be the first task to call `or_insert_with_if` for a key, so its
+        // async block will be evaluated and then a &str value "task1" will be
+        // inserted to the cache.
+        let task1 = {
+            let cache1 = cache.clone();
+            async move {
+                // Call `or_insert_with_if` immediately.
+                let v = cache1
+                    .entry_by_ref(KEY)
+                    .or_insert_with_if(
+                        async {
+                            // Wait for 300 ms and return a &str value.
+                            Timer::after(Duration::from_millis(300)).await;
+                            "task1"
+                        },
+                        |_v| unreachable!(),
+                    )
+                    .await
+                    .into_value();
+                assert_eq!(v, "task1");
+            }
+        };
 
-    //     // Task2 will be the second task to call `get_with_if_by_ref` for the same key, so
-    //     // its async block will not be evaluated. Once task1's async block finishes,
-    //     // it will get the value inserted by task1's async block.
-    //     let task2 = {
-    //         let cache2 = cache.clone();
-    //         async move {
-    //             // Wait for 100 ms before calling `get_with_if_by_ref`.
-    //             Timer::after(Duration::from_millis(100)).await;
-    //             let v = cache2
-    //                 .get_with_if_by_ref(KEY, async { unreachable!() }, |_v| unreachable!())
-    //                 .await;
-    //             assert_eq!(v, "task1");
-    //         }
-    //     };
+        // Task2 will be the second task to call `or_insert_with_if` for the same
+        // key, so its async block will not be evaluated. Once task1's async block
+        // finishes, it will get the value inserted by task1's async block.
+        let task2 = {
+            let cache2 = cache.clone();
+            async move {
+                // Wait for 100 ms before calling `or_insert_with_if`.
+                Timer::after(Duration::from_millis(100)).await;
+                let v = cache2
+                    .entry_by_ref(KEY)
+                    .or_insert_with_if(async { unreachable!() }, |_v| unreachable!())
+                    .await
+                    .into_value();
+                assert_eq!(v, "task1");
+            }
+        };
 
-    //     // Task3 will be the third task to call `get_with_if_by_ref` for the same key. By
-    //     // the time it calls, task1's async block should have finished already and
-    //     // the value should be already inserted to the cache. Also task3's
-    //     // `replace_if` closure returns `false`. So its async block will not be
-    //     // evaluated and will get the value inserted by task1's async block
-    //     // immediately.
-    //     let task3 = {
-    //         let cache3 = cache.clone();
-    //         async move {
-    //             // Wait for 350 ms before calling `get_with_if_by_ref`.
-    //             Timer::after(Duration::from_millis(350)).await;
-    //             let v = cache3
-    //                 .get_with_if_by_ref(KEY, async { unreachable!() }, |v| {
-    //                     assert_eq!(v, &"task1");
-    //                     false
-    //                 })
-    //                 .await;
-    //             assert_eq!(v, "task1");
-    //         }
-    //     };
+        // Task3 will be the third task to call `or_insert_with_if` for the same key.
+        // By the time it calls, task1's async block should have finished already and
+        // the value should be already inserted to the cache. Also task3's
+        // `replace_if` closure returns `false`. So its async block will not be
+        // evaluated and will get the value inserted by task1's async block
+        // immediately.
+        let task3 = {
+            let cache3 = cache.clone();
+            async move {
+                // Wait for 350 ms before calling `or_insert_with_if`.
+                Timer::after(Duration::from_millis(350)).await;
+                let v = cache3
+                    .entry_by_ref(KEY)
+                    .or_insert_with_if(async { unreachable!() }, |v| {
+                        assert_eq!(v, &"task1");
+                        false
+                    })
+                    .await
+                    .into_value();
+                assert_eq!(v, "task1");
+            }
+        };
 
-    //     // Task4 will be the fourth task to call `get_with_if_by_ref` for the same key. The
-    //     // value should have been already inserted to the cache by task1. However
-    //     // task4's `replace_if` closure returns `true`. So its async block will be
-    //     // evaluated to replace the current value.
-    //     let task4 = {
-    //         let cache4 = cache.clone();
-    //         async move {
-    //             // Wait for 400 ms before calling `get_with_if_by_ref`.
-    //             Timer::after(Duration::from_millis(400)).await;
-    //             let v = cache4
-    //                 .get_with_if_by_ref(KEY, async { "task4" }, |v| {
-    //                     assert_eq!(v, &"task1");
-    //                     true
-    //                 })
-    //                 .await;
-    //             assert_eq!(v, "task4");
-    //         }
-    //     };
+        // Task4 will be the fourth task to call `or_insert_with_if` for the same
+        // key. The value should have been already inserted to the cache by task1.
+        // However task4's `replace_if` closure returns `true`. So its async block
+        // will be evaluated to replace the current value.
+        let task4 = {
+            let cache4 = cache.clone();
+            async move {
+                // Wait for 400 ms before calling `or_insert_with_if`.
+                Timer::after(Duration::from_millis(400)).await;
+                let v = cache4
+                    .entry_by_ref(KEY)
+                    .or_insert_with_if(async { "task4" }, |v| {
+                        assert_eq!(v, &"task1");
+                        true
+                    })
+                    .await
+                    .into_value();
+                assert_eq!(v, "task4");
+            }
+        };
 
-    //     // Task5 will call `get` for the same key. It will call when task1's async
-    //     // block is still running, so it will get none for the key.
-    //     let task5 = {
-    //         let cache5 = cache.clone();
-    //         async move {
-    //             // Wait for 200 ms before calling `get`.
-    //             Timer::after(Duration::from_millis(200)).await;
-    //             let maybe_v = cache5.get(KEY);
-    //             assert!(maybe_v.is_none());
-    //         }
-    //     };
+        // Task5 will call `get` for the same key. It will call when task1's async
+        // block is still running, so it will get none for the key.
+        let task5 = {
+            let cache5 = cache.clone();
+            async move {
+                // Wait for 200 ms before calling `get`.
+                Timer::after(Duration::from_millis(200)).await;
+                let maybe_v = cache5.get(KEY);
+                assert!(maybe_v.is_none());
+            }
+        };
 
-    //     // Task6 will call `get` for the same key. It will call after task1's async
-    //     // block finished, so it will get the value insert by task1's async block.
-    //     let task6 = {
-    //         let cache6 = cache.clone();
-    //         async move {
-    //             // Wait for 350 ms before calling `get`.
-    //             Timer::after(Duration::from_millis(350)).await;
-    //             let maybe_v = cache6.get(KEY);
-    //             assert_eq!(maybe_v, Some("task1"));
-    //         }
-    //     };
+        // Task6 will call `get` for the same key. It will call after task1's async
+        // block finished, so it will get the value insert by task1's async block.
+        let task6 = {
+            let cache6 = cache.clone();
+            async move {
+                // Wait for 350 ms before calling `get`.
+                Timer::after(Duration::from_millis(350)).await;
+                let maybe_v = cache6.get(KEY);
+                assert_eq!(maybe_v, Some("task1"));
+            }
+        };
 
-    //     // Task7 will call `get` for the same key. It will call after task4's async
-    //     // block finished, so it will get the value insert by task4's async block.
-    //     let task7 = {
-    //         let cache7 = cache.clone();
-    //         async move {
-    //             // Wait for 450 ms before calling `get`.
-    //             Timer::after(Duration::from_millis(450)).await;
-    //             let maybe_v = cache7.get(KEY);
-    //             assert_eq!(maybe_v, Some("task4"));
-    //         }
-    //     };
+        // Task7 will call `get` for the same key. It will call after task4's async
+        // block finished, so it will get the value insert by task4's async block.
+        let task7 = {
+            let cache7 = cache.clone();
+            async move {
+                // Wait for 450 ms before calling `get`.
+                Timer::after(Duration::from_millis(450)).await;
+                let maybe_v = cache7.get(KEY);
+                assert_eq!(maybe_v, Some("task4"));
+            }
+        };
 
-    //     futures_util::join!(task1, task2, task3, task4, task5, task6, task7);
-    // }
+        futures_util::join!(task1, task2, task3, task4, task5, task6, task7);
+    }
 
     #[tokio::test]
     async fn try_get_with() {
@@ -2976,9 +3034,9 @@ mod tests {
 
         // This test will run eight async tasks:
         //
-        // Task1 will be the first task to call `try_get_with_by_ref` for a key, so its async
-        // block will be evaluated and then an error will be returned. Nothing will
-        // be inserted to the cache.
+        // Task1 will be the first task to call `try_get_with_by_ref` for a key, so
+        // its async block will be evaluated and then an error will be returned.
+        // Nothing will be inserted to the cache.
         let task1 = {
             let cache1 = cache.clone();
             async move {
@@ -3126,9 +3184,10 @@ mod tests {
             }
         };
 
-        // Task2 will be the second task to call `optionally_get_with` for the same key, so its
-        // async block will not be evaluated. Once task1's async block finishes, it
-        // will get the same error value returned by task1's async block.
+        // Task2 will be the second task to call `optionally_get_with` for the same
+        // key, so its async block will not be evaluated. Once task1's async block
+        // finishes, it will get the same error value returned by task1's async
+        // block.
         let task2 = {
             let cache2 = cache.clone();
             async move {
@@ -3240,8 +3299,8 @@ mod tests {
 
         // This test will run eight async tasks:
         //
-        // Task1 will be the first task to call `optionally_get_with_by_ref` for a key,
-        // so its async block will be evaluated and then an None will be
+        // Task1 will be the first task to call `optionally_get_with_by_ref` for a
+        // key, so its async block will be evaluated and then an None will be
         // returned. Nothing will be inserted to the cache.
         let task1 = {
             let cache1 = cache.clone();
@@ -3258,9 +3317,10 @@ mod tests {
             }
         };
 
-        // Task2 will be the second task to call `optionally_get_with_by_ref` for the same key, so its
-        // async block will not be evaluated. Once task1's async block finishes, it
-        // will get the same error value returned by task1's async block.
+        // Task2 will be the second task to call `optionally_get_with_by_ref` for the
+        // same key, so its async block will not be evaluated. Once task1's async
+        // block finishes, it will get the same error value returned by task1's async
+        // block.
         let task2 = {
             let cache2 = cache.clone();
             async move {

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -754,6 +754,38 @@ where
             .map(Entry::into_value)
     }
 
+    /// Takes a key `K` and returns an [`OwnedKeyEntrySelector`] that can be used to
+    /// select or insert an entry.
+    ///
+    /// [`OwnedKeyEntrySelector`]: ./struct.OwnedKeyEntrySelector.html
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, u32> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache.entry(key.clone()).or_insert(3).await;
+    ///     assert!(entry.is_fresh());
+    ///     assert_eq!(entry.key(), &key);
+    ///     assert_eq!(entry.into_value(), 3);
+    ///
+    ///     let entry = cache.entry(key).or_insert(6).await;
+    ///     // Not fresh because the value was already in the cache.
+    ///     assert!(!entry.is_fresh());
+    ///     assert_eq!(entry.into_value(), 3);
+    /// }
+    /// ```
     pub fn entry(&self, key: K) -> OwnedKeyEntrySelector<'_, K, V, S>
     where
         K: Hash + Eq,
@@ -762,6 +794,38 @@ where
         OwnedKeyEntrySelector::new(key, hash, self)
     }
 
+    /// Takes a reference `&Q` of a key and returns an [`RefKeyEntrySelector`] that
+    /// can be used to select or insert an entry.
+    ///
+    /// [`RefKeyEntrySelector`]: ./struct.RefKeyEntrySelector.html
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, u32> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache.entry_by_ref(&key).or_insert(3).await;
+    ///     assert!(entry.is_fresh());
+    ///     assert_eq!(entry.key(), &key);
+    ///     assert_eq!(entry.into_value(), 3);
+    ///
+    ///     let entry = cache.entry_by_ref(&key).or_insert(6).await;
+    ///     // Not fresh because the value was already in the cache.
+    ///     assert!(!entry.is_fresh());
+    ///     assert_eq!(entry.into_value(), 3);
+    /// }
+    /// ```
     pub fn entry_by_ref<'a, Q>(&'a self, key: &'a Q) -> RefKeyEntrySelector<'a, K, Q, V, S>
     where
         K: Borrow<Q>,

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -851,15 +851,16 @@ where
         self.try_get_with(key, init).await
     }
 
-    /// Ensures the value of the key exists by inserting the output of the `init`
-    /// future if not exist, and returns a _clone_ of the value.
+    /// Returns a _clone_ of the value corresponding to the key. If the value does
+    /// not exist, resolve the `init` future and inserts the output.
     ///
-    /// This method prevents to resolve the init future multiple times on the same
-    /// key even if the method is concurrently called by many async tasks; only one
-    /// of the calls resolves its future, and other calls wait for that future to
-    /// complete.
+    /// # Concurrent calls on the same key
     ///
-    /// # Example
+    /// This method guarantees that concurrent calls on the same not-existing key are
+    /// coalesced into one evaluation of the `init` future. Only one of the calls
+    /// evaluates its future, and other calls wait for that future to resolve.
+    ///
+    /// The following code snippet demonstrates this behavior:
     ///
     /// ```rust
     /// // Cargo.toml
@@ -957,8 +958,8 @@ where
             .into_value()
     }
 
-    /// Deprecated, replaced with [`entry()::or_insert_with_if()`]
-    /// (./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
+    /// Deprecated, replaced with
+    /// [`entry()::or_insert_with_if()`](./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
     #[deprecated(since = "0.10.0", note = "Replaced with `entry().or_insert_with_if()`")]
     pub async fn get_with_if(
         &self,
@@ -973,14 +974,18 @@ where
             .into_value()
     }
 
-    /// Try to ensure the value of the key exists by inserting an `Some` output of
-    /// the init future. If not exist, returns a _clone_ of the value or `None`
-    /// produced by the future.
+    /// Returns a _clone_ of the value corresponding to the key. If the value does
+    /// not exist, resolves the `init` future, and inserts the value if `Some(value)`
+    /// was returned. If `None` was returned from the future, this method does not
+    /// insert a value and returns `None`.
     ///
-    /// This method prevents to resolve the init future multiple times on the same
-    /// key even if the method is concurrently called by many async tasks; only one
-    /// of the calls resolves its future (as long as these futures return the value),
-    /// and other calls wait for that future to complete.
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing key are
+    /// coalesced into one evaluation of the `init` future. Only one of the calls
+    /// evaluates its future, and other calls wait for that future to resolve.
+    ///
+    /// The following code snippet demonstrates this behavior:
     ///
     /// # Example
     ///
@@ -1090,14 +1095,21 @@ where
             .map(Entry::into_value)
     }
 
-    /// Try to ensure the value of the key exists by inserting an `Ok` output of the
-    /// init future if not exist, and returns a _clone_ of the value or the `Err`
-    /// produced by the future.
+    /// Returns a _clone_ of the value corresponding to the key. If the value does
+    /// not exist, resolves the `init` future, and inserts the value if `Ok(value)`
+    /// was returned. If `Err(_)` was returned from the future, this method does not
+    /// insert a value and returns the `Err` wrapped by [`std::sync::Arc`][std-arc].
     ///
-    /// This method prevents to resolve the init future multiple times on the same
-    /// key even if the method is concurrently called by many async tasks; only one
-    /// of the calls resolves its future (as long as these futures return the same
-    /// error type), and other calls wait for that future to complete.
+    /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing key are
+    /// coalesced into one evaluation of the `init` future (as long as these
+    /// futures return the same error type). Only one of the calls evaluates its
+    /// future, and other calls wait for that future to resolve.
+    ///
+    /// The following code snippet demonstrates this behavior:
     ///
     /// # Example
     ///

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1508,7 +1508,8 @@ where
 
         let get = || {
             self.base
-                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut(), need_key)
+                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut(), false)
+                .map(Entry::into_value)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
 
@@ -1627,7 +1628,8 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, need_key)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if, false)
+                .map(Entry::into_value)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
 
@@ -1707,7 +1709,8 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, need_key)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if, false)
+                .map(Entry::into_value)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -984,10 +984,6 @@ where
     ///
     /// The following code snippet demonstrates this behavior:
     ///
-    /// # Example
-    ///
-    /// The following code snippet demonstrates this behavior:
-    ///
     /// ```rust
     /// // Cargo.toml
     /// //
@@ -1102,15 +1098,6 @@ where
     /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
     ///
     /// # Concurrent calls on the same key
-    ///
-    /// This method guarantees that concurrent calls on the same not-existing key are
-    /// coalesced into one evaluation of the `init` future (as long as these
-    /// futures return the same error type). Only one of the calls evaluates its
-    /// future, and other calls wait for that future to resolve.
-    ///
-    /// The following code snippet demonstrates this behavior:
-    ///
-    /// # Example
     ///
     /// This method guarantees that concurrent calls on the same not-existing key are
     /// coalesced into one evaluation of the `init` future (as long as these
@@ -1461,10 +1448,10 @@ where
         mut replace_if: Option<impl FnMut(&V) -> bool>,
         need_key: bool,
     ) -> Entry<K, V> {
-        let maybe_v =
+        let maybe_entry =
             self.base
                 .get_with_hash_but_ignore_if(&key, hash, replace_if.as_mut(), need_key);
-        if let Some(v) = maybe_v {
+        if let Some(v) = maybe_entry {
             v
         } else {
             self.insert_with_hash_and_fun(key, hash, init, replace_if, need_key)
@@ -1484,10 +1471,10 @@ where
         K: Borrow<Q>,
         Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
     {
-        let maybe_v =
+        let maybe_entry =
             self.base
                 .get_with_hash_but_ignore_if(key, hash, replace_if.as_mut(), need_key);
-        if let Some(v) = maybe_v {
+        if let Some(v) = maybe_entry {
             v
         } else {
             let key = Arc::new(key.to_owned());
@@ -1508,8 +1495,7 @@ where
 
         let get = || {
             self.base
-                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut(), false)
-                .map(Entry::into_value)
+                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut())
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
 
@@ -1628,8 +1614,7 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, false)
-                .map(Entry::into_value)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
 
@@ -1709,8 +1694,7 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, false)
-                .map(Entry::into_value)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1461,9 +1461,9 @@ where
         mut replace_if: Option<impl FnMut(&V) -> bool>,
         need_key: bool,
     ) -> Entry<K, V> {
-        let maybe_v = self
-            .base
-            .get_with_hash_but_ignore_if(&key, hash, replace_if.as_mut(), need_key);
+        let maybe_v =
+            self.base
+                .get_with_hash_but_ignore_if(&key, hash, replace_if.as_mut(), need_key);
         if let Some(v) = maybe_v {
             v
         } else {
@@ -1484,9 +1484,9 @@ where
         K: Borrow<Q>,
         Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
     {
-        let maybe_v = self
-            .base
-            .get_with_hash_but_ignore_if(key, hash, replace_if.as_mut(), need_key);
+        let maybe_v =
+            self.base
+                .get_with_hash_but_ignore_if(key, hash, replace_if.as_mut(), need_key);
         if let Some(v) = maybe_v {
             v
         } else {

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -9,6 +9,16 @@ use std::{
     sync::Arc,
 };
 
+/// Provides advanced methods to select or insert an entry of the cache.
+///
+/// Many methods here return an [`Entry`], a snapshot of a single key-value pair in
+/// the cache, carrying additional information like `is_fresh`.
+///
+/// `OwnedKeyEntrySelector` is constructed from the [`entry`][entry-method] method on
+/// the cache.
+///
+/// [`Entry`]: ../struct.Entry.html
+/// [entry-method]: ./struct.Cache.html#method.entry
 pub struct OwnedKeyEntrySelector<'a, K, V, S> {
     owned_key: K,
     hash: u64,
@@ -51,7 +61,7 @@ where
     ///     assert_eq!(entry.into_value(), None);
     ///
     ///     let entry = cache.entry(key).or_default().await;
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     /// }
     /// ```
@@ -87,7 +97,7 @@ where
     ///     assert_eq!(entry.into_value(), 3);
     ///
     ///     let entry = cache.entry(key).or_insert(6).await;
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
@@ -128,7 +138,7 @@ where
     ///         .entry(key)
     ///         .or_insert_with(async { "value2".to_string() })
     ///         .await;
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), "value1");
     /// }
@@ -197,7 +207,7 @@ where
     ///         .or_optionally_insert_with(async { Some(6) })
     ///         .await;
     ///     let entry = some_entry.unwrap();
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
@@ -248,7 +258,7 @@ where
     ///         .or_try_insert_with(async { Ok::<u32, &str>(6) })
     ///         .await;
     ///     let entry = ok_entry.unwrap();
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
@@ -265,6 +275,16 @@ where
     }
 }
 
+/// Provides advanced methods to select or insert an entry of the cache.
+///
+/// Many methods here return an [`Entry`], a snapshot of a single key-value pair in
+/// the cache, carrying additional information like `is_fresh`.
+///
+/// `RefKeyEntrySelector` is constructed from the
+/// [`entry_by_ref`][entry-by-ref-method] method on the cache.
+///
+/// [`Entry`]: ../struct.Entry.html
+/// [entry-by-ref-method]: ./struct.Cache.html#method.entry_by_ref
 pub struct RefKeyEntrySelector<'a, K, Q, V, S>
 where
     Q: ?Sized,
@@ -311,7 +331,7 @@ where
     ///     assert_eq!(entry.into_value(), None);
     ///
     ///     let entry = cache.entry_by_ref(&key).or_default().await;
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     /// }
     /// ```
@@ -346,7 +366,7 @@ where
     ///     assert_eq!(entry.into_value(), 3);
     ///
     ///     let entry = cache.entry_by_ref(&key).or_insert(6).await;
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
@@ -386,7 +406,7 @@ where
     ///         .entry_by_ref(&key)
     ///         .or_insert_with(async { "value2".to_string() })
     ///         .await;
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), "value1");
     /// }
@@ -449,7 +469,7 @@ where
     ///         .or_optionally_insert_with(async { Some(6) })
     ///         .await;
     ///     let entry = some_entry.unwrap();
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
@@ -499,7 +519,7 @@ where
     ///         .or_try_insert_with(async { Ok::<u32, &str>(6) })
     ///         .await;
     ///     let entry = ok_entry.unwrap();
-    ///     // Not fresh because the value is already in the cache.
+    ///     // Not fresh because the value was already in the cache.
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -39,6 +39,13 @@ where
         }
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, inserts one by calling
+    /// the [`default`][std-default-function] function of the value type `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-default-function]: https://doc.rust-lang.org/stable/std/default/trait.Default.html#tymethod.default
+    ///
     /// # Example
     ///
     /// ```rust
@@ -75,6 +82,12 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, inserts one by using
+    /// the the given `default` value for `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -110,6 +123,12 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, resolves the `init`
+    /// future and inserts the output.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -143,6 +162,15 @@ where
     ///     assert_eq!(entry.into_value(), "value1");
     /// }
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` future. Only one of the calls
+    /// evaluates its future, and other calls wait for that future to resolve. See
+    /// [`Cache::get_with`][get-with-method] for more details.
+    ///
+    /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
         let key = Arc::new(self.owned_key);
         let replace_if = None as Option<fn(&V) -> bool>;
@@ -170,6 +198,14 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, resolves the `init`
+    /// future, and inserts an entry if `Some(value)` was returned. If `None` was
+    /// returned from the future, this method does not insert an entry and returns
+    /// `None`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -211,6 +247,17 @@ where
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
+    /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` future. Only one of the calls
+    /// evaluates its future, and other calls wait for that future to resolve.
+    ///
+    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    ///
+    /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub async fn or_optionally_insert_with(
         self,
         init: impl Future<Output = Option<V>>,
@@ -221,6 +268,15 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, resolves the `init`
+    /// future, and inserts an entry if `Ok(value)` was returned. If `Err(_)` was
+    /// returned from the future, this method does not insert an entry and returns
+    /// the `Err` wrapped by [`std::sync::Arc`][std-arc].
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -263,6 +319,17 @@ where
     ///     assert_eq!(entry.into_value(), 3);
     /// }
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` future (as long as these
+    /// futures return the same error type). Only one of the calls evaluates its
+    /// future, and other calls wait for that future to resolve.
+    ///
+    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    ///
+    /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub async fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>
     where
         F: Future<Output = Result<V, E>>,
@@ -309,6 +376,14 @@ where
         }
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, inserts one
+    /// by cloning the key and calling the [`default`][std-default-function] function
+    /// of the value type `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-default-function]: https://doc.rust-lang.org/stable/std/default/trait.Default.html#tymethod.default
+    ///
     /// # Example
     ///
     /// ```rust
@@ -344,6 +419,12 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, inserts one
+    /// by cloning the key and using the given `default` value for `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -378,6 +459,12 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, inserts one
+    /// by cloning the key and resolving the `init` future for the value.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -411,6 +498,15 @@ where
     ///     assert_eq!(entry.into_value(), "value1");
     /// }
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` future. Only one of the calls
+    /// evaluates its future, and other calls wait for that future to resolve. See
+    /// [`Cache::get_with`][get-with-method] for more details.
+    ///
+    /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
         let owned_key: K = self.ref_key.to_owned();
         let key = Arc::new(owned_key);
@@ -420,6 +516,14 @@ where
             .await
     }
 
+    /// Works like [`or_insert_with`](#method.or_insert_with), but takes an additional
+    /// `replace_if` closure.
+    ///
+    /// This method will resolve the `init` future and insert the output to the
+    /// cache when:
+    ///
+    /// - The key does not exist.
+    /// - Or, `replace_if` closure returns `true`.
     pub async fn or_insert_with_if(
         self,
         init: impl Future<Output = V>,
@@ -432,6 +536,14 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, clones the
+    /// key and resolves the `init` future. If `Some(value)` was returned by the
+    /// future, inserts an entry with the value . If `None` was returned, this method
+    /// does not insert an entry and returns `None`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -473,6 +585,17 @@ where
     ///     assert!(!entry.is_fresh());
     ///     assert_eq!(entry.into_value(), 3);
     /// }
+    /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` future. Only one of the calls
+    /// evaluates its future, and other calls wait for that future to resolve.
+    ///
+    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    ///
+    /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub async fn or_optionally_insert_with(
         self,
         init: impl Future<Output = Option<V>>,
@@ -482,6 +605,16 @@ where
             .await
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, clones the
+    /// key and resolves the `init` future. If `Ok(value)` was returned from the
+    /// future, inserts an entry with the value. If `Err(_)` was returned, this
+    /// method does not insert an entry and returns the `Err` wrapped by
+    /// [`std::sync::Arc`][std-arc].
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -524,6 +657,17 @@ where
     ///     assert_eq!(entry.into_value(), 3);
     /// }
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` future (as long as these
+    /// futures return the same error type). Only one of the calls evaluates its
+    /// future, and other calls wait for that future to resolve.
+    ///
+    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    ///
+    /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub async fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>
     where
         F: Future<Output = Result<V, E>>,

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -1,0 +1,298 @@
+use crate::Entry;
+
+use super::Cache;
+
+use std::{
+    borrow::Borrow,
+    future::Future,
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+};
+
+pub struct OwnedKeyEntrySelector<'a, K, V, S> {
+    owned_key: K,
+    hash: u64,
+    cache: &'a Cache<K, V, S>,
+}
+
+impl<'a, K, V, S> OwnedKeyEntrySelector<'a, K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn new(owned_key: K, hash: u64, cache: &'a Cache<K, V, S>) -> Self {
+        Self {
+            owned_key,
+            hash,
+            cache,
+        }
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, Option<u32>> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache.entry(key.clone()).or_default().await;
+    ///     assert_eq!(entry.is_fresh(), true);
+    ///     assert_eq!(entry.into_value(), None);
+    ///
+    ///     let entry = cache.entry(key).or_default().await;
+    ///     assert_eq!(entry.is_fresh(), false);
+    /// }
+    /// ```
+    pub async fn or_default(self) -> Entry<K, V>
+    where
+        V: Default,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .get_or_insert_with_hash(key, self.hash, Default::default)
+            .await
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, u32> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache.entry(key.clone()).or_insert(3).await;
+    ///     assert_eq!(entry.is_fresh(), true);
+    ///     assert_eq!(entry.into_value(), 3);
+    ///
+    ///     let entry = cache.entry(key).or_insert(6).await;
+    ///     assert_eq!(entry.is_fresh(), false);
+    ///     assert_eq!(entry.into_value(), 3);
+    /// }
+    /// ```
+    pub async fn or_insert(self, default: V) -> Entry<K, V> {
+        let key = Arc::new(self.owned_key);
+        let init = || default;
+        self.cache
+            .get_or_insert_with_hash(key, self.hash, init)
+            .await
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, String> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache
+    ///         .entry(key.clone())
+    ///         .or_insert_with(async { "value1".to_string() })
+    ///         .await;
+    ///     assert_eq!(entry.is_fresh(), true);
+    ///     assert_eq!(entry.into_value(), "value1");
+    ///
+    ///     let entry = cache
+    ///         .entry(key)
+    ///         .or_insert_with(async { "value2".to_string() })
+    ///         .await;
+    ///     assert_eq!(entry.is_fresh(), false);
+    ///     assert_eq!(entry.into_value(), "value1");
+    /// }
+    /// ```
+    pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
+        let key = Arc::new(self.owned_key);
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.cache
+            .get_or_insert_with_hash_and_fun(key, self.hash, init, replace_if, true)
+            .await
+    }
+
+    /// Works like [`or_insert_with`](#method.or_insert_with), but takes an additional
+    /// `replace_if` closure.
+    ///
+    /// This method will resolve the `init` future and insert the output to the
+    /// cache when:
+    ///
+    /// - The key does not exist.
+    /// - Or, `replace_if` closure returns `true`.
+    pub async fn or_insert_with_if(
+        self,
+        init: impl Future<Output = V>,
+        replace_if: impl FnMut(&V) -> bool,
+    ) -> Entry<K, V> {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .get_or_insert_with_hash_and_fun(key, self.hash, init, Some(replace_if), true)
+            .await
+    }
+}
+
+pub struct RefKeyEntrySelector<'a, K, Q, V, S>
+where
+    Q: ?Sized,
+{
+    ref_key: &'a Q,
+    hash: u64,
+    cache: &'a Cache<K, V, S>,
+}
+
+impl<'a, K, Q, V, S> RefKeyEntrySelector<'a, K, Q, V, S>
+where
+    K: Borrow<Q> + Hash + Eq + Send + Sync + 'static,
+    Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn new(ref_key: &'a Q, hash: u64, cache: &'a Cache<K, V, S>) -> Self {
+        Self {
+            ref_key,
+            hash,
+            cache,
+        }
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, Option<u32>> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache.entry_by_ref(&key).or_default().await;
+    ///     assert_eq!(entry.is_fresh(), true);
+    ///     assert_eq!(entry.into_value(), None);
+    ///
+    ///     let entry = cache.entry_by_ref(&key).or_default().await;
+    ///     assert_eq!(entry.is_fresh(), false);
+    /// }
+    /// ```
+    pub async fn or_default(self) -> Entry<K, V>
+    where
+        V: Default,
+    {
+        self.cache
+            .get_or_insert_with_hash_by_ref(self.ref_key, self.hash, Default::default)
+            .await
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, u32> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache.entry_by_ref(&key).or_insert(3).await;
+    ///     assert_eq!(entry.is_fresh(), true);
+    ///     assert_eq!(entry.into_value(), 3);
+    ///
+    ///     let entry = cache.entry_by_ref(&key).or_insert(6).await;
+    ///     assert_eq!(entry.is_fresh(), false);
+    ///     assert_eq!(entry.into_value(), 3);
+    /// }
+    /// ```
+    pub async fn or_insert(self, default: V) -> Entry<K, V> {
+        let init = || default;
+        self.cache
+            .get_or_insert_with_hash_by_ref(self.ref_key, self.hash, init)
+            .await
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.10", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, String> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache
+    ///         .entry_by_ref(&key)
+    ///         .or_insert_with(async { "value1".to_string() })
+    ///         .await;
+    ///     assert_eq!(entry.is_fresh(), true);
+    ///     assert_eq!(entry.into_value(), "value1");
+    ///
+    ///     let entry = cache
+    ///         .entry_by_ref(&key)
+    ///         .or_insert_with(async { "value2".to_string() })
+    ///         .await;
+    ///     assert_eq!(entry.is_fresh(), false);
+    ///     assert_eq!(entry.into_value(), "value1");
+    /// }
+    /// ```
+    pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
+        let owned_key: K = self.ref_key.to_owned();
+        let key = Arc::new(owned_key);
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.cache
+            .get_or_insert_with_hash_and_fun(key, self.hash, init, replace_if, true)
+            .await
+    }
+
+    pub async fn or_insert_with_if(
+        self,
+        init: impl Future<Output = V>,
+        replace_if: impl FnMut(&V) -> bool,
+    ) -> Entry<K, V> {
+        let owned_key: K = self.ref_key.to_owned();
+        let key = Arc::new(owned_key);
+        self.cache
+            .get_or_insert_with_hash_and_fun(key, self.hash, init, Some(replace_if), true)
+            .await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,18 +64,16 @@
 //!
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
-//! | Feature    | Enabled by default? | MSRV        |
-//! |:-----------|:-------------------:|:-----------:|
-//! | no feature |                     | Rust 1.51.0 |
-//! | `atomic64` |       yes           | Rust 1.51.0 |
-//! | `quanta`   |       yes           | Rust 1.51.0 |
-//! | `future`   |                     | Rust 1.51.0 |
-//! | `dash`     |                     | Rust 1.51.0 |
+//! | Feature          | MSRV                     |
+//! |:-----------------|:------------------------:|
+//! | default features | Rust 1.51.0 (2021-03-25) |
+//! | `future`         | Rust 1.51.0 (2021-03-25) |
 //!
-//! If only the default features are enabled, MSRV will be updated conservatively.
-//! When using other features, like `future`, MSRV might be updated more frequently,
-//! up to the latest stable. In both cases, increasing MSRV is _not_ considered a
-//! semver-breaking change.
+//! It will keep a rolling MSRV policy of at least 6 months. If only the default
+//! features are enabled, MSRV will be updated conservatively. When using other
+//! features, like `future`, MSRV might be updated more frequently, up to the latest
+//! stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
+//! change.
 //!
 //! # Implementation Details
 //!
@@ -188,6 +186,9 @@ pub(crate) mod sync_base;
 
 #[cfg(any(feature = "sync", feature = "future"))]
 pub use common::error::PredicateError;
+
+#[cfg(any(feature = "sync", feature = "future"))]
+pub use common::entry::Entry;
 
 pub use policy::Policy;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,11 +2,17 @@
 
 mod builder;
 mod cache;
+mod entry_selector;
 mod segment;
 mod value_initializer;
 
 pub use crate::sync_base::{iter::Iter, PredicateId};
-pub use {builder::CacheBuilder, cache::Cache, segment::SegmentedCache};
+pub use {
+    builder::CacheBuilder,
+    cache::Cache,
+    entry_selector::{OwnedKeyEntrySelector, RefKeyEntrySelector},
+    segment::SegmentedCache,
+};
 
 /// Provides extra methods that will be useful for testing.
 pub trait ConcurrentCacheExt<K, V> {

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1159,8 +1159,7 @@ where
     ) -> Entry<K, V> {
         let get = || {
             self.base
-                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut(), false)
-                .map(Entry::into_value)
+                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut())
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v);
 
@@ -1382,8 +1381,7 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, false)
-                .map(Entry::into_value)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v);
 
@@ -1575,8 +1573,7 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, need_key)
-                .map(Entry::into_value)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v);
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1001,15 +1001,16 @@ where
         self.try_get_with(key, init)
     }
 
-    /// Ensures the value of the key exists by inserting the output of the `init`
-    /// closure if not exist, and returns a _clone_ of the value.
+    /// Returns a _clone_ of the value corresponding to the key. If the value does
+    /// not exist, evaluates the `init` closure and inserts the output.
     ///
-    /// This method prevents to evaluate the `init` closure multiple times on the
-    /// same key even if the method is concurrently called by many threads; only one
-    /// of the calls evaluates its closure, and other calls wait for that closure to
-    /// complete.
+    /// # Concurrent calls on the same key
     ///
-    /// # Example
+    /// This method guarantees that concurrent calls on the same not-existing key are
+    /// coalesced into one evaluation of the `init` closure. Only one of the calls
+    /// evaluates its closure, and other calls wait for that closure to complete.
+    ///
+    /// The following code snippet demonstrates this behavior:
     ///
     /// ```rust
     /// use moka::sync::Cache;
@@ -1097,8 +1098,8 @@ where
             .into_value()
     }
 
-    /// Deprecated, replaced with [`entry()::or_insert_with_if()`]
-    /// (./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
+    /// Deprecated, replaced with
+    /// [`entry()::or_insert_with_if()`](./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
     #[deprecated(since = "0.10.0", note = "Replaced with `entry().or_insert_with_if()`")]
     pub fn get_with_if(
         &self,
@@ -1232,16 +1233,18 @@ where
         }
     }
 
-    /// Try to ensure the value of the key exists by inserting an `Some` result of
-    /// the init closure if not exist, and returns a _clone_ of the value or `None`
-    /// returned by the closure.
+    /// Returns a _clone_ of the value corresponding to the key. If the value does
+    /// not exist, evaluates the `init` closure, and inserts the value if
+    /// `Some(value)` was returned. If `None` was returned from the closure, this
+    /// method does not insert a value and returns `None`.
     ///
-    /// This method prevents to evaluate the init closure multiple times on the same
-    /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its closure (as long as these closures return the same
-    /// Option type), and other calls wait for that closure to complete.
+    /// # Concurrent calls on the same key
     ///
-    /// # Example
+    /// This method guarantees that concurrent calls on the same not-existing key are
+    /// coalesced into one evaluation of the `init` closure. Only one of the calls
+    /// evaluates its closure, and other calls wait for that closure to complete.
+    ///
+    /// The following code snippet demonstrates this behavior:
     ///
     /// ```rust
     /// use moka::sync::Cache;
@@ -1414,16 +1417,21 @@ where
         }
     }
 
-    /// Try to ensure the value of the key exists by inserting an `Ok` result of the
-    /// init closure if not exist, and returns a _clone_ of the value or the `Err`
-    /// returned by the closure.
+    /// Returns a _clone_ of the value corresponding to the key. If the value does
+    /// not exist, evaluates the `init` closure, and inserts the value if `Ok(value)`
+    /// was returned. If `Err(_)` was returned from the closure, this method does not
+    /// insert a value and returns the `Err` wrapped by [`std::sync::Arc`][std-arc].
     ///
-    /// This method prevents to evaluate the init closure multiple times on the same
-    /// key even if the method is concurrently called by many threads; only one of
-    /// the calls evaluates its closure (as long as these closures return the same
-    /// error type), and other calls wait for that closure to complete.
+    /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
     ///
-    /// # Example
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing key are
+    /// coalesced into one evaluation of the `init` closure (as long as these
+    /// closures return the same error type). Only one of the calls evaluates its
+    /// closure, and other calls wait for that closure to complete.
+    ///
+    /// The following code snippet demonstrates this behavior:
     ///
     /// ```rust
     /// use moka::sync::Cache;

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -922,6 +922,29 @@ where
         self.base.get_with_hash(key, hash, need_key)
     }
 
+    /// Takes a key `K` and returns an [`OwnedKeyEntrySelector`] that can be used to
+    /// select or insert an entry.
+    ///
+    /// [`OwnedKeyEntrySelector`]: ./struct.OwnedKeyEntrySelector.html
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, u32> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache.entry(key.clone()).or_insert(3);
+    /// assert!(entry.is_fresh());
+    /// assert_eq!(entry.key(), &key);
+    /// assert_eq!(entry.into_value(), 3);
+    ///
+    /// let entry = cache.entry(key).or_insert(6);
+    /// // Not fresh because the value was already in the cache.
+    /// assert!(!entry.is_fresh());
+    /// assert_eq!(entry.into_value(), 3);
+    /// ```
     pub fn entry(&self, key: K) -> OwnedKeyEntrySelector<'_, K, V, S>
     where
         K: Hash + Eq,
@@ -930,6 +953,29 @@ where
         OwnedKeyEntrySelector::new(key, hash, self)
     }
 
+    /// Takes a reference `&Q` of a key and returns an [`RefKeyEntrySelector`] that
+    /// can be used to select or insert an entry.
+    ///
+    /// [`RefKeyEntrySelector`]: ./struct.RefKeyEntrySelector.html
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, u32> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache.entry_by_ref(&key).or_insert(3);
+    /// assert!(entry.is_fresh());
+    /// assert_eq!(entry.key(), &key);
+    /// assert_eq!(entry.into_value(), 3);
+    ///
+    /// let entry = cache.entry_by_ref(&key).or_insert(6);
+    /// // Not fresh because the value was already in the cache.
+    /// assert!(!entry.is_fresh());
+    /// assert_eq!(entry.into_value(), 3);
+    /// ```
     pub fn entry_by_ref<'a, Q>(&'a self, key: &'a Q) -> RefKeyEntrySelector<'a, K, Q, V, S>
     where
         K: Borrow<Q>,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1159,7 +1159,8 @@ where
     ) -> Entry<K, V> {
         let get = || {
             self.base
-                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut(), need_key)
+                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut(), false)
+                .map(Entry::into_value)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v);
 
@@ -1381,7 +1382,8 @@ where
         let get = || {
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
-                .get_with_hash_but_no_recording(&key, hash, ignore_if, need_key)
+                .get_with_hash_but_no_recording(&key, hash, ignore_if, false)
+                .map(Entry::into_value)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v);
 
@@ -1574,6 +1576,7 @@ where
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             self.base
                 .get_with_hash_but_no_recording(&key, hash, ignore_if, need_key)
+                .map(Entry::into_value)
         };
         let insert = |v| self.insert_with_hash(key.clone(), hash, v);
 

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -38,6 +38,13 @@ where
         }
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, inserts one by calling
+    /// the [`default`][std-default-function] function of the value type `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-default-function]: https://doc.rust-lang.org/stable/std/default/trait.Default.html#tymethod.default
+    ///
     /// # Example
     ///
     /// ```rust
@@ -64,6 +71,12 @@ where
             .get_or_insert_with_hash(key, self.hash, Default::default)
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, inserts one by using
+    /// the the given `default` value for `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -88,6 +101,12 @@ where
         self.cache.get_or_insert_with_hash(key, self.hash, init)
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, evaluates the `init`
+    /// closure and inserts the output.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -110,6 +129,15 @@ where
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), "value1");
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` closure. Only one of the
+    /// calls evaluates its closure, and other calls wait for that closure to
+    /// complete. See [`Cache::get_with`][get-with-method] for more details.
+    ///
+    /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub fn or_insert_with(self, init: impl FnOnce() -> V) -> Entry<K, V> {
         let key = Arc::new(self.owned_key);
         let replace_if = None as Option<fn(&V) -> bool>;
@@ -135,6 +163,14 @@ where
             .get_or_insert_with_hash_and_fun(key, self.hash, init, Some(replace_if), true)
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, evaluates the `init`
+    /// closure, and inserts an entry if `Some(value)` was returned. If `None` was
+    /// returned from the closure, this method does not insert an entry and returns
+    /// `None`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -165,6 +201,16 @@ where
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` closure. Only one of the calls
+    /// evaluates its closure, and other calls wait for that closure to complete.
+    ///
+    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    ///
+    /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub fn or_optionally_insert_with(
         self,
         init: impl FnOnce() -> Option<V>,
@@ -174,6 +220,15 @@ where
             .get_or_optionally_insert_with_hash_and_fun(key, self.hash, init, true)
     }
 
+    /// Returns the corresponding [`Entry`] for the key given when this entry
+    /// selector was constructed. If the entry does not exist, evaluates the `init`
+    /// closure, and inserts an entry if `Ok(value)` was returned. If `Err(_)` was
+    /// returned from the closure, this method does not insert an entry and returns
+    /// the `Err` wrapped by [`std::sync::Arc`][std-arc].
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -204,6 +259,17 @@ where
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` closure (as long as these
+    /// closures return the same error type). Only one of the calls evaluates its
+    /// closure, and other calls wait for that closure to complete.
+    ///
+    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    ///
+    /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>
     where
         F: FnOnce() -> Result<V, E>,
@@ -249,6 +315,14 @@ where
         }
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, inserts one
+    /// by cloning the key and calling the [`default`][std-default-function] function
+    /// of the value type `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-default-function]: https://doc.rust-lang.org/stable/std/default/trait.Default.html#tymethod.default
+    ///
     /// # Example
     ///
     /// ```rust
@@ -274,6 +348,12 @@ where
             .get_or_insert_with_hash_by_ref(self.ref_key, self.hash, Default::default)
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, inserts one
+    /// by cloning the key and using the given `default` value for `V`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -298,6 +378,12 @@ where
             .get_or_insert_with_hash_by_ref(self.ref_key, self.hash, init)
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, inserts one
+    /// by cloning the key and evaluating the `init` closure for the value.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -320,6 +406,15 @@ where
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), "value1");
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` closure. Only one of the calls
+    /// evaluates its closure, and other calls wait for that closure to complete. See
+    /// [`Cache::get_with`][get-with-method] for more details.
+    ///
+    /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub fn or_insert_with(self, init: impl FnOnce() -> V) -> Entry<K, V> {
         let replace_if = None as Option<fn(&V) -> bool>;
         self.cache.get_or_insert_with_hash_by_ref_and_fun(
@@ -331,6 +426,14 @@ where
         )
     }
 
+    /// Works like [`or_insert_with`](#method.or_insert_with), but takes an additional
+    /// `replace_if` closure.
+    ///
+    /// This method will evaluate the `init` closure and insert the output to the
+    /// cache when:
+    ///
+    /// - The key does not exist.
+    /// - Or, `replace_if` closure returns `true`.
     pub fn or_insert_with_if(
         self,
         init: impl FnOnce() -> V,
@@ -345,6 +448,14 @@ where
         )
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, clones the
+    /// key and evaluates the `init` closure. If `Some(value)` was returned by the
+    /// closure, inserts an entry with the value . If `None` was returned, this
+    /// method does not insert an entry and returns `None`.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -375,6 +486,17 @@ where
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` closure. Only one of the
+    /// calls evaluates its closure, and other calls wait for that closure to
+    /// complete.
+    ///
+    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    ///
+    /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub fn or_optionally_insert_with(
         self,
         init: impl FnOnce() -> Option<V>,
@@ -383,6 +505,16 @@ where
             .get_or_optionally_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, true)
     }
 
+    /// Returns the corresponding [`Entry`] for the reference of the key given when
+    /// this entry selector was constructed. If the entry does not exist, clones the
+    /// key and evaluates the `init` closure. If `Ok(value)` was returned from the
+    /// closure, inserts an entry with the value. If `Err(_)` was returned, this
+    /// method does not insert an entry and returns the `Err` wrapped by
+    /// [`std::sync::Arc`][std-arc].
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+    ///
     /// # Example
     ///
     /// ```rust
@@ -413,6 +545,17 @@ where
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same not-existing entry
+    /// are coalesced into one evaluation of the `init` closure (as long as these
+    /// closures return the same error type). Only one of the calls evaluates its
+    /// closure, and other calls wait for that closure to complete.
+    ///
+    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    ///
+    /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>
     where
         F: FnOnce() -> Result<V, E>,

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -1,0 +1,236 @@
+use crate::Entry;
+
+use super::Cache;
+
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+};
+
+pub struct OwnedKeyEntrySelector<'a, K, V, S> {
+    owned_key: K,
+    hash: u64,
+    cache: &'a Cache<K, V, S>,
+}
+
+impl<'a, K, V, S> OwnedKeyEntrySelector<'a, K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn new(owned_key: K, hash: u64, cache: &'a Cache<K, V, S>) -> Self {
+        Self {
+            owned_key,
+            hash,
+            cache,
+        }
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, Option<u32>> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache.entry(key.clone()).or_default();
+    /// assert_eq!(entry.is_fresh(), true);
+    /// assert_eq!(entry.into_value(), None);
+    ///
+    /// let entry = cache.entry(key).or_default();
+    /// assert_eq!(entry.is_fresh(), false);
+    /// ```
+    pub fn or_default(self) -> Entry<K, V>
+    where
+        V: Default,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .get_or_insert_with_hash(key, self.hash, Default::default)
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, u32> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache.entry(key.clone()).or_insert(3);
+    /// assert_eq!(entry.is_fresh(), true);
+    /// assert_eq!(entry.into_value(), 3);
+    ///
+    /// let entry = cache.entry(key).or_insert(6);
+    /// assert_eq!(entry.is_fresh(), false);
+    /// assert_eq!(entry.into_value(), 3);
+    /// ```
+    pub fn or_insert(self, default: V) -> Entry<K, V> {
+        let key = Arc::new(self.owned_key);
+        let init = || default;
+        self.cache.get_or_insert_with_hash(key, self.hash, init)
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, String> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache
+    ///     .entry(key.clone())
+    ///     .or_insert_with(|| "value1".to_string());
+    /// assert_eq!(entry.is_fresh(), true);
+    /// assert_eq!(entry.into_value(), "value1");
+    ///
+    /// let entry = cache
+    ///     .entry(key)
+    ///     .or_insert_with(|| "value2".to_string());
+    /// assert_eq!(entry.is_fresh(), false);
+    /// assert_eq!(entry.into_value(), "value1");
+    /// ```
+    pub fn or_insert_with(self, init: impl FnOnce() -> V) -> Entry<K, V> {
+        let key = Arc::new(self.owned_key);
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.cache
+            .get_or_insert_with_hash_and_fun(key, self.hash, init, replace_if, true)
+    }
+
+    /// Works like [`or_insert_with`](#method.or_insert_with), but takes an additional
+    /// `replace_if` closure.
+    ///
+    /// This method will evaluate the `init` closure and insert the output to the
+    /// cache when:
+    ///
+    /// - The key does not exist.
+    /// - Or, `replace_if` closure returns `true`.
+    pub fn or_insert_with_if(
+        self,
+        init: impl FnOnce() -> V,
+        replace_if: impl FnMut(&V) -> bool,
+    ) -> Entry<K, V> {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .get_or_insert_with_hash_and_fun(key, self.hash, init, Some(replace_if), true)
+    }
+}
+
+pub struct RefKeyEntrySelector<'a, K, Q, V, S>
+where
+    Q: ?Sized,
+{
+    ref_key: &'a Q,
+    hash: u64,
+    cache: &'a Cache<K, V, S>,
+}
+
+impl<'a, K, Q, V, S> RefKeyEntrySelector<'a, K, Q, V, S>
+where
+    K: Borrow<Q> + Hash + Eq + Send + Sync + 'static,
+    Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    pub(crate) fn new(ref_key: &'a Q, hash: u64, cache: &'a Cache<K, V, S>) -> Self {
+        Self {
+            ref_key,
+            hash,
+            cache,
+        }
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, Option<u32>> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache.entry_by_ref(&key).or_default();
+    /// assert_eq!(entry.is_fresh(), true);
+    /// assert_eq!(entry.into_value(), None);
+    ///
+    /// let entry = cache.entry_by_ref(&key).or_default();
+    /// assert_eq!(entry.is_fresh(), false);
+    /// ```
+    pub fn or_default(self) -> Entry<K, V>
+    where
+        V: Default,
+    {
+        self.cache
+            .get_or_insert_with_hash_by_ref(self.ref_key, self.hash, Default::default)
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, u32> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache.entry_by_ref(&key).or_insert(3);
+    /// assert_eq!(entry.is_fresh(), true);
+    /// assert_eq!(entry.into_value(), 3);
+    ///
+    /// let entry = cache.entry_by_ref(&key).or_insert(6);
+    /// assert_eq!(entry.is_fresh(), false);
+    /// assert_eq!(entry.into_value(), 3);
+    /// ```
+    pub fn or_insert(self, default: V) -> Entry<K, V> {
+        let init = || default;
+        self.cache
+            .get_or_insert_with_hash_by_ref(self.ref_key, self.hash, init)
+    }
+
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, String> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache
+    ///     .entry_by_ref(&key)
+    ///     .or_insert_with(|| "value1".to_string());
+    /// assert_eq!(entry.is_fresh(), true);
+    /// assert_eq!(entry.into_value(), "value1");
+    ///
+    /// let entry = cache
+    ///     .entry_by_ref(&key)
+    ///     .or_insert_with(|| "value2".to_string());
+    /// assert_eq!(entry.is_fresh(), false);
+    /// assert_eq!(entry.into_value(), "value1");
+    /// ```
+    pub fn or_insert_with(self, init: impl FnOnce() -> V) -> Entry<K, V> {
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.cache.get_or_insert_with_hash_by_ref_and_fun(
+            self.ref_key,
+            self.hash,
+            init,
+            replace_if,
+            true,
+        )
+    }
+
+    pub fn or_insert_with_if(
+        self,
+        init: impl FnOnce() -> V,
+        replace_if: impl FnMut(&V) -> bool,
+    ) -> Entry<K, V> {
+        self.cache.get_or_insert_with_hash_by_ref_and_fun(
+            self.ref_key,
+            self.hash,
+            init,
+            Some(replace_if),
+            true,
+        )
+    }
+}

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -8,6 +8,16 @@ use std::{
     sync::Arc,
 };
 
+/// Provides advanced methods to select or insert an entry of the cache.
+///
+/// Many methods here return an [`Entry`], a snapshot of a single key-value pair in
+/// the cache, carrying additional information like `is_fresh`.
+///
+/// `OwnedKeyEntrySelector` is constructed from the [`entry`][entry-method] method on
+/// the cache.
+///
+/// [`Entry`]: ../struct.Entry.html
+/// [entry-method]: ./struct.Cache.html#method.entry
 pub struct OwnedKeyEntrySelector<'a, K, V, S> {
     owned_key: K,
     hash: u64,
@@ -42,7 +52,7 @@ where
     /// assert_eq!(entry.into_value(), None);
     ///
     /// let entry = cache.entry(key).or_default();
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// ```
     pub fn or_default(self) -> Entry<K, V>
@@ -68,7 +78,7 @@ where
     /// assert_eq!(entry.into_value(), 3);
     ///
     /// let entry = cache.entry(key).or_insert(6);
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
@@ -96,7 +106,7 @@ where
     /// let entry = cache
     ///     .entry(key)
     ///     .or_insert_with(|| "value2".to_string());
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), "value1");
     /// ```
@@ -151,7 +161,7 @@ where
     ///     .entry(key)
     ///     .or_optionally_insert_with(|| Some(6));
     /// let entry = some_entry.unwrap();
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
@@ -190,7 +200,7 @@ where
     ///     .entry(key)
     ///     .or_try_insert_with(|| Ok::<u32, &str>(6));
     /// let entry = ok_entry.unwrap();
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
@@ -205,6 +215,16 @@ where
     }
 }
 
+/// Provides advanced methods to select or insert an entry of the cache.
+///
+/// Many methods here return an [`Entry`], a snapshot of a single key-value pair in
+/// the cache, carrying additional information like `is_fresh`.
+///
+/// `RefKeyEntrySelector` is constructed from the
+/// [`entry_by_ref`][entry-by-ref-method] method on the cache.
+///
+/// [`Entry`]: ../struct.Entry.html
+/// [entry-by-ref-method]: ./struct.Cache.html#method.entry_by_ref
 pub struct RefKeyEntrySelector<'a, K, Q, V, S>
 where
     Q: ?Sized,
@@ -243,7 +263,7 @@ where
     /// assert_eq!(entry.into_value(), None);
     ///
     /// let entry = cache.entry_by_ref(&key).or_default();
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// ```
     pub fn or_default(self) -> Entry<K, V>
@@ -268,7 +288,7 @@ where
     /// assert_eq!(entry.into_value(), 3);
     ///
     /// let entry = cache.entry_by_ref(&key).or_insert(6);
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
@@ -296,7 +316,7 @@ where
     /// let entry = cache
     ///     .entry_by_ref(&key)
     ///     .or_insert_with(|| "value2".to_string());
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), "value1");
     /// ```
@@ -351,7 +371,7 @@ where
     ///     .entry_by_ref(&key)
     ///     .or_optionally_insert_with(|| Some(6));
     /// let entry = some_entry.unwrap();
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```
@@ -389,7 +409,7 @@ where
     ///     .entry_by_ref(&key)
     ///     .or_try_insert_with(|| Ok::<u32, &str>(6));
     /// let entry = ok_entry.unwrap();
-    /// // Not fresh because the value is already in the cache.
+    /// // Not fresh because the value was already in the cache.
     /// assert!(!entry.is_fresh());
     /// assert_eq!(entry.into_value(), 3);
     /// ```

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -406,7 +406,8 @@ where
         let key = Arc::new(key);
         self.inner
             .select(hash)
-            .get_or_try_insert_with_hash_and_fun(key, hash, init)
+            .get_or_try_insert_with_hash_and_fun(key, hash, init, false)
+            .map(Entry::into_value)
     }
 
     /// Similar to [`try_get_with`](#method.try_get_with), but instead of passing an
@@ -422,7 +423,8 @@ where
         let hash = self.inner.hash(key);
         self.inner
             .select(hash)
-            .get_or_try_insert_with_hash_by_ref_and_fun(key, hash, init)
+            .get_or_try_insert_with_hash_by_ref_and_fun(key, hash, init, false)
+            .map(Entry::into_value)
     }
 
     /// Try to ensure the value of the key exists by inserting an `Some` result of

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -441,7 +441,8 @@ where
         let key = Arc::new(key);
         self.inner
             .select(hash)
-            .get_or_optionally_insert_with_hash_and_fun(key, hash, init)
+            .get_or_optionally_insert_with_hash_and_fun(key, hash, init, false)
+            .map(Entry::into_value)
     }
 
     /// Similar to [`optionally_get_with`](#method.optionally_get_with), but instead
@@ -457,7 +458,8 @@ where
         let hash = self.inner.hash(key);
         self.inner
             .select(hash)
-            .get_or_optionally_insert_with_hash_by_ref_and_fun(key, hash, init)
+            .get_or_optionally_insert_with_hash_by_ref_and_fun(key, hash, init, false)
+            .map(Entry::into_value)
     }
 
     /// Inserts a key-value pair into the cache.

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -257,8 +257,7 @@ where
         key: &Q,
         hash: u64,
         ignore_if: Option<&mut I>,
-        need_key: bool,
-    ) -> Option<Entry<K, V>>
+    ) -> Option<V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -266,7 +265,8 @@ where
     {
         // Define a closure that skips to record a read op.
         let record = |_op, _now| {};
-        self.do_get_with_hash(key, hash, record, ignore_if, need_key)
+        self.do_get_with_hash(key, hash, record, ignore_if, false)
+            .map(Entry::into_value)
     }
 
     fn do_get_with_hash<Q, R, I>(

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -229,7 +229,7 @@ where
                 .expect("Failed to record a get op");
         };
         let ignore_if = None as Option<&mut fn(&V) -> bool>;
-        self.do_get_with_hash(key, hash, record, ignore_if)
+        self.do_get_with_hash(key, hash, record, ignore_if, need_key)
     }
 
     pub(crate) fn get_with_hash_but_ignore_if<Q, I>(
@@ -237,7 +237,8 @@ where
         key: &Q,
         hash: u64,
         ignore_if: Option<&mut I>,
-    ) -> Option<V>
+        need_key: bool,
+    ) -> Option<Entry<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -248,7 +249,7 @@ where
             self.record_read_op(op, now)
                 .expect("Failed to record a get op");
         };
-        self.do_get_with_hash(key, hash, record, ignore_if)
+        self.do_get_with_hash(key, hash, record, ignore_if, need_key)
     }
 
     pub(crate) fn get_with_hash_but_no_recording<Q, I>(
@@ -256,7 +257,8 @@ where
         key: &Q,
         hash: u64,
         ignore_if: Option<&mut I>,
-    ) -> Option<V>
+        need_key: bool,
+    ) -> Option<Entry<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -264,7 +266,7 @@ where
     {
         // Define a closure that skips to record a read op.
         let record = |_op, _now| {};
-        self.do_get_with_hash(key, hash, record, ignore_if)
+        self.do_get_with_hash(key, hash, record, ignore_if, need_key)
     }
 
     fn do_get_with_hash<Q, R, I>(
@@ -273,7 +275,8 @@ where
         hash: u64,
         read_recorder: R,
         mut ignore_if: Option<&mut I>,
-    ) -> Option<V>
+        need_key: bool,
+    ) -> Option<Entry<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -298,18 +298,18 @@ where
                 let i = &self.inner;
                 let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
 
-            if is_expired_entry_wo(ttl, va, entry, now)
-                || is_expired_entry_ao(tti, va, entry, now)
-                || i.is_invalidated_entry(k, entry)
-            {
-                // Expired or invalidated entry.
-                None
-            } else {
-                // Valid entry.
-                let maybe_key = if need_key { Some(Arc::clone(k)) } else { None };
-                Some((maybe_key, TrioArc::clone(entry), now))
-            }
-        });
+                if is_expired_entry_wo(ttl, va, entry, now)
+                    || is_expired_entry_ao(tti, va, entry, now)
+                    || i.is_invalidated_entry(k, entry)
+                {
+                    // Expired or invalidated entry.
+                    None
+                } else {
+                    // Valid entry.
+                    let maybe_key = if need_key { Some(Arc::clone(k)) } else { None };
+                    Some((maybe_key, TrioArc::clone(entry), now))
+                }
+            });
 
         if let Some((maybe_key, entry, now)) = maybe_entry {
             let v = entry.value.clone();

--- a/tests/entry_api_actix_rt2.rs
+++ b/tests/entry_api_actix_rt2.rs
@@ -32,7 +32,7 @@ fn test_get_with() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Task {} started.", task_id);
 
                 let key = "key1".to_string();
-                let value = match task_id % 2 {
+                let value = match task_id % 4 {
                     0 => {
                         my_cache
                             .get_with(key.clone(), async move {
@@ -51,6 +51,24 @@ fn test_get_with() -> Result<(), Box<dyn std::error::Error>> {
                             })
                             .await
                     }
+                    2 => my_cache
+                        .entry(key.clone())
+                        .or_insert_with(async move {
+                            println!("Task {} inserting a value.", task_id);
+                            my_call_counter.fetch_add(1, Ordering::AcqRel);
+                            Arc::new(vec![0u8; TEN_MIB])
+                        })
+                        .await
+                        .into_value(),
+                    3 => my_cache
+                        .entry_by_ref(key.as_str())
+                        .or_insert_with(async move {
+                            println!("Task {} inserting a value.", task_id);
+                            my_call_counter.fetch_add(1, Ordering::AcqRel);
+                            Arc::new(vec![0u8; TEN_MIB])
+                        })
+                        .await
+                        .into_value(),
                     _ => unreachable!(),
                 };
 

--- a/tests/entry_api_async_std.rs
+++ b/tests/entry_api_async_std.rs
@@ -29,7 +29,7 @@ async fn test_get_with() {
                 println!("Task {} started.", task_id);
 
                 let key = "key1".to_string();
-                let value = match task_id % 2 {
+                let value = match task_id % 4 {
                     0 => {
                         my_cache
                             .get_with(key.clone(), async move {
@@ -48,6 +48,24 @@ async fn test_get_with() {
                             })
                             .await
                     }
+                    2 => my_cache
+                        .entry(key.clone())
+                        .or_insert_with(async move {
+                            println!("Task {} inserting a value.", task_id);
+                            my_call_counter.fetch_add(1, Ordering::AcqRel);
+                            Arc::new(vec![0u8; TEN_MIB])
+                        })
+                        .await
+                        .into_value(),
+                    3 => my_cache
+                        .entry_by_ref(key.as_str())
+                        .or_insert_with(async move {
+                            println!("Task {} inserting a value.", task_id);
+                            my_call_counter.fetch_add(1, Ordering::AcqRel);
+                            Arc::new(vec![0u8; TEN_MIB])
+                        })
+                        .await
+                        .into_value(),
                     _ => unreachable!(),
                 };
 


### PR DESCRIPTION
Add `entry` and `entry_by_ref` APIs to `sync` and `future` caches. They return a struct `OwnedKeyEntrySelector` or `RefKeyEntrySelector` respectively. You can use their methods like `or_insert` to select or insert an entry of a cache.

These methods on the entry selectors return an `Entry`, a snapshot of key and value, carrying additional information `is_fresh` to indicates if the value was freshly computed or cached.

```rust
use moka::sync::Cache;

let cache: Cache<String, u32> = Cache::new(100);
let key = "key1".to_string();

let entry = cache.entry_by_ref(&key).or_insert(3);
assert!(entry.is_fresh());
assert_eq!(entry.key(), &key);
assert_eq!(entry.into_value(), 3);

let entry = cache.entry(key).or_insert(6);
// Not fresh because the value was already in the cache.
assert!(!entry.is_fresh());
assert_eq!(entry.into_value(), 3);
```

`OwnedKeyEntrySelector` and `RefKeyEntrySelector` structs provide the following methods:

- `or_default`
- `or_insert`
- `or_insert_with`
- `or_insert_with_if`
- `or_optionally_insert_with`
- `or_try_insert_with`

Also deprecate `get_with_if` methods in `sync` and `future` caches. The same functionality is provided by the entry selector's `or_insert_with_if` method.