### PR TITLE
Do not cache anything when max capacity is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.10.1
+
+### Changed
+
+- Now `sync` and `future` caches will not cache anything when the max capacity is set
+  to zero ([#230][gh-issue-0230]):
+    - Previously, they would cache some entries for short time (< 0.5 secs) even
+      though the max capacity is zero.
+
+
 ## Version 0.10.0
 
 ### Breaking Changes
@@ -575,6 +585,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
 
+[gh-issue-0230]: https://github.com/moka-rs/moka/issues/230/
 [gh-issue-0212]: https://github.com/moka-rs/moka/issues/212/
 [gh-issue-0207]: https://github.com/moka-rs/moka/issues/207/
 [gh-issue-0162]: https://github.com/moka-rs/moka/issues/162/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2018"
 rust-version = "1.51"
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -294,6 +294,10 @@ where
         R: Fn(ReadOp<K, V>, Instant),
         I: FnMut(&V) -> bool,
     {
+        if self.is_map_disabled() {
+            return None;
+        }
+
         let now = self.current_time_from_expiration_clock();
 
         let maybe_entry = self


### PR DESCRIPTION
To fix #230, make the cache implementations to store nothing when the max capacity is set to 0.

## Changes

When the max capacity is set to 0, cache will do the followings:

- Create the internal concurrent hash map with initial capacity of 0.
- Do not enable the frequency sketch.
- Make the following methods to do nothing and return immediately:
    - internal `insert_with_hash`
    - internal `do_get_with_hash`
    - external `sync`

Also added unit test called `max_capacity_zero`.

## Verification

- [x] Ran all unit tests and they all passed.
    - command: `RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test -F future`