### PR TITLE
Add the `remove` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Version 0.11.0
 
-### Breaking Changes
-
-- (Will change the return type of the `invalidate` method from `()` to `Option<V>`)
-
 ### Added
 
-- Added support for per-entry expiration. ([#248][gh-pull-0248])
+- Added support for per-entry expiration ([#248][gh-pull-0248]):
     - In addition to the existing TTL and TTI (time-to-idle) expiration times that
       apply to all entries in the cache, the `sync` and `future` caches can now allow
       different expiration times for individual entries.
+- Added the `remove` method to the `sync` and `future` caches
+  ([#255](gh-issue-0255)):
+    - Like the `invalidate` method, this method discards any cached value for the
+      key, but returns a clone of the value.
 
 ### Removed
 
@@ -623,6 +623,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
 
+[gh-issue-0255]: https://github.com/moka-rs/moka/issues/255/
 [gh-issue-0252]: https://github.com/moka-rs/moka/issues/252/
 [gh-issue-0243]: https://github.com/moka-rs/moka/issues/243/
 [gh-issue-0242]: https://github.com/moka-rs/moka/issues/242/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following table shows the trade-offs between the different cache implementat
 | Bounded by the maximum number of entries | ✅ | ✅ | ✅ |
 | Bounded by the total weighted size of entries | ✅ | ✅ | ✅ |
 | Near optimal hit ratio | ✅ TinyLFU | ✅ TinyLFU | ✅ CLOCK-Pro |
-| Cache-level expiration policies (Time-to-live and time-to-idle) | ✅ | ✅ | ❌ |
+| Cache-level expiration policies (time-to-live and time-to-idle) | ✅ | ✅ | ❌ |
 | Per-entry variable expiration | ✅ | ❌ | ❌ |
 | Eviction listener | ✅ | ❌ | ❌ |
 | Per-key, atomic insertion | ✅ `get_with` family methods | ❌ | ❌ |


### PR DESCRIPTION
This PR adds the `remove` method to `future` and `sync` caches. It does the same to the `invalidate` method except returning a _clone_ of the value that has been discarded.

```rust
// moka::future::Cache

/// Discards any cached value for the key and returns a _clone_ of the value.
///
/// If you do not need to get the value that has been discarded, use the
/// [`invalidate`](#method.invalidate) method instead.
///
/// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
/// on the borrowed form _must_ match those for the key type.
pub async fn remove<Q>(&self, key: &Q) -> Option<V>
where
    K: Borrow<Q>,
    Q: Hash + Eq + ?Sized;

// FYI, an existing `invalidate` method.
pub async fn invalidate<Q>(&self, key: &Q)
where
    K: Borrow<Q>,
    Q: Hash + Eq + ?Sized,
```

Fixes #255.