### PR TITLE
Do not run external CI on temporary branches for GitHub merge queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,5 +26,9 @@ jobs:
 workflows:
   build:
     jobs:
-    - rust/coverage
+    - rust/coverage:
+        filters:
+          # Ignore pushes on temporary branches for GitHub merge queue.
+          branches:
+            ignore: /gh-readonly-queue\/.*/
   version: 2

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,9 @@ env:
   NUM_CPUS: "2"
 
 linux_arm64_task:
+  # Skip the whole task when this is a temporary branch for GitHub merge queue.
+  skip: $CIRRUS_BRANCH =~ 'gh-readonly-queue/.*'
+
   arm_container:
     cpu: $NUM_CPUS
     matrix:


### PR DESCRIPTION
To fix #233, skip CI jobs on Circle CI and Cirrus CI if the branch is a temporary branch for GitHub merge queue.