### PR TITLE
Fix Clippy warnings (Rust 1.66 beta)

### DIFF
--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -683,13 +683,10 @@ mod tests {
             .collect::<Result<BTreeMap<_, _>, _>>()
             .expect("Got an error from a thread");
 
-        assert_eq!(hashmap.len(), MAX_VALUE as usize);
+        assert_eq!(hashmap.len(), MAX_VALUE);
 
         // Verify that the sum of success insertion counts should be MAX_VALUE.
-        let sum_of_insertions: usize = results1
-            .iter()
-            .map(|(_thread_id, success_count)| success_count)
-            .sum();
+        let sum_of_insertions: usize = results1.values().sum();
         assert_eq!(sum_of_insertions, MAX_VALUE);
 
         // Get all entries from the cht HashMap and turn them into the same format

--- a/src/dash/base_cache.rs
+++ b/src/dash/base_cache.rs
@@ -497,7 +497,7 @@ where
             dashmap::DashMap::with_capacity_and_hasher(initial_capacity, build_hasher.clone());
 
         Self {
-            max_capacity: max_capacity.map(|n| n as u64),
+            max_capacity,
             entry_count: Default::default(),
             weighted_size: Default::default(),
             cache,

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -868,7 +868,7 @@ where
 
         Self {
             name,
-            max_capacity: max_capacity.map(|n| n as u64),
+            max_capacity,
             entry_count: Default::default(),
             weighted_size: Default::default(),
             cache,

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -284,7 +284,7 @@ where
         );
 
         Self {
-            max_capacity: max_capacity.map(|n| n as u64),
+            max_capacity,
             entry_count: 0,
             weighted_size: 0,
             cache,
@@ -620,12 +620,12 @@ where
 
     fn saturating_add_to_total_weight(&mut self, weight: u64) {
         let total = &mut self.weighted_size;
-        *total = total.saturating_add(weight as u64);
+        *total = total.saturating_add(weight);
     }
 
     fn saturating_sub_from_total_weight(&mut self, weight: u64) {
         let total = &mut self.weighted_size;
-        *total = total.saturating_sub(weight as u64);
+        *total = total.saturating_sub(weight);
     }
 
     #[inline]


### PR DESCRIPTION
clippy 0.1.66 (e080cc5a659 2022-11-01)