### PR TITLE
Fix flaky tests on GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Show CPU info
+          command: |
+            nproc
+            lscpu
+      - run:
           name: Run cargo tarpaulin (Allowing a failure)
           command: |
             docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,14 +63,20 @@ linux_arm64_task:
     # Run tests (debug, sync feature)
     - cargo test -j 1 --lib --features sync -- --test-threads=$NUM_CPUS
 
-    # Run tests (debug, sync feature, thread-pool test for sync::Cache)
-    - cargo test -j 1  --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored --test-threads=$NUM_CPUS
-
-    # Run tests (debug, sync feature, thread-pool test for sync::SegmentCache)
-    - cargo test -j 1  --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored --test-threads=$NUM_CPUS
-
     # Run tests (release, sync feature)
-    - cargo test -j 1  --release --features sync -- --test-threads=$NUM_CPUS
+    - cargo test -j 1 --release --features sync -- --test-threads=$NUM_CPUS
+
+    # Run tests (release, sync feature, thread-pool test for sync::Cache)
+    - cargo test --release --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+    # Run tests (release, sync feature, thread-pool test for sync::SegmentCache)
+    - cargo test --release --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+    # Run tests (sync feature, key lock test for notification)
+    - cargo test --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact --ignored
+
+    # Run tests (sync feature, drop value after eviction)
+    - cargo test --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact --ignored
 
     # Run tests (future feature, but no sync feature)
     - cargo test -j 1  --no-default-features --features 'future, atomic64, quanta' -- --test-threads=$NUM_CPUS

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Checkout Moka
         uses: actions/checkout@v2
 
+      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+      # 2-core CPU (x86_64), 7 GB of RAM
+      - name: Show CPU into
+        run: |
+          nproc
+          lscpu
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,18 +82,6 @@ jobs:
         env:
           RUSTFLAGS: '--cfg rustver'
 
-      - name: Run tests (debug, sync feature, thread-pool test for sync::Cache)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored
-
-      - name: Run tests (debug, sync feature, thread-pool test for sync::SegmentCache)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored
-
       - name: Run tests (release, sync feature)
         uses: actions-rs/cargo@v1
         with:
@@ -101,6 +89,30 @@ jobs:
           args: --release --features sync
         env:
           RUSTFLAGS: '--cfg rustver'
+
+      - name: Run tests (sync feature, thread-pool test for sync::Cache)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --lib --features sync sync::cache::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+      - name: Run tests (sync feature, thread-pool test for sync::SegmentCache)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --lib --features sync sync::segment::tests::enabling_and_disabling_thread_pools -- --exact --ignored
+
+      - name: Run tests (sync feature, key lock test for notification)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact --ignored
+
+      - name: Run tests (sync feature, drop value after eviction)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact --ignored
 
       - name: Run tests (future feature, but no sync feature)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Hope this PR fixes the flaky tests on GitHub Actions.

## Changes

- Make the following tests in the `sync::cache` ignored by default and run separately in GitHub Actions:
  - `test_key_lock_used_by_immediate_removal_notifications`
  - `drop_value_immediately_after_eviction`
- Show CPU info on GitHub Actions and CircleCI