### PR TITLE
Fix the CI for MSRV 1.51

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,6 +58,7 @@ linux_arm64_task:
       cargo update -p async-global-executor --precise 2.0.4
       cargo update -p pulldown-cmark --precise 0.9.1
       cargo update -p once_cell --precise 1.14.0
+      cargo update -p tokio-native-tls --precise 0.3.0
     else
       echo 'Skipped'
     fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,7 @@ jobs:
         # async-global-executor >= 2.1 requires Rust 2021 edition.
         # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
         # once_cell >= 1.15.0 requires Rust 2021 edition.
+        # tokio-native-tls >= 0.3.1 requires a lint `rustdoc::broken_intra_doc_links`.
         run: |
           rm -f Cargo.lock
           sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
@@ -82,6 +83,7 @@ jobs:
           cargo update -p async-global-executor --precise 2.0.4
           cargo update -p pulldown-cmark --precise 0.9.1
           cargo update -p once_cell --precise 1.14.0
+          cargo update -p tokio-native-tls --precise 0.3.0
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -65,6 +65,7 @@ jobs:
         # async-global-executor >= 2.1 requires Rust 2021 edition.
         # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
         # once_cell >= 1.15.0 requires Rust 2021 edition.
+        # tokio-native-tls >= 0.3.1 requires a lint `rustdoc::broken_intra_doc_links`.
         run: |
           rm -f Cargo.lock
           sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
@@ -75,6 +76,7 @@ jobs:
           cargo update -p async-global-executor --precise 2.0.4
           cargo update -p pulldown-cmark --precise 0.9.1
           cargo update -p once_cell --precise 1.14.0
+          cargo update -p tokio-native-tls --precise 0.3.0
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
When testing the MSRV, downgrade `tokio-native-tls` to v0.3.0.