### PR TITLE
Avoid a deprecation warning from scheduled-thread-pool v0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ crossbeam-utils = "0.8"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.12"
-scheduled-thread-pool = "0.2.6"
+scheduled-thread-pool = "0.2.7"
 smallvec = "1.8"
 tagptr = "0.2"
 

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -35,7 +35,10 @@ pub(crate) struct ThreadPool {
 
 impl ThreadPool {
     fn new(name: PoolName, num_threads: usize) -> Self {
-        let pool = ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);
+        let pool = ScheduledThreadPool::builder()
+            .num_threads(num_threads)
+            .thread_name_pattern(name.thread_name_template())
+            .build();
         Self {
             name,
             pool,


### PR DESCRIPTION
- Replace the deprecated `ScheduledThreadPool::with_name` method with the recommended `builder` method.
- Since the `builder` method was just added to v0.2.7, had to change the minimum version of scheduled-thread-pool from v0.2.6 to v0.2.7.