### PR TITLE
Reduce the size of the future returned by async `get_with` and friend methods (v0.10)

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -25,7 +25,7 @@ pub use {
 pub type PredicateId = String;
 
 // Empty struct to be used in InitResult::InitErr to represent the Option None.
-struct OptionallyNone;
+pub(crate) struct OptionallyNone;
 
 pub struct Iter<'i, K, V>(crate::sync_base::iter::Iter<'i, K, V>);
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -32,88 +32,6 @@ use std::{
     time::Duration,
 };
 
-//
-// Macros to mitigate the compiler issue that inflates the size of future returned
-// from `get_with` and friends methods:
-//
-// - https://github.com/moka-rs/moka/issues/212
-// - https://swatinem.de/blog/future-size/
-//
-// These macros are used by `get_with`, etc. of this module. We are not big fans of
-// macros as they make the code difficult to understand. However, we believe the
-// benefits of reducing the future size outweigh this drawback.
-//
-macro_rules! insert_with_hash_and_fun_m(
-    ( $self:ident, $key:expr, $hash:expr, $get:expr, $init:ident, $replace_if:expr, $need_key:expr ) => {
-        {
-            use futures_util::FutureExt;
-
-            let insert = |v| $self.insert_with_hash($key.clone(), $hash, v).boxed();
-
-            let k = if $need_key {
-                Some(Arc::clone(&$key))
-            } else {
-                None
-            };
-
-            let type_id = ValueInitializer::<K, V, S>::type_id_for_get_with();
-            let post_init = ValueInitializer::<K, V, S>::post_init_for_get_with;
-
-            match $self
-                .value_initializer
-                .try_init_or_read(&Arc::clone(&$key), type_id, $get, $init, insert, post_init)
-                .await
-            {
-                InitResult::Initialized(v) => {
-                    crossbeam_epoch::pin().flush();
-                    Entry::new(k, v, true)
-                }
-                InitResult::ReadExisting(v) => Entry::new(k, v, false),
-                InitResult::InitErr(_) => unreachable!(),
-            }
-        }
-    }
-);
-
-macro_rules! get_or_insert_with_hash_and_fun_m(
-    ( $self:ident, $key:expr, $hash:expr, $init:ident, $replace_if:expr, $need_key:expr ) => {
-        {
-            let maybe_entry =
-                $self.base
-                    .get_with_hash_but_ignore_if(&$key, $hash, $replace_if.as_mut(), $need_key);
-            if let Some(entry) = maybe_entry {
-                entry
-            } else {
-                let get = || {
-                    $self.base
-                        .get_with_hash_but_no_recording(&$key, $hash, $replace_if.as_mut())
-                };
-                insert_with_hash_and_fun_m!($self, $key, $hash, get, $init, $replace_if, $need_key)
-            }
-        }
-    }
-);
-
-macro_rules! get_or_insert_with_hash_by_ref_and_fun_m(
-    ( $self:ident, $key:expr, $hash:expr, $init:ident, $replace_if:expr, $need_key:expr ) => {
-        {
-            let maybe_entry =
-                $self.base
-                    .get_with_hash_but_ignore_if($key, $hash, $replace_if.as_mut(), $need_key);
-            if let Some(entry) = maybe_entry {
-                entry
-            } else {
-                let get = || {
-                    $self.base
-                        .get_with_hash_but_no_recording(&$key, $hash, $replace_if.as_mut())
-                };
-                let arc_key = Arc::new($key.to_owned());
-                insert_with_hash_and_fun_m!($self, arc_key, $hash, get, $init, $replace_if, $need_key)
-            }
-        }
-    }
-);
-
 /// A thread-safe, futures-aware concurrent in-memory cache.
 ///
 /// `Cache` supports full concurrency of retrievals and a high expected concurrency
@@ -1001,8 +919,10 @@ where
         futures_util::pin_mut!(init);
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
-        let mut replace_if = None as Option<fn(&V) -> bool>;
-        get_or_insert_with_hash_and_fun_m!(self, key, hash, init, replace_if, false).into_value()
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if, false)
+            .await
+            .into_value()
     }
 
     /// Similar to [`get_with`](#method.get_with), but instead of passing an owned
@@ -1015,8 +935,9 @@ where
     {
         futures_util::pin_mut!(init);
         let hash = self.base.hash(key);
-        let mut replace_if = None as Option<fn(&V) -> bool>;
-        get_or_insert_with_hash_by_ref_and_fun_m!(self, key, hash, init, replace_if, false)
+        let replace_if = None as Option<fn(&V) -> bool>;
+        self.get_or_insert_with_hash_by_ref_and_fun(key, hash, init, replace_if, false)
+            .await
             .into_value()
     }
 
@@ -1032,8 +953,10 @@ where
         futures_util::pin_mut!(init);
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
-        let mut replace_if = Some(replace_if);
-        get_or_insert_with_hash_and_fun_m!(self, key, hash, init, replace_if, false).into_value()
+        let replace_if = Some(replace_if);
+        self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if, false)
+            .await
+            .into_value()
     }
 
     /// Returns a _clone_ of the value corresponding to the key. If the value does
@@ -1517,7 +1440,15 @@ where
         mut replace_if: Option<impl FnMut(&V) -> bool>,
         need_key: bool,
     ) -> Entry<K, V> {
-        get_or_insert_with_hash_and_fun_m!(self, key, hash, init, replace_if, need_key)
+        let maybe_entry =
+            self.base
+                .get_with_hash_but_ignore_if(&key, hash, replace_if.as_mut(), need_key);
+        if let Some(entry) = maybe_entry {
+            entry
+        } else {
+            self.insert_with_hash_and_fun(key, hash, init, replace_if, need_key)
+                .await
+        }
     }
 
     pub(crate) async fn get_or_insert_with_hash_by_ref_and_fun<Q>(
@@ -1532,7 +1463,55 @@ where
         K: Borrow<Q>,
         Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
     {
-        get_or_insert_with_hash_by_ref_and_fun_m!(self, key, hash, init, replace_if, need_key)
+        let maybe_entry =
+            self.base
+                .get_with_hash_but_ignore_if(key, hash, replace_if.as_mut(), need_key);
+        if let Some(entry) = maybe_entry {
+            entry
+        } else {
+            let key = Arc::new(key.to_owned());
+            self.insert_with_hash_and_fun(key, hash, init, replace_if, need_key)
+                .await
+        }
+    }
+
+    async fn insert_with_hash_and_fun(
+        &self,
+        key: Arc<K>,
+        hash: u64,
+        init: Pin<&mut impl Future<Output = V>>,
+        mut replace_if: Option<impl FnMut(&V) -> bool>,
+        need_key: bool,
+    ) -> Entry<K, V> {
+        use futures_util::FutureExt;
+
+        let get = || {
+            self.base
+                .get_with_hash_but_no_recording(&key, hash, replace_if.as_mut())
+        };
+        let insert = |v| self.insert_with_hash(key.clone(), hash, v).boxed();
+
+        let k = if need_key {
+            Some(Arc::clone(&key))
+        } else {
+            None
+        };
+
+        let type_id = ValueInitializer::<K, V, S>::type_id_for_get_with();
+        let post_init = ValueInitializer::<K, V, S>::post_init_for_get_with;
+
+        match self
+            .value_initializer
+            .try_init_or_read(&Arc::clone(&key), type_id, get, init, insert, post_init)
+            .await
+        {
+            InitResult::Initialized(v) => {
+                crossbeam_epoch::pin().flush();
+                Entry::new(k, v, true)
+            }
+            InitResult::ReadExisting(v) => Entry::new(k, v, false),
+            InitResult::InitErr(_) => unreachable!(),
+        }
     }
 
     pub(crate) async fn get_or_insert_with_hash(

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -953,8 +953,7 @@ where
         futures_util::pin_mut!(init);
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
-        let replace_if = Some(replace_if);
-        self.get_or_insert_with_hash_and_fun(key, hash, init, replace_if, false)
+        self.get_or_insert_with_hash_and_fun(key, hash, init, Some(replace_if), false)
             .await
             .into_value()
     }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -176,6 +176,7 @@ where
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
+        futures_util::pin_mut!(init);
         let key = Arc::new(self.owned_key);
         let replace_if = None as Option<fn(&V) -> bool>;
         self.cache
@@ -196,6 +197,7 @@ where
         init: impl Future<Output = V>,
         replace_if: impl FnMut(&V) -> bool,
     ) -> Entry<K, V> {
+        futures_util::pin_mut!(init);
         let key = Arc::new(self.owned_key);
         self.cache
             .get_or_insert_with_hash_and_fun(key, self.hash, init, Some(replace_if), true)
@@ -269,6 +271,7 @@ where
         self,
         init: impl Future<Output = Option<V>>,
     ) -> Option<Entry<K, V>> {
+        futures_util::pin_mut!(init);
         let key = Arc::new(self.owned_key);
         self.cache
             .get_or_optionally_insert_with_hash_and_fun(key, self.hash, init, true)
@@ -344,6 +347,7 @@ where
         F: Future<Output = Result<V, E>>,
         E: Send + Sync + 'static,
     {
+        futures_util::pin_mut!(init);
         let key = Arc::new(self.owned_key);
         self.cache
             .get_or_try_insert_with_hash_and_fun(key, self.hash, init, true)
@@ -521,6 +525,7 @@ where
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
+        futures_util::pin_mut!(init);
         let replace_if = None as Option<fn(&V) -> bool>;
         self.cache
             .get_or_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, replace_if, true)
@@ -540,6 +545,7 @@ where
         init: impl Future<Output = V>,
         replace_if: impl FnMut(&V) -> bool,
     ) -> Entry<K, V> {
+        futures_util::pin_mut!(init);
         self.cache
             .get_or_insert_with_hash_by_ref_and_fun(
                 self.ref_key,
@@ -617,6 +623,7 @@ where
         self,
         init: impl Future<Output = Option<V>>,
     ) -> Option<Entry<K, V>> {
+        futures_util::pin_mut!(init);
         self.cache
             .get_or_optionally_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, true)
             .await
@@ -692,6 +699,7 @@ where
         F: Future<Output = Result<V, E>>,
         E: Send + Sync + 'static,
     {
+        futures_util::pin_mut!(init);
         self.cache
             .get_or_try_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, true)
             .await

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -521,11 +521,9 @@ where
     ///
     /// [get-with-method]: ./struct.Cache.html#method.get_with
     pub async fn or_insert_with(self, init: impl Future<Output = V>) -> Entry<K, V> {
-        let owned_key: K = self.ref_key.to_owned();
-        let key = Arc::new(owned_key);
         let replace_if = None as Option<fn(&V) -> bool>;
         self.cache
-            .get_or_insert_with_hash_and_fun(key, self.hash, init, replace_if, true)
+            .get_or_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, replace_if, true)
             .await
     }
 
@@ -542,10 +540,14 @@ where
         init: impl Future<Output = V>,
         replace_if: impl FnMut(&V) -> bool,
     ) -> Entry<K, V> {
-        let owned_key: K = self.ref_key.to_owned();
-        let key = Arc::new(owned_key);
         self.cache
-            .get_or_insert_with_hash_and_fun(key, self.hash, init, Some(replace_if), true)
+            .get_or_insert_with_hash_by_ref_and_fun(
+                self.ref_key,
+                self.hash,
+                init,
+                Some(replace_if),
+                true,
+            )
             .await
     }
 

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -117,141 +117,18 @@ where
 
     /// # Panics
     /// Panics if the `init` future has been panicked.
-    pub(crate) async fn init_or_read<'a>(
-        &'a self,
-        key: Arc<K>,
-        // Closure to get an existing value from cache.
-        get: impl FnMut() -> Option<V>,
-        init: impl Future<Output = V>,
-        // Closure to insert a new value into cache.
-        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
-    ) -> InitResult<V, ()> {
-        // This closure will be called before the init future is resolved, in order
-        // to check if the value has already been inserted by other async task.
-        let pre_init = make_pre_init(get);
-
-        // This closure will be called after the init future has returned a value. It
-        // will insert the returned value (from init) to the cache, and convert the
-        // value into a pair of a WaiterValue and an InitResult.
-        let post_init = |value: V| {
-            async move {
-                insert(value.clone()).await;
-                (
-                    WaiterValue::Ready(Ok(value.clone())),
-                    InitResult::Initialized(value),
-                )
-            }
-            .boxed()
-        };
-
-        let type_id = TypeId::of::<()>();
-        self.do_try_init(&key, type_id, pre_init, init, post_init)
-            .await
-    }
-
-    /// # Panics
-    /// Panics if the `init` future has been panicked.
-    pub(crate) async fn try_init_or_read<'a, E>(
-        &'a self,
-        key: Arc<K>,
-        get: impl FnMut() -> Option<V>,
-        init: impl Future<Output = Result<V, E>>,
-        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
-    ) -> InitResult<V, E>
-    where
-        E: Send + Sync + 'static,
-    {
-        // This closure will be called before the init future is resolved, in order
-        // to check if the value has already been inserted by other async task.
-        let pre_init = make_pre_init(get);
-
-        // This closure will be called after the init future has returned a value. It
-        // will insert the returned value (from init) to the cache, and convert the
-        // value into a pair of a WaiterValue and an InitResult.
-        let post_init = move |value: Result<V, E>| {
-            async move {
-                match value {
-                    Ok(value) => {
-                        insert(value.clone()).await;
-                        (
-                            WaiterValue::Ready(Ok(value.clone())),
-                            InitResult::Initialized(value),
-                        )
-                    }
-                    Err(e) => {
-                        let err: ErrorObject = Arc::new(e);
-                        (
-                            WaiterValue::Ready(Err(Arc::clone(&err))),
-                            InitResult::InitErr(err.downcast().unwrap()),
-                        )
-                    }
-                }
-            }
-            .boxed()
-        };
-
-        let type_id = TypeId::of::<E>();
-        self.do_try_init(&key, type_id, pre_init, init, post_init)
-            .await
-    }
-
-    /// # Panics
-    /// Panics if the `init` future has been panicked.
-    pub(super) async fn optionally_init_or_read<'a>(
-        &'a self,
-        key: Arc<K>,
-        get: impl FnMut() -> Option<V>,
-        init: impl Future<Output = Option<V>>,
-        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
-    ) -> InitResult<V, OptionallyNone> {
-        // This closure will be called before the init future is resolved, in order
-        // to check if the value has already been inserted by other async task.
-        let pre_init = make_pre_init(get);
-
-        // This closure will be called after the init future has returned a value. It
-        // will insert the returned value (from init) to the cache, and convert the
-        // value into a pair of a WaiterValue and an InitResult.
-        let post_init = |value: Option<V>| {
-            async move {
-                match value {
-                    Some(value) => {
-                        insert(value.clone()).await;
-                        (
-                            WaiterValue::Ready(Ok(value.clone())),
-                            InitResult::Initialized(value),
-                        )
-                    }
-                    None => {
-                        // `value` can be either `Some` or `None`. For `None` case,
-                        // without change the existing API too much, we will need to
-                        // convert `None` to Arc<E> here. `Infallible` could not be
-                        // instantiated. So it might be good to use an empty struct
-                        // to indicate the error type.
-                        let err: ErrorObject = Arc::new(OptionallyNone);
-                        (
-                            WaiterValue::Ready(Err(Arc::clone(&err))),
-                            InitResult::InitErr(err.downcast().unwrap()),
-                        )
-                    }
-                }
-            }
-            .boxed()
-        };
-
-        let type_id = TypeId::of::<OptionallyNone>();
-        self.do_try_init(&key, type_id, pre_init, init, post_init)
-            .await
-    }
-
-    /// # Panics
-    /// Panics if the `init` future has been panicked.
-    async fn do_try_init<'a, O, E>(
+    pub(crate) async fn try_init_or_read<'a, O, E>(
         &'a self,
         key: &Arc<K>,
         type_id: TypeId,
-        mut pre_init: impl FnMut() -> Option<(WaiterValue<V>, InitResult<V, E>)>,
+        // Closure to get an existing value from cache.
+        mut get: impl FnMut() -> Option<V>,
         init: impl Future<Output = O>,
-        post_init: impl FnOnce(O) -> BoxFuture<'a, (WaiterValue<V>, InitResult<V, E>)>,
+        // Closure to insert a new value into cache.
+        mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
+        // This function will be called after the init future has returned a value of
+        // type O. It converts O into Result<V, E>.
+        post_init: fn(O) -> Result<V, E>,
     ) -> InitResult<V, E>
     where
         E: Send + Sync + 'static,
@@ -283,12 +160,12 @@ where
                     );
 
                     // Check if the value has already been inserted by other thread.
-                    if let Some((waiter_val, init_res)) = pre_init() {
+                    if let Some(value) = get() {
                         // Yes. Set the waiter value, remove our waiter, and return
                         // the existing value.
-                        waiter_guard.set_waiter_value(waiter_val);
+                        waiter_guard.set_waiter_value(WaiterValue::Ready(Ok(value.clone())));
                         remove_waiter(&self.waiters, cht_key, hash);
-                        return init_res;
+                        return InitResult::ReadExisting(value);
                     }
 
                     // The value still does note exist. Let's resolve the init future.
@@ -297,7 +174,22 @@ where
                     match AssertUnwindSafe(init).catch_unwind().await {
                         // Resolved.
                         Ok(value) => {
-                            let (waiter_val, init_res) = post_init(value).await;
+                            let (waiter_val, init_res) = match post_init(value) {
+                                Ok(value) => {
+                                    insert(value.clone()).await;
+                                    (
+                                        WaiterValue::Ready(Ok(value.clone())),
+                                        InitResult::Initialized(value),
+                                    )
+                                }
+                                Err(e) => {
+                                    let err: ErrorObject = Arc::new(e);
+                                    (
+                                        WaiterValue::Ready(Err(Arc::clone(&err))),
+                                        InitResult::InitErr(err.downcast().unwrap()),
+                                    )
+                                }
+                            };
                             waiter_guard.set_waiter_value(waiter_val);
                             remove_waiter(&self.waiters, cht_key, hash);
                             return init_res;
@@ -345,6 +237,42 @@ where
             }
         }
     }
+
+    /// The `post_init` function for the `get_with` method of cache.
+    pub(crate) fn post_init_for_get_with(value: V) -> Result<V, ()> {
+        Ok(value)
+    }
+
+    /// The `post_init` function for the `optionally_get_with` method of cache.
+    pub(crate) fn post_init_for_optionally_get_with(
+        value: Option<V>,
+    ) -> Result<V, Arc<OptionallyNone>> {
+        // `value` can be either `Some` or `None`. For `None` case, without change
+        // the existing API too much, we will need to convert `None` to Arc<E> here.
+        // `Infallible` could not be instantiated. So it might be good to use an
+        // empty struct to indicate the error type.
+        value.ok_or(Arc::new(OptionallyNone))
+    }
+
+    /// The `post_init` function for `try_get_with` method of cache.
+    pub(crate) fn post_init_for_try_get_with<E>(result: Result<V, E>) -> Result<V, E> {
+        result
+    }
+
+    /// Returns the `type_id` for `get_with` method of cache.
+    pub(crate) fn type_id_for_get_with() -> TypeId {
+        TypeId::of::<()>()
+    }
+
+    /// Returns the `type_id` for `optionally_get_with` method of cache.
+    pub(crate) fn type_id_for_optionally_get_with() -> TypeId {
+        TypeId::of::<()>()
+    }
+
+    /// Returns the `type_id` for `try_get_with` method of cache.
+    pub(crate) fn type_id_for_try_get_with<E: 'static>() -> TypeId {
+        TypeId::of::<E>()
+    }
 }
 
 #[inline]
@@ -384,23 +312,6 @@ where
     let cht_key = (Arc::clone(key), type_id);
     let hash = waiter_map.hash(&cht_key);
     (cht_key, hash)
-}
-
-#[inline]
-fn make_pre_init<V, E>(
-    mut get: impl FnMut() -> Option<V>,
-) -> impl FnMut() -> Option<(WaiterValue<V>, InitResult<V, E>)>
-where
-    V: Clone,
-{
-    move || {
-        get().map(|value| {
-            (
-                WaiterValue::Ready(Ok(value.clone())),
-                InitResult::ReadExisting(value),
-            )
-        })
-    }
 }
 
 fn panic_if_retry_exhausted_for_panicking(retries: usize, max: usize) {

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -266,7 +266,7 @@ where
 
     /// Returns the `type_id` for `optionally_get_with` method of cache.
     pub(crate) fn type_id_for_optionally_get_with() -> TypeId {
-        TypeId::of::<()>()
+        TypeId::of::<OptionallyNone>()
     }
 
     /// Returns the `type_id` for `try_get_with` method of cache.

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -4,6 +4,7 @@ use std::{
     any::{Any, TypeId},
     future::Future,
     hash::{BuildHasher, Hash},
+    pin::Pin,
     sync::Arc,
 };
 use triomphe::Arc as TrioArc;
@@ -123,7 +124,7 @@ where
         type_id: TypeId,
         // Closure to get an existing value from cache.
         mut get: impl FnMut() -> Option<V>,
-        init: impl Future<Output = O>,
+        init: Pin<&mut impl Future<Output = O>>,
         // Closure to insert a new value into cache.
         mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
         // This function will be called after the init future has returned a value of


### PR DESCRIPTION
This PR will mitigate #212 for upcoming Moka v0.10.0 release.

## Changes

This PR does the same thing to PR #222, but on the `master` branch instead of the `maint-09` branch.

`future::Cache`:

1. To mitigate current `rustc`'s optimization issue, switched the internally using type for the `init` future from `impl Future` to a reference `Pin<&mut impl Future>`.
2. Eliminated an internal async function `ValueInitializer:init_or_read(..., init, ...)` from the call path.

## Updated Methods:

`future::Cache`:

- [x] `get_with(...)`
- [x] `get_with_if(...)`
- [x] `optionally_get_with(...)`
- [x] `try_get_with(...)`
- [x] `get_with_by_ref(...)`
- [x] `optionally_get_with_by_ref(...)`
- [x] `try_get_with_by_ref(...)`
- [x] `entry(...).or_insert_with(...)`
- [x] `entry(...).or_insert_with_if(...)`
- [x] `entry(...).or_optionally_insert_with(...)`
- [x] `entry(...).or_try_insert_with(...)`
- [x] `entry_by_ref(...).or_insert_with(...)`
- [x] `entry_by_ref(...).or_insert_with_if(...)`
- [x] `entry_by_ref(...).or_optionally_insert_with(...)`
- [x] `entry_by_ref(...).or_try_insert_with(...)`
