### PR TITLE
Fix the CI for Rust nightly with minimal dependency versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,7 @@ linux_arm64_task:
     if [ -z "$RUST_VERSION" ]; then
       echo 'Downgrading dependencies to minimal versions'
       cargo update -Z minimal-versions
+      cargo update -p openssl --precise 0.10.39
     else
       echo 'Skipped'
     fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,11 @@ jobs:
           command: update
           args: -Z minimal-versions
 
+      - name: Pin some dependencies to specific versions (Nightly only)
+        if: ${{ matrix.rust == 'nightly' }}
+        run: |
+          cargo update -p openssl --precise 0.10.39
+
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
         # hashbrown >= v0.12 requires Rust 2021 edition.

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -52,6 +52,11 @@ jobs:
           command: update
           args: -Z minimal-versions
 
+      - name: Pin some dependencies to specific versions (Nightly only)
+        if: ${{ matrix.rust == 'nightly' }}
+        run: |
+          cargo update -p openssl --precise 0.10.39
+
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}
         # hashbrown >= v0.12 requires Rust 2021 edition.


### PR DESCRIPTION
When testing minimal dependency versions, upgrade `openssl` to v0.10.39, otherwise building `openssl-sys` will fail on Linux.