### PR TITLE
Update test cases and documentation for entry's `is_fresh` method

### DIFF
--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -512,8 +512,12 @@ where
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` future. Only one of the calls
-    /// evaluates its future, and other calls wait for that future to resolve. See
-    /// [`Cache::get_with`][get-with-method] for more details.
+    /// evaluates its future (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that future to resolve (and their
+    /// `is_fresh` return `false`).
+    ///
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::get_with`][get-with-method].
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
@@ -597,12 +601,14 @@ where
     /// ```
     ///
     /// # Concurrent calls on the same key
-    ///
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` future. Only one of the calls
-    /// evaluates its future, and other calls wait for that future to resolve.
+    /// evaluates its future (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that future to resolve (and their
+    /// `is_fresh` return `false`).
     ///
-    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::optionally_get_with`][opt-get-with-method].
     ///
     /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub async fn or_optionally_insert_with(
@@ -672,9 +678,11 @@ where
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` future (as long as these
     /// futures return the same error type). Only one of the calls evaluates its
-    /// future, and other calls wait for that future to resolve.
+    /// future (thus returned entry's `is_fresh` method returns `true`), and other
+    /// calls wait for that future to resolve (and their `is_fresh` return `false`).
     ///
-    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::try_get_with`][try-get-with-method].
     ///
     /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub async fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -167,8 +167,12 @@ where
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` future. Only one of the calls
-    /// evaluates its future, and other calls wait for that future to resolve. See
-    /// [`Cache::get_with`][get-with-method] for more details.
+    /// evaluates its future (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that future to resolve (and their
+    /// `is_fresh` return `false`).
+    ///
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::get_with`][get-with-method].
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
@@ -253,9 +257,12 @@ where
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` future. Only one of the calls
-    /// evaluates its future, and other calls wait for that future to resolve.
+    /// evaluates its future (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that future to resolve (and their
+    /// `is_fresh` return `false`).
     ///
-    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::optionally_get_with`][opt-get-with-method].
     ///
     /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub async fn or_optionally_insert_with(
@@ -325,9 +332,11 @@ where
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` future (as long as these
     /// futures return the same error type). Only one of the calls evaluates its
-    /// future, and other calls wait for that future to resolve.
+    /// future (thus returned entry's `is_fresh` method returns `true`), and other
+    /// calls wait for that future to resolve (and their `is_fresh` return `false`).
     ///
-    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::try_get_with`][try-get-with-method].
     ///
     /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub async fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -134,8 +134,12 @@ where
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` closure. Only one of the
-    /// calls evaluates its closure, and other calls wait for that closure to
-    /// complete. See [`Cache::get_with`][get-with-method] for more details.
+    /// calls evaluates its closure (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that closure to complete (and their
+    /// `is_fresh` return `false`).
+    ///
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::get_with`][get-with-method].
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub fn or_insert_with(self, init: impl FnOnce() -> V) -> Entry<K, V> {
@@ -205,10 +209,13 @@ where
     /// # Concurrent calls on the same key
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
-    /// are coalesced into one evaluation of the `init` closure. Only one of the calls
-    /// evaluates its closure, and other calls wait for that closure to complete.
+    /// are coalesced into one evaluation of the `init` closure. Only one of the
+    /// calls evaluates its closure (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that closure to complete (and their
+    /// `is_fresh` return `false`).
     ///
-    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::optionally_get_with`][opt-get-with-method].
     ///
     /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub fn or_optionally_insert_with(
@@ -265,9 +272,12 @@ where
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` closure (as long as these
     /// closures return the same error type). Only one of the calls evaluates its
-    /// closure, and other calls wait for that closure to complete.
+    /// closure (thus returned entry's `is_fresh` method returns `true`), and other
+    /// calls wait for that closure to complete (and their `is_fresh` return
+    /// `false`).
     ///
-    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::try_get_with`][try-get-with-method].
     ///
     /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>
@@ -410,9 +420,13 @@ where
     /// # Concurrent calls on the same key
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
-    /// are coalesced into one evaluation of the `init` closure. Only one of the calls
-    /// evaluates its closure, and other calls wait for that closure to complete. See
-    /// [`Cache::get_with`][get-with-method] for more details.
+    /// are coalesced into one evaluation of the `init` closure. Only one of the
+    /// calls evaluates its closure (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that closure to complete (and their
+    /// `is_fresh` return `false`).
+    ///
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::get_with`][get-with-method].
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub fn or_insert_with(self, init: impl FnOnce() -> V) -> Entry<K, V> {
@@ -491,10 +505,12 @@ where
     ///
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` closure. Only one of the
-    /// calls evaluates its closure, and other calls wait for that closure to
-    /// complete.
+    /// calls evaluates its closure (thus returned entry's `is_fresh` method returns
+    /// `true`), and other calls wait for that closure to complete (and their
+    /// `is_fresh` return `false`).
     ///
-    /// See [`Cache::optionally_get_with`][opt-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::optionally_get_with`][opt-get-with-method].
     ///
     /// [opt-get-with-method]: ./struct.Cache.html#method.optionally_get_with
     pub fn or_optionally_insert_with(
@@ -551,9 +567,12 @@ where
     /// This method guarantees that concurrent calls on the same not-existing entry
     /// are coalesced into one evaluation of the `init` closure (as long as these
     /// closures return the same error type). Only one of the calls evaluates its
-    /// closure, and other calls wait for that closure to complete.
+    /// closure (thus returned entry's `is_fresh` method returns `true`), and other
+    /// calls wait for that closure to complete (and their `is_fresh` return
+    /// `false`).
     ///
-    /// See [`Cache::try_get_with`][try-get-with-method] for more details.
+    /// For more detail about the coalescing behavior, see
+    /// [`Cache::try_get_with`][try-get-with-method].
     ///
     /// [try-get-with-method]: ./struct.Cache.html#method.try_get_with
     pub fn or_try_insert_with<F, E>(self, init: F) -> Result<Entry<K, V>, Arc<E>>


### PR DESCRIPTION
This PR updates the test cases and documentation for entry's `is_fresh` method, to verify and clarify the guarantees for call coalescing. 

## Tasks

**Test Cases**

Update test cases to verify the return value of `is_fresh` method:

- [x] `future::Cache`
- [x] `sync::Cache` 

**Documentation**

Update the documentation to clarify `is_fresh`'s guarantee for call coalescing.

- [x] `future::OwnedKeyEntrySelector`
- [x] `future::RefKeyEntrySelector`
- [x] `sync::OwnedKeyEntrySelector`
- [x] `sync::RefKeyEntrySelector`

* * *
Fixes #217.