### PR TITLE
Fix the CI for MSRV 1.51

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,6 +65,8 @@ linux_arm64_task:
       cargo update -p tokio-native-tls --precise 0.3.0
       cargo update -p thiserror --precise 1.0.39
       cargo update -p serde --precise 1.0.156
+      cargo update -p tokio --precise 1.26.0
+      cargo update -p futures-util --precise 0.3.27
     else
       echo 'Skipped'
     fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,6 +87,8 @@ jobs:
           cargo update -p tokio-native-tls --precise 0.3.0
           cargo update -p thiserror --precise 1.0.39
           cargo update -p serde --precise 1.0.156
+          cargo update -p tokio --precise 1.26.0
+          cargo update -p futures-util --precise 0.3.27
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -80,6 +80,8 @@ jobs:
           cargo update -p tokio-native-tls --precise 0.3.0
           cargo update -p thiserror --precise 1.0.39
           cargo update -p serde --precise 1.0.156
+          cargo update -p tokio --precise 1.26.0
+          cargo update -p futures-util --precise 0.3.27
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
When testing the MSRV, downgrade `tokio` and `futures-util` to v1.26.0 and v0.3.27 respectively, so that they will compile.