### PR TITLE
Bump the MSRV to 1.60 (2022-04-07)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ linux_arm64_task:
     matrix:
       - image: rust:slim  # docker's official latest rust stable version
       - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
-      - image: rust:1.51.0-slim # MSRV
+      - image: rust:1.60.0-slim # MSRV
       # no rust-beta image found in docker hub, won't be tested
 
   ## Disable caching as there is no Cargo.lock file in Moka repository.
@@ -50,26 +50,13 @@ linux_arm64_task:
     fi
 
   # Pin some dependencies to specific versions (MSRV only)
-  pin_deps_script: |
-    if [ "v$RUST_VERSION" == "v1.51.0" ]; then
-      echo 'Pinning some dependencies to specific versions'
-      rm -f Cargo.lock
-      sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
-      cargo update -p indexmap --precise 1.8.2
-      cargo update -p hashbrown --precise 0.11.2
-      cargo update -p reqwest --precise 0.11.12
-      cargo update -p native-tls --precise 0.2.8
-      cargo update -p async-global-executor --precise 2.0.4
-      cargo update -p pulldown-cmark --precise 0.9.1
-      cargo update -p once_cell --precise 1.14.0
-      cargo update -p tokio-native-tls --precise 0.3.0
-      cargo update -p thiserror --precise 1.0.39
-      cargo update -p serde --precise 1.0.156
-      cargo update -p tokio --precise 1.26.0
-      cargo update -p futures-util --precise 0.3.27
-    else
-      echo 'Skipped'
-    fi
+  # pin_deps_script: |
+  #   if [ "v$RUST_VERSION" == "v1.60.0" ]; then
+  #     echo 'Pinning some dependencies to specific versions'
+  #     cargo update -p <crate> --precise <version>
+  #   else
+  #     echo 'Skipped'
+  #   fi
 
   test_script:
     # Run tests (debug, sync feature)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.51.0  # MSRV
+          - 1.60.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -65,30 +65,10 @@ jobs:
           cargo update -p openssl --precise 0.10.39
           cargo update -p cc --precise 1.0.61
 
-      - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.51.0' }}
-        # hashbrown >= v0.12 requires Rust 2021 edition.
-        # reqwest >= v0.11.13 requires native-tls v0.2.10.
-        # native-tls >= v0.2.9 requires more recent Rust version.
-        # async-global-executor >= 2.1 requires Rust 2021 edition.
-        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
-        # once_cell >= 1.15.0 requires Rust 2021 edition.
-        # tokio-native-tls >= 0.3.1 requires a lint `rustdoc::broken_intra_doc_links`.
-        run: |
-          rm -f Cargo.lock
-          sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
-          cargo update -p indexmap --precise 1.8.2
-          cargo update -p hashbrown --precise 0.11.2
-          cargo update -p reqwest --precise 0.11.12
-          cargo update -p native-tls --precise 0.2.8
-          cargo update -p async-global-executor --precise 2.0.4
-          cargo update -p pulldown-cmark --precise 0.9.1
-          cargo update -p once_cell --precise 1.14.0
-          cargo update -p tokio-native-tls --precise 0.3.0
-          cargo update -p thiserror --precise 1.0.39
-          cargo update -p serde --precise 1.0.156
-          cargo update -p tokio --precise 1.26.0
-          cargo update -p futures-util --precise 0.3.27
+      # - name: Pin some dependencies to specific versions (MSRV only)
+      #   if: ${{ matrix.rust == '1.60.0' }}
+      #   run: |
+      #     cargo update -p <crate> --precise <version>
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.51.0  # MSRV
+          - 1.60.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -58,30 +58,10 @@ jobs:
           cargo update -p openssl --precise 0.10.39
           cargo update -p cc --precise 1.0.61
 
-      - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.51.0' }}
-        # hashbrown >= v0.12 requires Rust 2021 edition.
-        # reqwest >= v0.11.13 requires native-tls v0.2.10.
-        # native-tls >= v0.2.9 requires more recent Rust version.
-        # async-global-executor >= 2.1 requires Rust 2021 edition.
-        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
-        # once_cell >= 1.15.0 requires Rust 2021 edition.
-        # tokio-native-tls >= 0.3.1 requires a lint `rustdoc::broken_intra_doc_links`.
-        run: |
-          rm -f Cargo.lock
-          sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
-          cargo update -p indexmap --precise 1.8.2
-          cargo update -p hashbrown --precise 0.11.2
-          cargo update -p reqwest --precise 0.11.12
-          cargo update -p native-tls --precise 0.2.8
-          cargo update -p async-global-executor --precise 2.0.4
-          cargo update -p pulldown-cmark --precise 0.9.1
-          cargo update -p once_cell --precise 1.14.0
-          cargo update -p tokio-native-tls --precise 0.3.0
-          cargo update -p thiserror --precise 1.0.39
-          cargo update -p serde --precise 1.0.156
-          cargo update -p tokio --precise 1.26.0
-          cargo update -p futures-util --precise 0.3.27
+      # - name: Pin some dependencies to specific versions (MSRV only)
+      #   if: ${{ matrix.rust == '1.60.0' }}
+      #   run: |
+      #     cargo update -p <crate> --precise <version>
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.10.2
+
+Bumped the minimum supported Rust version (MSRV) to 1.60 (2022-04-07).
+([#252][gh-issue-0252])
+
+
 ## Version 0.10.1
 
 ### Fixed
@@ -590,6 +596,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
 
+[gh-issue-0252]: https://github.com/moka-rs/moka/issues/252/
 [gh-issue-0242]: https://github.com/moka-rs/moka/issues/242/
 [gh-issue-0230]: https://github.com/moka-rs/moka/issues/230/
 [gh-issue-0212]: https://github.com/moka-rs/moka/issues/212/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "moka"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.60"  # Released on April 7, 2022, supporting 2021 edition.
 
 description = "A fast and concurrent cache library inspired by Java Caffeine"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -459,8 +459,8 @@ Moka's minimum supported Rust versions (MSRV) are the followings:
 
 | Feature          | MSRV                     |
 |:-----------------|:------------------------:|
-| default features | Rust 1.51.0 (2021-03-25) |
-| `future`         | Rust 1.51.0 (2021-03-25) |
+| default features | Rust 1.60.0 (2022-04-07) |
+| `future`         | Rust 1.60.0 (2022-04-07) |
 
 It will keep a rolling MSRV policy of at least 6 months. If only the default features
 are enabled, MSRV will be updated conservatively. When using other features, like
@@ -468,9 +468,7 @@ are enabled, MSRV will be updated conservatively. When using other features, lik
 cases, increasing MSRV is _not_ considered a semver-breaking change.
 
 <!--
-- tagptr 0.2.0 requires 1.51.
-- socket2 0.4.0 requires 1.46.
-- quanta requires 1.45.
+- quanta v0.11.0 requires 1.60.
 -->
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,8 @@
 //!
 //! | Feature          | MSRV                     |
 //! |:-----------------|:------------------------:|
-//! | default features | Rust 1.51.0 (2021-03-25) |
-//! | `future`         | Rust 1.51.0 (2021-03-25) |
+//! | default features | Rust 1.60.0 (2022-04-07) |
+//! | `future`         | Rust 1.60.0 (2022-04-07) |
 //!
 //! It will keep a rolling MSRV policy of at least 6 months. If only the default
 //! features are enabled, MSRV will be updated conservatively. When using other


### PR DESCRIPTION
Fixes #252

- Bump the MSRV from 1.51 to 1.60 (2022-04-07).
- Bump the `moka` version to v0.10.2.