### PR TITLE
Fix the CI for MSRV and Rust nightly (cc, thiserror, serde)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,6 +63,8 @@ linux_arm64_task:
       cargo update -p pulldown-cmark --precise 0.9.1
       cargo update -p once_cell --precise 1.14.0
       cargo update -p tokio-native-tls --precise 0.3.0
+      cargo update -p thiserror --precise 1.0.39
+      cargo update -p serde --precise 1.0.156
     else
       echo 'Skipped'
     fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,6 +44,7 @@ linux_arm64_task:
       echo 'Downgrading dependencies to minimal versions'
       cargo update -Z minimal-versions
       cargo update -p openssl --precise 0.10.39
+      cargo update -p cc --precise 1.0.61
     else
       echo 'Skipped'
     fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,8 @@ jobs:
           cargo update -p pulldown-cmark --precise 0.9.1
           cargo update -p once_cell --precise 1.14.0
           cargo update -p tokio-native-tls --precise 0.3.0
+          cargo update -p thiserror --precise 1.0.39
+          cargo update -p serde --precise 1.0.156
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,6 +63,7 @@ jobs:
         if: ${{ matrix.rust == 'nightly' }}
         run: |
           cargo update -p openssl --precise 0.10.39
+          cargo update -p cc --precise 1.0.61
 
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -56,6 +56,7 @@ jobs:
         if: ${{ matrix.rust == 'nightly' }}
         run: |
           cargo update -p openssl --precise 0.10.39
+          cargo update -p cc --precise 1.0.61
 
       - name: Pin some dependencies to specific versions (MSRV only)
         if: ${{ matrix.rust == '1.51.0' }}

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -78,6 +78,8 @@ jobs:
           cargo update -p pulldown-cmark --precise 0.9.1
           cargo update -p once_cell --precise 1.14.0
           cargo update -p tokio-native-tls --precise 0.3.0
+          cargo update -p thiserror --precise 1.0.39
+          cargo update -p serde --precise 1.0.156
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
- When testing minimal dependency versions, upgrade `cc` to v1.0.61, otherwise building `openssl-sys` will fail on Linux.
- When testing MSRV 1.51.0, downgrade `thiserror` and `serde` to v1.0.39 and v1.0.156
respectively.