### PR TITLE
Remove deprecated APIs `get_or_insert_with` and `get_or_try_insert_with`

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -832,22 +832,6 @@ where
         RefKeyEntrySelector::new(key, hash, self)
     }
 
-    /// Deprecated, replaced with [`get_with`](#method.get_with)
-    #[deprecated(since = "0.8.0", note = "Replaced with `get_with`")]
-    pub async fn get_or_insert_with(&self, key: K, init: impl Future<Output = V>) -> V {
-        self.get_with(key, init).await
-    }
-
-    /// Deprecated, replaced with [`try_get_with`](#method.try_get_with)
-    #[deprecated(since = "0.8.0", note = "Replaced with `try_get_with`")]
-    pub async fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
-    where
-        F: Future<Output = Result<V, E>>,
-        E: Send + Sync + 'static,
-    {
-        self.try_get_with(key, init).await
-    }
-
     /// Returns a _clone_ of the value corresponding to the key. If the value does
     /// not exist, resolve the `init` future and inserts the output.
     ///
@@ -1451,8 +1435,8 @@ where
         let maybe_entry =
             self.base
                 .get_with_hash_but_ignore_if(&key, hash, replace_if.as_mut(), need_key);
-        if let Some(v) = maybe_entry {
-            v
+        if let Some(entry) = maybe_entry {
+            entry
         } else {
             self.insert_with_hash_and_fun(key, hash, init, replace_if, need_key)
                 .await
@@ -1474,8 +1458,8 @@ where
         let maybe_entry =
             self.base
                 .get_with_hash_but_ignore_if(key, hash, replace_if.as_mut(), need_key);
-        if let Some(v) = maybe_entry {
-            v
+        if let Some(entry) = maybe_entry {
+            entry
         } else {
             let key = Arc::new(key.to_owned());
             self.insert_with_hash_and_fun(key, hash, init, replace_if, need_key)

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -984,22 +984,6 @@ where
         RefKeyEntrySelector::new(key, hash, self)
     }
 
-    /// Deprecated, replaced with [`get_with`](#method.get_with)
-    #[deprecated(since = "0.8.0", note = "Replaced with `get_with`")]
-    pub fn get_or_insert_with(&self, key: K, init: impl FnOnce() -> V) -> V {
-        self.get_with(key, init)
-    }
-
-    /// Deprecated, replaced with [`try_get_with`](#method.try_get_with)
-    #[deprecated(since = "0.8.0", note = "Replaced with `try_get_with`")]
-    pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>
-    where
-        F: FnOnce() -> Result<V, E>,
-        E: Send + Sync + 'static,
-    {
-        self.try_get_with(key, init)
-    }
-
     /// Returns a _clone_ of the value corresponding to the key. If the value does
     /// not exist, evaluates the `init` closure and inserts the output.
     ///


### PR DESCRIPTION
They were deprecated since v0.8.0 (March 23rd, 2022).