### PR TITLE
Prevent race condition in `get_with` method to avoid evaluating `init` closure/future multiple times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ anyhow = "1.0.19"
 async-std = { version = "1.11", features = ["attributes"] }
 env_logger = "0.9"
 getrandom = "0.2"
+paste = "1.0.9"
 reqwest = "0.11.11"
 skeptic = "0.13"
 tokio = { version = "1.19", features = ["fs", "macros", "rt-multi-thread", "sync", "time" ] }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -932,7 +932,7 @@ where
     /// // This async function tries to get HTML from the given URI.
     /// async fn get_html(task_id: u8, uri: &str) -> Result<String, reqwest::Error> {
     ///     println!("get_html() called by task {}.", task_id);
-    ///     Ok(reqwest::get(uri).await?.text().await?)
+    ///     reqwest::get(uri).await?.text().await
     /// }
     ///
     /// #[tokio::main]

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -1,4 +1,5 @@
-use async_lock::RwLock;
+use async_lock::{RwLock, RwLockWriteGuard};
+use futures_util::{future::BoxFuture, FutureExt};
 use std::{
     any::{Any, TypeId},
     future::Future,
@@ -29,6 +30,7 @@ enum WaiterValue<V> {
 }
 
 type Waiter<V> = TrioArc<RwLock<WaiterValue<V>>>;
+type WaiterMap<K, V, S> = crate::cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>;
 
 struct WaiterGuard<'a, K, V, S>
 // NOTE: We usually do not attach trait bounds to here at the struct definition, but
@@ -39,10 +41,10 @@ where
     S: BuildHasher,
 {
     is_waiter_value_set: bool,
-    key: &'a Arc<K>,
-    type_id: TypeId,
-    value_initializer: &'a ValueInitializer<K, V, S>,
-    write_lock: &'a mut WaiterValue<V>,
+    cht_key: (Arc<K>, TypeId),
+    hash: u64,
+    waiters: TrioArc<WaiterMap<K, V, S>>,
+    write_lock: RwLockWriteGuard<'a, WaiterValue<V>>,
 }
 
 impl<'a, K, V, S> WaiterGuard<'a, K, V, S>
@@ -52,16 +54,16 @@ where
     S: BuildHasher,
 {
     fn new(
-        key: &'a Arc<K>,
-        type_id: TypeId,
-        value_initializer: &'a ValueInitializer<K, V, S>,
-        write_lock: &'a mut WaiterValue<V>,
+        cht_key: (Arc<K>, TypeId),
+        hash: u64,
+        waiters: TrioArc<WaiterMap<K, V, S>>,
+        write_lock: RwLockWriteGuard<'a, WaiterValue<V>>,
     ) -> Self {
         Self {
             is_waiter_value_set: false,
-            key,
-            type_id,
-            value_initializer,
+            cht_key,
+            hash,
+            waiters,
             write_lock,
         }
     }
@@ -84,7 +86,7 @@ where
             // `get_or_*_insert_with` has been aborted. Remove our waiter to prevent
             // the issue described in https://github.com/moka-rs/moka/issues/59
             *self.write_lock = WaiterValue::EnclosingFutureAborted;
-            self.value_initializer.remove_waiter(self.key, self.type_id);
+            remove_waiter(&self.waiters, self.cht_key.clone(), self.hash);
             self.is_waiter_value_set = true;
         }
     }
@@ -95,153 +97,229 @@ pub(crate) struct ValueInitializer<K, V, S> {
     // try_init_or_read(). We use the type ID as a part of the key to ensure that
     // we can always downcast the trait object ErrorObject (in Waiter<V>) into
     // its concrete type.
-    waiters: crate::cht::SegmentedHashMap<(Arc<K>, TypeId), Waiter<V>, S>,
+    waiters: TrioArc<WaiterMap<K, V, S>>,
 }
 
 impl<K, V, S> ValueInitializer<K, V, S>
 where
-    K: Eq + Hash,
-    V: Clone,
-    S: BuildHasher,
+    K: Eq + Hash + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Send + Sync + 'static,
 {
     pub(crate) fn with_hasher(hasher: S) -> Self {
         Self {
-            waiters: crate::cht::SegmentedHashMap::with_num_segments_and_hasher(
+            waiters: TrioArc::new(crate::cht::SegmentedHashMap::with_num_segments_and_hasher(
                 WAITER_MAP_NUM_SEGMENTS,
                 hasher,
-            ),
+            )),
         }
     }
 
     /// # Panics
     /// Panics if the `init` future has been panicked.
-    pub(crate) async fn init_or_read<F>(&self, key: Arc<K>, init: F) -> InitResult<V, ()>
-    where
-        F: Future<Output = V>,
-    {
+    pub(crate) async fn init_or_read<'a>(
+        &'a self,
+        key: Arc<K>,
+        // Closure to get an existing value from cache.
+        get: impl FnMut() -> Option<V>,
+        init: impl Future<Output = V>,
+        // Closure to insert a new value into cache.
+        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
+    ) -> InitResult<V, ()> {
+        // This closure will be called before the init closure is called, in order to
+        // check if the value has already been inserted by other async task.
+        let pre_init = make_pre_init(get);
+
         // This closure will be called after the init closure has returned a value.
-        // It will convert the returned value (from init) into an InitResult.
-        let post_init = |_key, value: V, mut guard: WaiterGuard<'_, K, V, S>| {
-            guard.set_waiter_value(WaiterValue::Ready(Ok(value.clone())));
-            InitResult::Initialized(value)
+        // It will convert the returned value (from init) into a pair of a
+        // WaiterValue and an InitResult.
+        let post_init = |value: V| {
+            async move {
+                insert(value.clone()).await;
+                (
+                    WaiterValue::Ready(Ok(value.clone())),
+                    InitResult::Initialized(value),
+                )
+            }
+            .boxed()
         };
 
         let type_id = TypeId::of::<()>();
-        self.do_try_init(&key, type_id, init, post_init).await
+        self.do_try_init(&key, type_id, pre_init, init, post_init)
+            .await
     }
 
     /// # Panics
     /// Panics if the `init` future has been panicked.
-    pub(crate) async fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
+    pub(crate) async fn try_init_or_read<'a, F, E>(
+        &'a self,
+        key: Arc<K>,
+        get: impl FnMut() -> Option<V>,
+        init: F,
+        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
+    ) -> InitResult<V, E>
     where
         F: Future<Output = Result<V, E>>,
         E: Send + Sync + 'static,
     {
-        let type_id = TypeId::of::<E>();
+        // This closure will be called before the init closure is called, in order to
+        // check if the value has already been inserted by other async task.
+        let pre_init = make_pre_init(get);
 
         // This closure will be called after the init closure has returned a value.
-        // It will convert the returned value (from init) into an InitResult.
-        let post_init = |key, value: Result<V, E>, mut guard: WaiterGuard<'_, K, V, S>| match value
-        {
-            Ok(value) => {
-                guard.set_waiter_value(WaiterValue::Ready(Ok(value.clone())));
-                InitResult::Initialized(value)
+        // It will convert the returned value (from init) into a pair of a
+        // WaiterValue and an InitResult.
+        let post_init = move |value: Result<V, E>| {
+            async move {
+                match value {
+                    Ok(value) => {
+                        insert(value.clone()).await;
+                        (
+                            WaiterValue::Ready(Ok(value.clone())),
+                            InitResult::Initialized(value),
+                        )
+                    }
+                    Err(e) => {
+                        let err: ErrorObject = Arc::new(e);
+                        (
+                            WaiterValue::Ready(Err(Arc::clone(&err))),
+                            InitResult::InitErr(err.downcast().unwrap()),
+                        )
+                    }
+                }
             }
-            Err(e) => {
-                let err: ErrorObject = Arc::new(e);
-                guard.set_waiter_value(WaiterValue::Ready(Err(Arc::clone(&err))));
-                self.remove_waiter(key, type_id);
-                InitResult::InitErr(err.downcast().unwrap())
-            }
+            .boxed()
         };
 
-        self.do_try_init(&key, type_id, init, post_init).await
+        let type_id = TypeId::of::<E>();
+        self.do_try_init(&key, type_id, pre_init, init, post_init)
+            .await
     }
 
     /// # Panics
     /// Panics if the `init` future has been panicked.
-    pub(super) async fn optionally_init_or_read<F>(
-        &self,
+    pub(super) async fn optionally_init_or_read<'a, F>(
+        &'a self,
         key: Arc<K>,
+        get: impl FnMut() -> Option<V>,
         init: F,
+        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
     ) -> InitResult<V, OptionallyNone>
     where
         F: Future<Output = Option<V>>,
     {
-        let type_id = TypeId::of::<OptionallyNone>();
+        // This closure will be called before the init closure is called, in order to
+        // check if the value has already been inserted by other async task.
+        let pre_init = make_pre_init(get);
 
         // This closure will be called after the init closure has returned a value.
-        // It will convert the returned value (from init) into an InitResult.
-        let post_init = |key, value: Option<V>, mut guard: WaiterGuard<'_, K, V, S>| match value {
-            Some(value) => {
-                guard.set_waiter_value(WaiterValue::Ready(Ok(value.clone())));
-                InitResult::Initialized(value)
+        // It will convert the returned value (from init) into a pair of a
+        // WaiterValue and an InitResult.
+        let post_init = |value: Option<V>| {
+            async move {
+                match value {
+                    Some(value) => {
+                        insert(value.clone()).await;
+                        (
+                            WaiterValue::Ready(Ok(value.clone())),
+                            InitResult::Initialized(value),
+                        )
+                    }
+                    None => {
+                        // `value` can be either `Some` or `None`. For `None` case, without
+                        // change the existing API too much, we will need to convert `None`
+                        // to Arc<E> here. `Infalliable` could not be instantiated. So it
+                        // might be good to use an empty struct to indicate the error type.
+                        let err: ErrorObject = Arc::new(OptionallyNone);
+                        (
+                            WaiterValue::Ready(Err(Arc::clone(&err))),
+                            InitResult::InitErr(err.downcast().unwrap()),
+                        )
+                    }
+                }
             }
-            None => {
-                // `value` can be either `Some` or `None`. For `None` case, without
-                // change the existing API too much, we will need to convert `None`
-                // to Arc<E> here. `Infalliable` could not be instantiated. So it
-                // might be good to use an empty struct to indicate the error type.
-                let err: ErrorObject = Arc::new(OptionallyNone);
-                guard.set_waiter_value(WaiterValue::Ready(Err(Arc::clone(&err))));
-                self.remove_waiter(key, type_id);
-                InitResult::InitErr(err.downcast().unwrap())
-            }
+            .boxed()
         };
 
-        self.do_try_init(&key, type_id, init, post_init).await
+        let type_id = TypeId::of::<OptionallyNone>();
+        self.do_try_init(&key, type_id, pre_init, init, post_init)
+            .await
     }
 
     /// # Panics
     /// Panics if the `init` future has been panicked.
-    async fn do_try_init<'a, F, O, C, E>(
-        &self,
-        key: &'a Arc<K>,
+    async fn do_try_init<'a, F, O, C1, C2, E>(
+        &'a self,
+        key: &Arc<K>,
         type_id: TypeId,
+        mut pre_init: C1,
         init: F,
-        mut post_init: C,
+        post_init: C2,
     ) -> InitResult<V, E>
     where
         F: Future<Output = O>,
-        C: FnMut(&'a Arc<K>, O, WaiterGuard<'_, K, V, S>) -> InitResult<V, E>,
+        C1: FnMut() -> Option<(WaiterValue<V>, InitResult<V, E>)>,
+        C2: FnOnce(O) -> BoxFuture<'a, (WaiterValue<V>, InitResult<V, E>)>,
         E: Send + Sync + 'static,
     {
-        use futures_util::FutureExt;
         use std::panic::{resume_unwind, AssertUnwindSafe};
         use InitResult::*;
 
         const MAX_RETRIES: usize = 200;
         let mut retries = 0;
 
+        let (cht_key, hash) = cht_key_hash(&self.waiters, key, type_id);
+
         loop {
             let waiter = TrioArc::new(RwLock::new(WaiterValue::Computing));
-            let mut lock = waiter.write().await;
+            let lock = waiter.write().await;
 
-            match self.try_insert_waiter(key, type_id, &waiter) {
+            match try_insert_waiter(&self.waiters, cht_key.clone(), hash, &waiter) {
                 None => {
-                    // Our waiter was inserted. Let's resolve the init future.
+                    // Our waiter was inserted.
 
                     // Create a guard. This will ensure to remove our waiter when the
                     // enclosing future has been aborted:
                     // https://github.com/moka-rs/moka/issues/59
-                    let mut waiter_guard = WaiterGuard::new(key, type_id, self, &mut lock);
+                    let mut waiter_guard = WaiterGuard::new(
+                        cht_key.clone(),
+                        hash,
+                        TrioArc::clone(&self.waiters),
+                        lock,
+                    );
+
+                    // Check if the value has already been inserted by other thread.
+                    if let Some((waiter_val, init_res)) = pre_init() {
+                        // Yes. Set the waiter value, remove our waiter, and return
+                        // the existing value.
+                        waiter_guard.set_waiter_value(waiter_val);
+                        remove_waiter(&self.waiters, cht_key, hash);
+                        return init_res;
+                    }
+
+                    // The value still does note exist. Let's resolve the init future.
 
                     // Catching panic is safe here as we do not try to resolve the future again.
                     match AssertUnwindSafe(init).catch_unwind().await {
                         // Resolved.
-                        Ok(value) => return post_init(key, value, waiter_guard),
+                        Ok(value) => {
+                            let (waiter_val, init_res) = post_init(value).await;
+                            waiter_guard.set_waiter_value(waiter_val);
+                            remove_waiter(&self.waiters, cht_key, hash);
+                            return init_res;
+                        }
                         // Panicked.
                         Err(payload) => {
                             waiter_guard.set_waiter_value(WaiterValue::InitFuturePanicked);
                             // Remove the waiter so that others can retry.
-                            self.remove_waiter(key, type_id);
+                            remove_waiter(&self.waiters, cht_key, hash);
                             resume_unwind(payload);
-                        } // The lock will be unlocked here.
-                    }
+                        }
+                    } // The lock will be unlocked here.
                 }
                 Some(res) => {
-                    // Somebody else's waiter already exists. Drop our write lock and wait
-                    // for a read lock to become available.
+                    // Somebody else's waiter already exists. Drop our write lock and
+                    // wait for the read lock to become available.
                     std::mem::drop(lock);
                     match &*res.read().await {
                         WaiterValue::Ready(Ok(value)) => return ReadExisting(value.clone()),
@@ -273,30 +351,61 @@ where
             }
         }
     }
+}
 
-    #[inline]
-    pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
-        let (cht_key, hash) = self.cht_key_hash(key, type_id);
-        self.waiters.remove(hash, |k| k == &cht_key);
-    }
+#[inline]
+fn remove_waiter<K, V, S>(waiter_map: &WaiterMap<K, V, S>, cht_key: (Arc<K>, TypeId), hash: u64)
+where
+    (Arc<K>, TypeId): Eq + Hash,
+    S: BuildHasher,
+{
+    waiter_map.remove(hash, |k| k == &cht_key);
+}
 
-    #[inline]
-    fn try_insert_waiter(
-        &self,
-        key: &Arc<K>,
-        type_id: TypeId,
-        waiter: &Waiter<V>,
-    ) -> Option<Waiter<V>> {
-        let (cht_key, hash) = self.cht_key_hash(key, type_id);
-        let waiter = TrioArc::clone(waiter);
-        self.waiters.insert_if_not_present(cht_key, hash, waiter)
-    }
+#[inline]
+fn try_insert_waiter<K, V, S>(
+    waiter_map: &WaiterMap<K, V, S>,
+    cht_key: (Arc<K>, TypeId),
+    hash: u64,
+    waiter: &Waiter<V>,
+) -> Option<Waiter<V>>
+where
+    (Arc<K>, TypeId): Eq + Hash,
+    S: BuildHasher,
+{
+    let waiter = TrioArc::clone(waiter);
+    waiter_map.insert_if_not_present(cht_key, hash, waiter)
+}
 
-    #[inline]
-    fn cht_key_hash(&self, key: &Arc<K>, type_id: TypeId) -> ((Arc<K>, TypeId), u64) {
-        let cht_key = (Arc::clone(key), type_id);
-        let hash = self.waiters.hash(&cht_key);
-        (cht_key, hash)
+#[inline]
+fn cht_key_hash<K, V, S>(
+    waiter_map: &WaiterMap<K, V, S>,
+    key: &Arc<K>,
+    type_id: TypeId,
+) -> ((Arc<K>, TypeId), u64)
+where
+    (Arc<K>, TypeId): Eq + Hash,
+    S: BuildHasher,
+{
+    let cht_key = (Arc::clone(key), type_id);
+    let hash = waiter_map.hash(&cht_key);
+    (cht_key, hash)
+}
+
+#[inline]
+fn make_pre_init<V, E>(
+    mut get: impl FnMut() -> Option<V>,
+) -> impl FnMut() -> Option<(WaiterValue<V>, InitResult<V, E>)>
+where
+    V: Clone,
+{
+    move || {
+        get().map(|value| {
+            (
+                WaiterValue::Ready(Ok(value.clone())),
+                InitResult::ReadExisting(value),
+            )
+        })
     }
 }
 

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -44,64 +44,96 @@ where
     }
 
     /// # Panics
-    /// Panics if the `init` future has been panicked.
-    pub(crate) fn init_or_read(&self, key: Arc<K>, init: impl FnOnce() -> V) -> InitResult<V, ()> {
+    /// Panics if the `init` closure has been panicked.
+    pub(crate) fn init_or_read(
+        &self,
+        key: Arc<K>,
+        // Closure to get an existing value from cache.
+        get: impl FnMut() -> Option<V>,
+        init: impl FnOnce() -> V,
+        // Closure to insert a new value into cache.
+        mut insert: impl FnMut(V),
+    ) -> InitResult<V, ()> {
+        // This closure will be called before the init closure is called, in order to
+        // check if the value has already been inserted by other thread.
+        let pre_init = make_pre_init(get);
+
         // This closure will be called after the init closure has returned a value.
-        // It will convert the returned value (from init) into an InitResult.
-        let post_init = |_key, value: V, lock: &mut WaiterValue<V>| {
-            *lock = Some(Ok(value.clone()));
-            InitResult::Initialized(value)
+        // It will convert the returned value (from init) into a pair of a
+        // WaiterValue and an InitResult.
+        let post_init = |value: V| {
+            insert(value.clone());
+            (Some(Ok(value.clone())), InitResult::Initialized(value))
         };
 
         let type_id = TypeId::of::<()>();
-        self.do_try_init(&key, type_id, init, post_init)
+        self.do_try_init(&key, type_id, pre_init, init, post_init)
     }
 
     /// # Panics
-    /// Panics if the `init` future has been panicked.
-    pub(crate) fn try_init_or_read<F, E>(&self, key: Arc<K>, init: F) -> InitResult<V, E>
+    /// Panics if the `init` closure has been panicked.
+    pub(crate) fn try_init_or_read<F, E>(
+        &self,
+        key: Arc<K>,
+        get: impl FnMut() -> Option<V>,
+        init: F,
+        mut insert: impl FnMut(V),
+    ) -> InitResult<V, E>
     where
         F: FnOnce() -> Result<V, E>,
         E: Send + Sync + 'static,
     {
         let type_id = TypeId::of::<E>();
 
+        // This closure will be called before the init closure is called, in order to
+        // check if the value has already been inserted by other thread.
+        let pre_init = make_pre_init(get);
+
         // This closure will be called after the init closure has returned a value.
-        // It will convert the returned value (from init) into an InitResult.
-        let post_init = |key, value: Result<V, E>, lock: &mut WaiterValue<V>| match value {
+        // It will convert the returned value (from init) into a pair of a
+        // WaiterValue and an InitResult.
+        let post_init = |value: Result<V, E>| match value {
             Ok(value) => {
-                *lock = Some(Ok(value.clone()));
-                InitResult::Initialized(value)
+                insert(value.clone());
+                (Some(Ok(value.clone())), InitResult::Initialized(value))
             }
             Err(e) => {
                 let err: ErrorObject = Arc::new(e);
-                *lock = Some(Err(Arc::clone(&err)));
-                self.remove_waiter(key, type_id);
-                InitResult::InitErr(err.downcast().unwrap())
+                (
+                    Some(Err(Arc::clone(&err))),
+                    InitResult::InitErr(err.downcast().unwrap()),
+                )
             }
         };
 
-        self.do_try_init(&key, type_id, init, post_init)
+        self.do_try_init(&key, type_id, pre_init, init, post_init)
     }
 
     /// # Panics
-    /// Panics if the `init` future has been panicked.
+    /// Panics if the `init` closure has been panicked.
     pub(super) fn optionally_init_or_read<F>(
         &self,
         key: Arc<K>,
+        get: impl FnMut() -> Option<V>,
         init: F,
+        mut insert: impl FnMut(V),
     ) -> InitResult<V, OptionallyNone>
     where
         F: FnOnce() -> Option<V>,
     {
         let type_id = TypeId::of::<OptionallyNone>();
 
+        // This closure will be called before the init closure is called, in order to
+        // check if the value has already been inserted by other thread.
+        let pre_init = make_pre_init(get);
+
         // This closure will be called after the init closure has returned a value.
-        // It will convert the returned value (from init) into an InitResult.
-        let post_init = |key, value: Option<V>, lock: &mut WaiterValue<V>| match value {
+        // It will convert the returned value (from init) into a pair of a
+        // WaiterValue and an InitResult.
+        let post_init = |value: Option<V>| match value {
             Some(value) => {
-                *lock = Some(Ok(value.clone()));
-                InitResult::Initialized(value)
+                insert(value.clone());
+                (Some(Ok(value.clone())), InitResult::Initialized(value))
             }
             None => {
                 // `value` can be either `Some` or `None`. For `None` case, without
@@ -109,27 +141,30 @@ where
                 // to Arc<E> here. `Infalliable` could not be instantiated. So it
                 // might be good to use an empty struct to indicate the error type.
                 let err: ErrorObject = Arc::new(OptionallyNone);
-                *lock = Some(Err(Arc::clone(&err)));
-                self.remove_waiter(key, type_id);
-                InitResult::InitErr(err.downcast().unwrap())
+                (
+                    Some(Err(Arc::clone(&err))),
+                    InitResult::InitErr(err.downcast().unwrap()),
+                )
             }
         };
 
-        self.do_try_init(&key, type_id, init, post_init)
+        self.do_try_init(&key, type_id, pre_init, init, post_init)
     }
 
     /// # Panics
-    /// Panics if the `init` future has been panicked.
-    fn do_try_init<'a, F, O, C, E>(
+    /// Panics if the `init` closure has been panicked.
+    fn do_try_init<F, O, C1, C2, E>(
         &self,
-        key: &'a Arc<K>,
+        key: &Arc<K>,
         type_id: TypeId,
+        mut pre_init: C1,
         init: F,
-        mut post_init: C,
+        mut post_init: C2,
     ) -> InitResult<V, E>
     where
         F: FnOnce() -> O,
-        C: FnMut(&'a Arc<K>, O, &mut WaiterValue<V>) -> InitResult<V, E>,
+        C1: FnMut() -> Option<(WaiterValue<V>, InitResult<V, E>)>,
+        C2: FnMut(O) -> (WaiterValue<V>, InitResult<V, E>),
         E: Send + Sync + 'static,
     {
         use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
@@ -138,29 +173,47 @@ where
         const MAX_RETRIES: usize = 200;
         let mut retries = 0;
 
+        let (cht_key, hash) = self.cht_key_hash(key, type_id);
+
         loop {
             let waiter = TrioArc::new(RwLock::new(None));
             let mut lock = waiter.write();
 
-            match self.try_insert_waiter(key, type_id, &waiter) {
+            match self.try_insert_waiter(cht_key.clone(), hash, &waiter) {
                 None => {
-                    // Our waiter was inserted. Let's resolve the init future.
-                    // Catching panic is safe here as we do not try to resolve the future again.
+                    // Our waiter was inserted.
+                    // Check if the value has already been inserted by other thread.
+                    if let Some((waiter_val, init_res)) = pre_init() {
+                        // Yes. Set the waiter value, remove our waiter, and return
+                        // the existing value.
+                        *lock = waiter_val;
+                        self.remove_waiter(cht_key, hash);
+                        return init_res;
+                    }
+
+                    // The value still does note exist. Let's evaluate the init
+                    // closure. Catching panic is safe here as we do not try to
+                    // evaluate the closure again.
                     match catch_unwind(AssertUnwindSafe(init)) {
-                        // Resolved.
-                        Ok(value) => return post_init(key, value, &mut lock),
+                        // Evaluated.
+                        Ok(value) => {
+                            let (waiter_val, init_res) = post_init(value);
+                            *lock = waiter_val;
+                            self.remove_waiter(cht_key, hash);
+                            return init_res;
+                        }
                         // Panicked.
                         Err(payload) => {
                             *lock = None;
                             // Remove the waiter so that others can retry.
-                            self.remove_waiter(key, type_id);
+                            self.remove_waiter(cht_key, hash);
                             resume_unwind(payload);
-                        } // The write lock will be unlocked here.
-                    }
+                        }
+                    } // The write lock will be unlocked here.
                 }
                 Some(res) => {
-                    // Somebody else's waiter already exists. Drop our write lock and wait
-                    // for a read lock to become available.
+                    // Somebody else's waiter already exists. Drop our write lock and
+                    // wait for the read lock to become available.
                     std::mem::drop(lock);
                     match &*res.read() {
                         Some(Ok(value)) => return ReadExisting(value.clone()),
@@ -186,19 +239,17 @@ where
     }
 
     #[inline]
-    pub(crate) fn remove_waiter(&self, key: &Arc<K>, type_id: TypeId) {
-        let (cht_key, hash) = self.cht_key_hash(key, type_id);
+    fn remove_waiter(&self, cht_key: (Arc<K>, TypeId), hash: u64) {
         self.waiters.remove(hash, |k| k == &cht_key);
     }
 
     #[inline]
     fn try_insert_waiter(
         &self,
-        key: &Arc<K>,
-        type_id: TypeId,
+        cht_key: (Arc<K>, TypeId),
+        hash: u64,
         waiter: &Waiter<V>,
     ) -> Option<Waiter<V>> {
-        let (cht_key, hash) = self.cht_key_hash(key, type_id);
         let waiter = TrioArc::clone(waiter);
         self.waiters.insert_if_not_present(cht_key, hash, waiter)
     }
@@ -209,4 +260,14 @@ where
         let hash = self.waiters.hash(&cht_key);
         (cht_key, hash)
     }
+}
+
+#[inline]
+fn make_pre_init<V, E>(
+    mut get: impl FnMut() -> Option<V>,
+) -> impl FnMut() -> Option<(WaiterValue<V>, InitResult<V, E>)>
+where
+    V: Clone,
+{
+    move || get().map(|value| (Some(Ok(value.clone())), InitResult::ReadExisting(value)))
 }

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -277,7 +277,7 @@ where
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
-        R: FnOnce(ReadOp<K, V>, Instant),
+        R: Fn(ReadOp<K, V>, Instant),
         I: FnMut(&V) -> bool,
     {
         let now = self.current_time_from_expiration_clock();

--- a/tests/entry_api_actix_rt2.rs
+++ b/tests/entry_api_actix_rt2.rs
@@ -1,0 +1,69 @@
+#![cfg(all(test, feature = "future"))]
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use actix_rt::Runtime;
+use async_lock::Barrier;
+use moka::future::Cache;
+
+const NUM_THREADS: u8 = 16;
+
+#[test]
+fn test_get_with() -> Result<(), Box<dyn std::error::Error>> {
+    const TEN_MIB: usize = 10 * 1024 * 1024; // 10MiB
+    let cache = Cache::new(100);
+    let call_counter = Arc::new(AtomicUsize::default());
+    let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+    let rt = Runtime::new()?;
+
+    let tasks: Vec<_> = (0..NUM_THREADS)
+        .map(|task_id| {
+            let my_cache = cache.clone();
+            let my_call_counter = Arc::clone(&call_counter);
+            let my_barrier = Arc::clone(&barrier);
+
+            rt.spawn(async move {
+                my_barrier.wait().await;
+
+                println!("Task {} started.", task_id);
+
+                let key = "key1".to_string();
+                let value = match task_id % 2 {
+                    0 => {
+                        my_cache
+                            .get_with(key.clone(), async move {
+                                println!("Task {} inserting a value.", task_id);
+                                my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                Arc::new(vec![0u8; TEN_MIB])
+                            })
+                            .await
+                    }
+                    1 => {
+                        my_cache
+                            .get_with_by_ref(key.as_str(), async move {
+                                println!("Task {} inserting a value.", task_id);
+                                my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                Arc::new(vec![0u8; TEN_MIB])
+                            })
+                            .await
+                    }
+                    _ => unreachable!(),
+                };
+
+                assert_eq!(value.len(), TEN_MIB);
+                assert!(my_cache.get(key.as_str()).is_some());
+
+                println!("Task {} got the value. (len: {})", task_id, value.len());
+            })
+        })
+        .collect();
+
+    rt.block_on(futures_util::future::join_all(tasks));
+    assert_eq!(call_counter.load(Ordering::Acquire), 1);
+
+    Ok(())
+}

--- a/tests/entry_api_async_std.rs
+++ b/tests/entry_api_async_std.rs
@@ -1,0 +1,64 @@
+#![cfg(all(test, feature = "future"))]
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use async_lock::Barrier;
+use moka::future::Cache;
+
+const NUM_THREADS: u8 = 16;
+
+#[async_std::test]
+async fn test_get_with() {
+    const TEN_MIB: usize = 10 * 1024 * 1024; // 10MiB
+    let cache = Cache::new(100);
+    let call_counter = Arc::new(AtomicUsize::default());
+    let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+    let tasks: Vec<_> = (0..NUM_THREADS)
+        .map(|task_id| {
+            let my_cache = cache.clone();
+            let my_call_counter = Arc::clone(&call_counter);
+            let my_barrier = Arc::clone(&barrier);
+
+            async_std::task::spawn(async move {
+                my_barrier.wait().await;
+
+                println!("Task {} started.", task_id);
+
+                let key = "key1".to_string();
+                let value = match task_id % 2 {
+                    0 => {
+                        my_cache
+                            .get_with(key.clone(), async move {
+                                println!("Task {} inserting a value.", task_id);
+                                my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                Arc::new(vec![0u8; TEN_MIB])
+                            })
+                            .await
+                    }
+                    1 => {
+                        my_cache
+                            .get_with_by_ref(key.as_str(), async move {
+                                println!("Task {} inserting a value.", task_id);
+                                my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                Arc::new(vec![0u8; TEN_MIB])
+                            })
+                            .await
+                    }
+                    _ => unreachable!(),
+                };
+
+                assert_eq!(value.len(), TEN_MIB);
+                assert!(my_cache.get(key.as_str()).is_some());
+
+                println!("Task {} got the value. (len: {})", task_id, value.len());
+            })
+        })
+        .collect();
+
+    futures_util::future::join_all(tasks).await;
+    assert_eq!(call_counter.load(Ordering::Acquire), 1);
+}

--- a/tests/entry_api_sync.rs
+++ b/tests/entry_api_sync.rs
@@ -3,7 +3,7 @@
 use std::{
     path::Path,
     sync::atomic::{AtomicUsize, Ordering},
-    sync::Arc,
+    sync::{Arc, Barrier},
     thread,
 };
 
@@ -13,35 +13,103 @@ use paste::paste;
 const NUM_THREADS: u8 = 16;
 const FILE: &str = "./Cargo.toml";
 
-fn get_file_size(thread_id: u8, path: impl AsRef<Path>, call_counter: &AtomicUsize) -> Option<u64> {
-    println!("get_file_size() called by thread {}.", thread_id);
-    call_counter.fetch_add(1, Ordering::AcqRel);
-    std::fs::metadata(path).ok().map(|m| m.len())
-}
-
 macro_rules! generate_test_get_with {
     ($name:ident, $cache_init:expr) => {
         paste! {
             #[test]
             fn [<test_ $name _get_with>]() {
+                const TEN_MIB: usize = 10 * 1024 * 1024; // 10MiB
+
                 let cache = $cache_init;
                 let call_counter = Arc::new(AtomicUsize::default());
+                let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
 
                 let threads: Vec<_> = (0..NUM_THREADS)
                     .map(|thread_id| {
                         let my_cache = cache.clone();
                         let my_call_counter = Arc::clone(&call_counter);
+                        let my_barrier = Arc::clone(&barrier);
+
                         thread::spawn(move || {
+                            my_barrier.wait();
+
                             println!("Thread {} started.", thread_id);
 
                             let key = "key1".to_string();
                             let value = match thread_id % 2 {
-                                0 => my_cache.optionally_get_with(key.clone(), || {
-                                    get_file_size(thread_id, FILE, &my_call_counter)
+                                0 => my_cache.get_with(key.clone(), || {
+                                    println!("Thread {} inserting a value.", thread_id);
+                                    my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                    Arc::new(vec![0u8; TEN_MIB])
                                 }),
-                                1 => my_cache.optionally_get_with_by_ref(key.as_str(), || {
-                                    get_file_size(thread_id, FILE, &my_call_counter)
+                                1 => my_cache.get_with_by_ref(key.as_str(), || {
+                                    println!("Thread {} inserting a value.", thread_id);
+                                    my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                    Arc::new(vec![0u8; TEN_MIB])
                                 }),
+                                _ => unreachable!(),
+                            };
+
+                            assert_eq!(value.len(), TEN_MIB);
+                            assert!(my_cache.get(key.as_str()).is_some());
+
+                            println!("Thread {} got the value. (len: {})", thread_id, value.len());
+                        })
+                    })
+                    .collect();
+
+                threads
+                    .into_iter()
+                    .for_each(|t| t.join().expect("Thread failed"));
+
+                assert_eq!(call_counter.load(Ordering::Acquire), 1);
+            }
+        }
+    };
+}
+
+macro_rules! generate_test_optionally_get_with {
+    ($name:ident, $cache_init:expr) => {
+        paste! {
+            #[test]
+            fn [<test_ $name _optionally_get_with>]() {
+                let cache = $cache_init;
+                let call_counter = Arc::new(AtomicUsize::default());
+                let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+                fn get_file_size(
+                    thread_id: u8,
+                    path: impl AsRef<Path>,
+                    call_counter: &AtomicUsize,
+                ) -> Option<u64> {
+                    println!("get_file_size() called by thread {}.", thread_id);
+                    call_counter.fetch_add(1, Ordering::AcqRel);
+                    std::fs::metadata(path).ok().map(|m| m.len())
+                }
+
+                let threads: Vec<_> = (0..NUM_THREADS)
+                    .map(|thread_id| {
+                        let my_cache = cache.clone();
+                        let my_call_counter = Arc::clone(&call_counter);
+                        let my_barrier = Arc::clone(&barrier);
+
+                        thread::spawn(move || {
+                            my_barrier.wait();
+
+                            println!("Thread {} started.", thread_id);
+
+                            let key = "key1".to_string();
+                            let value = match thread_id % 2 {
+                                0 => {
+                                    my_cache.optionally_get_with(key.clone(), || {
+                                        get_file_size(thread_id, FILE, &my_call_counter)
+                                    })
+                                }
+                                1 => {
+                                    my_cache.optionally_get_with_by_ref(key.as_str(), || {
+                                       get_file_size(thread_id, FILE, &my_call_counter)
+                                    })
+                                },
                                 _ => unreachable!(),
                             };
 
@@ -67,5 +135,79 @@ macro_rules! generate_test_get_with {
     };
 }
 
-generate_test_get_with!(cache, Cache::<String, u64>::new(100));
-generate_test_get_with!(seg_cache, SegmentedCache::<String, u64>::new(100, 4));
+macro_rules! generate_test_try_get_with {
+    ($name:ident, $cache_init:expr) => {
+        paste! {
+            #[test]
+            fn [<test_ $name _try_get_with>]() {
+                let cache = $cache_init;
+                let call_counter = Arc::new(AtomicUsize::default());
+                let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+                fn get_file_size(
+                    thread_id: u8,
+                    path: impl AsRef<Path>,
+                    call_counter: &AtomicUsize,
+                ) -> Result<u64, std::io::Error> {
+                    println!("get_file_size() called by thread {}.", thread_id);
+                    call_counter.fetch_add(1, Ordering::AcqRel);
+                    Ok(std::fs::metadata(path)?.len())
+                }
+
+                let threads: Vec<_> = (0..NUM_THREADS)
+                    .map(|thread_id| {
+                        let my_cache = cache.clone();
+                        let my_call_counter = Arc::clone(&call_counter);
+                        let my_barrier = Arc::clone(&barrier);
+
+                        thread::spawn(move || {
+                            my_barrier.wait();
+
+                            println!("Thread {} started.", thread_id);
+
+                            let key = "key1".to_string();
+                            let value = match thread_id % 2 {
+                                0 => {
+                                    my_cache.try_get_with(key.clone(), || {
+                                        get_file_size(thread_id, FILE, &my_call_counter)
+                                    })
+                                }
+                                1 => {
+                                    my_cache.try_get_with_by_ref(key.as_str(), || {
+                                       get_file_size(thread_id, FILE, &my_call_counter)
+                                    })
+                                },
+                                _ => unreachable!(),
+                            };
+
+                            assert!(value.is_ok());
+                            assert!(my_cache.get(key.as_str()).is_some());
+
+                            println!(
+                                "Thread {} got the value. (len: {})",
+                                thread_id,
+                                value.unwrap()
+                            );
+                        })
+                    })
+                    .collect();
+
+                threads
+                    .into_iter()
+                    .for_each(|t| t.join().expect("Thread failed"));
+
+                assert_eq!(call_counter.load(Ordering::Acquire), 1);
+            }
+        }
+    };
+}
+
+generate_test_get_with!(cache, Cache::<String, Arc<Vec<u8>>>::new(100));
+generate_test_get_with!(
+    seg_cache,
+    SegmentedCache::<String, Arc<Vec<u8>>>::new(100, 4)
+);
+generate_test_optionally_get_with!(cache, Cache::<String, u64>::new(100));
+generate_test_optionally_get_with!(seg_cache, SegmentedCache::<String, u64>::new(100, 4));
+generate_test_try_get_with!(cache, Cache::<String, u64>::new(100));
+generate_test_try_get_with!(seg_cache, SegmentedCache::<String, u64>::new(100, 4));

--- a/tests/entry_api_sync.rs
+++ b/tests/entry_api_sync.rs
@@ -1,0 +1,71 @@
+#![cfg(all(test, feature = "sync"))]
+
+use std::{
+    path::Path,
+    sync::atomic::{AtomicUsize, Ordering},
+    sync::Arc,
+    thread,
+};
+
+use moka::sync::{Cache, SegmentedCache};
+use paste::paste;
+
+const NUM_THREADS: u8 = 16;
+const FILE: &str = "./Cargo.toml";
+
+fn get_file_size(thread_id: u8, path: impl AsRef<Path>, call_counter: &AtomicUsize) -> Option<u64> {
+    println!("get_file_size() called by thread {}.", thread_id);
+    call_counter.fetch_add(1, Ordering::AcqRel);
+    std::fs::metadata(path).ok().map(|m| m.len())
+}
+
+macro_rules! generate_test_get_with {
+    ($name:ident, $cache_init:expr) => {
+        paste! {
+            #[test]
+            fn [<test_ $name _get_with>]() {
+                let cache = $cache_init;
+                let call_counter = Arc::new(AtomicUsize::default());
+
+                let threads: Vec<_> = (0..NUM_THREADS)
+                    .map(|thread_id| {
+                        let my_cache = cache.clone();
+                        let my_call_counter = Arc::clone(&call_counter);
+                        thread::spawn(move || {
+                            println!("Thread {} started.", thread_id);
+
+                            let key = "key1".to_string();
+                            let value = match thread_id % 2 {
+                                0 => my_cache.optionally_get_with(key.clone(), || {
+                                    get_file_size(thread_id, FILE, &my_call_counter)
+                                }),
+                                1 => my_cache.optionally_get_with_by_ref(key.as_str(), || {
+                                    get_file_size(thread_id, FILE, &my_call_counter)
+                                }),
+                                _ => unreachable!(),
+                            };
+
+                            assert!(value.is_some());
+                            assert!(my_cache.get(key.as_str()).is_some());
+
+                            println!(
+                                "Thread {} got the value. (len: {})",
+                                thread_id,
+                                value.unwrap()
+                            );
+                        })
+                    })
+                    .collect();
+
+                threads
+                    .into_iter()
+                    .for_each(|t| t.join().expect("Thread failed"));
+
+                assert_eq!(call_counter.load(Ordering::Acquire), 1);
+            }
+        }
+    };
+}
+
+generate_test_get_with!(cache, Cache::<String, u64>::new(100));
+generate_test_get_with!(seg_cache, SegmentedCache::<String, u64>::new(100, 4));

--- a/tests/entry_api_tokio.rs
+++ b/tests/entry_api_tokio.rs
@@ -1,0 +1,186 @@
+#![cfg(all(test, feature = "future"))]
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use async_lock::Barrier;
+use moka::future::Cache;
+
+const NUM_THREADS: u8 = 16;
+const SITE: &str = "https://www.rust-lang.org/";
+
+#[tokio::test]
+async fn test_get_with() {
+    const TEN_MIB: usize = 10 * 1024 * 1024; // 10MiB
+    let cache = Cache::new(100);
+    let call_counter = Arc::new(AtomicUsize::default());
+    let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+    let tasks: Vec<_> = (0..NUM_THREADS)
+        .map(|task_id| {
+            let my_cache = cache.clone();
+            let my_call_counter = Arc::clone(&call_counter);
+            let my_barrier = Arc::clone(&barrier);
+
+            tokio::spawn(async move {
+                my_barrier.wait().await;
+
+                println!("Task {} started.", task_id);
+
+                let key = "key1".to_string();
+                let value = match task_id % 2 {
+                    0 => {
+                        my_cache
+                            .get_with(key.clone(), async move {
+                                println!("Task {} inserting a value.", task_id);
+                                my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                Arc::new(vec![0u8; TEN_MIB])
+                            })
+                            .await
+                    }
+                    1 => {
+                        my_cache
+                            .get_with_by_ref(key.as_str(), async move {
+                                println!("Task {} inserting a value.", task_id);
+                                my_call_counter.fetch_add(1, Ordering::AcqRel);
+                                Arc::new(vec![0u8; TEN_MIB])
+                            })
+                            .await
+                    }
+                    _ => unreachable!(),
+                };
+
+                assert_eq!(value.len(), TEN_MIB);
+                assert!(my_cache.get(key.as_str()).is_some());
+
+                println!("Task {} got the value. (len: {})", task_id, value.len());
+            })
+        })
+        .collect();
+
+    futures_util::future::join_all(tasks).await;
+    assert_eq!(call_counter.load(Ordering::Acquire), 1);
+}
+
+#[tokio::test]
+async fn test_optionally_get_with() {
+    let cache = Cache::new(100);
+    let call_counter = Arc::new(AtomicUsize::default());
+    let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+    async fn get_html(task_id: u8, uri: &str, call_counter: &AtomicUsize) -> Option<String> {
+        println!("get_html() called by task {}.", task_id);
+        call_counter.fetch_add(1, Ordering::AcqRel);
+        reqwest::get(uri).await.ok()?.text().await.ok()
+    }
+
+    let tasks: Vec<_> = (0..NUM_THREADS)
+        .map(|task_id| {
+            let my_cache = cache.clone();
+            let my_call_counter = Arc::clone(&call_counter);
+            let my_barrier = Arc::clone(&barrier);
+
+            tokio::spawn(async move {
+                my_barrier.wait().await;
+
+                println!("Task {} started.", task_id);
+
+                let key = "key1".to_string();
+                let value = match task_id % 2 {
+                    0 => {
+                        my_cache
+                            .optionally_get_with(
+                                key.clone(),
+                                get_html(task_id, SITE, &my_call_counter),
+                            )
+                            .await
+                    }
+                    1 => {
+                        my_cache
+                            .optionally_get_with_by_ref(
+                                key.as_str(),
+                                get_html(task_id, SITE, &my_call_counter),
+                            )
+                            .await
+                    }
+                    _ => unreachable!(),
+                };
+
+                assert!(value.is_some());
+                assert!(my_cache.get(key.as_str()).is_some());
+
+                println!(
+                    "Task {} got the value. (len: {})",
+                    task_id,
+                    value.unwrap().len()
+                );
+            })
+        })
+        .collect();
+
+    futures_util::future::join_all(tasks).await;
+    assert_eq!(call_counter.load(Ordering::Acquire), 1);
+}
+
+#[tokio::test]
+async fn test_try_get_with() {
+    let cache = Cache::new(100);
+    let call_counter = Arc::new(AtomicUsize::default());
+    let barrier = Arc::new(Barrier::new(NUM_THREADS as usize));
+
+    async fn get_html(
+        task_id: u8,
+        uri: &str,
+        call_counter: &AtomicUsize,
+    ) -> Result<String, reqwest::Error> {
+        println!("get_html() called by task {}.", task_id);
+        call_counter.fetch_add(1, Ordering::AcqRel);
+        reqwest::get(uri).await?.text().await
+    }
+
+    let tasks: Vec<_> = (0..NUM_THREADS)
+        .map(|task_id| {
+            let my_cache = cache.clone();
+            let my_call_counter = Arc::clone(&call_counter);
+            let my_barrier = Arc::clone(&barrier);
+
+            tokio::spawn(async move {
+                my_barrier.wait().await;
+
+                println!("Task {} started.", task_id);
+
+                let key = "key1".to_string();
+                let value = match task_id % 2 {
+                    0 => {
+                        my_cache
+                            .try_get_with(key.clone(), get_html(task_id, SITE, &my_call_counter))
+                            .await
+                    }
+                    1 => {
+                        my_cache
+                            .try_get_with_by_ref(
+                                key.as_str(),
+                                get_html(task_id, SITE, &my_call_counter),
+                            )
+                            .await
+                    }
+                    _ => unreachable!(),
+                };
+
+                assert!(value.is_ok());
+                assert!(my_cache.get(key.as_str()).is_some());
+
+                println!(
+                    "Task {} got the value. (len: {})",
+                    task_id,
+                    value.unwrap().len()
+                );
+            })
+        })
+        .collect();
+
+    futures_util::future::join_all(tasks).await;
+    assert_eq!(call_counter.load(Ordering::Acquire), 1);
+}


### PR DESCRIPTION
In the current implementation (up to v0.9.5), there is a small chance that the following methods to evaluate the `init` closure/function more than once in concurrent calls:

- `get_with`
- `get_with_if`
- `optionally_get_with`
- `try_get_with`

It will happen when a call to one of these methods is made when another call to the same method on the same key is about to complete.

New test cases in he following files will reproduce the issue:

- `tests/entry_api_sync.rs`
- `tests/entry_api_tokio.rs`
- `tests/entry_api_actix_rt2.rs`
- `tests/entry_api_async_std.rs`

This PR fixes the issue by doing a double check if the value still does not exist after the lock is acquired and also extending the lock as needed.