### PR TITLE
Fix the CI for MSRV 1.51

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,6 +50,7 @@ linux_arm64_task:
       echo 'Pinning some dependencies to specific versions'
       cargo update -p indexmap --precise 1.8.2
       cargo update -p hashbrown --precise 0.11.2
+      cargo update -p reqwest --precise 0.11.12
       cargo update -p native-tls --precise 0.2.8
       cargo update -p async-global-executor --precise 2.0.4
       cargo update -p pulldown-cmark --precise 0.9.1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
         # hashbrown >= v0.12 requires Rust 2021 edition.
+        # reqwest >= v0.11.13 requires native-tls v0.2.10.
         # native-tls >= v0.2.9 requires more recent Rust version.
         # async-global-executor >= 2.1 requires Rust 2021 edition.
         # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
@@ -69,6 +70,7 @@ jobs:
         run: |
           cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
+          cargo update -p reqwest --precise 0.11.12
           cargo update -p native-tls --precise 0.2.8
           cargo update -p async-global-executor --precise 2.0.4
           cargo update -p pulldown-cmark --precise 0.9.1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
         # hashbrown >= v0.12 requires Rust 2021 edition.
+        # reqwest >= v0.11.13 requires native-tls v0.2.10.
         # native-tls >= v0.2.9 requires more recent Rust version.
         # async-global-executor >= 2.1 requires Rust 2021 edition.
         # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
@@ -62,6 +63,7 @@ jobs:
         run: |
           cargo update -p indexmap --precise 1.8.2
           cargo update -p hashbrown --precise 0.11.2
+          cargo update -p reqwest --precise 0.11.12
           cargo update -p native-tls --precise 0.2.8
           cargo update -p async-global-executor --precise 2.0.4
           cargo update -p pulldown-cmark --precise 0.9.1


### PR DESCRIPTION
When testing the MSRV, downgrade `reqwest` to v0.11.12, otherwise we cannot downgrade `native-tls` to v0.2.8.