### PR TITLE
Refactor an internal module `sync::value_initializer`

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1501,7 +1501,7 @@ where
 
         match self
             .value_initializer
-            .try_init_or_read(&Arc::clone(&key), type_id, get, init, insert, post_init)
+            .try_init_or_read(&key, type_id, get, init, insert, post_init)
             .await
         {
             InitResult::Initialized(v) => {
@@ -1623,7 +1623,7 @@ where
 
         match self
             .value_initializer
-            .try_init_or_read(&Arc::clone(&key), type_id, get, init, insert, post_init)
+            .try_init_or_read(&key, type_id, get, init, insert, post_init)
             .await
         {
             InitResult::Initialized(v) => {
@@ -1706,7 +1706,7 @@ where
 
         match self
             .value_initializer
-            .try_init_or_read(&Arc::clone(&key), type_id, get, init, insert, post_init)
+            .try_init_or_read(&key, type_id, get, init, insert, post_init)
             .await
         {
             InitResult::Initialized(v) => {

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -138,8 +138,8 @@ where
         init: Pin<&mut impl Future<Output = O>>,
         // Closure that returns a future to insert a new value into cache.
         mut insert: impl FnMut(V) -> BoxFuture<'a, ()> + Send + 'a,
-        // This function will be called after the init future has returned a value of
-        // type O. It converts O into Result<V, E>.
+        // Function to convert a value O, returned from the init future, into
+        // Result<V, E>.
         post_init: fn(O) -> Result<V, E>,
     ) -> InitResult<V, E>
     where
@@ -180,9 +180,9 @@ where
                         return InitResult::ReadExisting(value);
                     }
 
-                    // The value still does note exist. Let's resolve the init future.
-
-                    // Catching panic is safe here as we do not try to resolve the future again.
+                    // The value still does note exist. Let's resolve the init
+                    // future. Catching panic is safe here as we do not try to
+                    // resolve the future again.
                     match AssertUnwindSafe(init).catch_unwind().await {
                         // Resolved.
                         Ok(value) => {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -22,4 +22,4 @@ pub trait ConcurrentCacheExt<K, V> {
 
 // Empty internal struct to be used in optionally_get_with to represent the None
 // results.
-struct OptionallyNone;
+pub(crate) struct OptionallyNone;

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1153,9 +1153,12 @@ where
             None
         };
 
+        let type_id = ValueInitializer::<K, V, S>::type_id_for_get_with();
+        let post_init = ValueInitializer::<K, V, S>::post_init_for_get_with;
+
         match self
             .value_initializer
-            .init_or_read(Arc::clone(&key), get, init, insert)
+            .try_init_or_read(&key, type_id, get, init, insert, post_init)
         {
             InitResult::Initialized(v) => {
                 crossbeam_epoch::pin().flush();
@@ -1375,9 +1378,12 @@ where
             None
         };
 
+        let type_id = ValueInitializer::<K, V, S>::type_id_for_optionally_get_with();
+        let post_init = ValueInitializer::<K, V, S>::post_init_for_optionally_get_with;
+
         match self
             .value_initializer
-            .optionally_init_or_read(Arc::clone(&key), get, init, insert)
+            .try_init_or_read(&key, type_id, get, init, insert, post_init)
         {
             InitResult::Initialized(v) => {
                 crossbeam_epoch::pin().flush();
@@ -1567,9 +1573,12 @@ where
             None
         };
 
+        let type_id = ValueInitializer::<K, V, S>::type_id_for_try_get_with::<E>();
+        let post_init = ValueInitializer::<K, V, S>::post_init_for_try_get_with;
+
         match self
             .value_initializer
-            .try_init_or_read(Arc::clone(&key), get, init, insert)
+            .try_init_or_read(&key, type_id, get, init, insert, post_init)
         {
             InitResult::Initialized(v) => {
                 crossbeam_epoch::pin().flush();


### PR DESCRIPTION
Refactor an internal module `sync::value_initializer` to match the new structure of `future::value_initializer` introduced by #220.

- Eliminated an internal method `ValueInitializer:init_or_read(..., init, ...)` from the call path.

Also remove unnecessary `Arc::clone`s from both `sync::Cache` and `future::Cache`.