### PR TITLE
Deduplicate `do_get_with_hash`

### DIFF
--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -294,13 +294,18 @@ where
                 } else {
                     // Valid entry.
                     let maybe_key = if need_key { Some(Arc::clone(k)) } else { None };
-                    Some((maybe_key, TrioArc::clone(entry), now))
+                    let v = entry.value.clone();
+                    let maybe_entry = if record_read {
+                        Some(TrioArc::clone(entry))
+                    } else {
+                        None
+                    };
+                    Some((maybe_key, v, maybe_entry, now))
                 }
             });
 
-        if let Some((maybe_key, entry, now)) = maybe_entry {
-            let v = entry.value.clone();
-            if record_read {
+        if let Some((maybe_key, v, maybe_entry, now)) = maybe_entry {
+            if let Some(entry) = maybe_entry {
                 self.record_read_op(ReadOp::Hit(hash, entry, now), now)
                     .expect("Failed to record a get op");
             }


### PR DESCRIPTION
Due to the generic `read_recorder` closure, the `do_get_with_hash` function was generated twice in `cargo-llvm-lines` for a simple test.

This is the first improvement to #203 I have found