### PR TITLE
Fix the caches mutating a deque node through a `NonNull` pointer derived from a shared reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
     - Like the `invalidate` method, this method discards any cached value for the
       key, but returns a clone of the value.
 
+### Fixed
+
+- Fixed the caches mutating a deque node through a `NonNull` pointer derived from a
+  shared reference. ([#259][gh-pull-0259])
+
 ### Removed
 
 - Removed `unsync` cache that was marked as deprecated in [v0.10.0](#version-0100).
@@ -642,6 +647,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0259]: https://github.com/moka-rs/moka/pull/259/
 [gh-pull-0251]: https://github.com/moka-rs/moka/pull/251/
 [gh-pull-0248]: https://github.com/moka-rs/moka/pull/248/
 [gh-pull-0216]: https://github.com/moka-rs/moka/pull/216/

--- a/src/common/concurrent/deques.rs
+++ b/src/common/concurrent/deques.rs
@@ -194,3 +194,5 @@ impl<K> Deques<K> {
         }
     }
 }
+
+// TODO: Add tests and run Miri with them.

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -335,6 +335,8 @@ impl<T> Deque<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::ptr::NonNull;
+
     use super::{CacheRegion::MainProbation, DeqNode, Deque};
 
     #[test]
@@ -712,6 +714,32 @@ mod tests {
         let node2a = node1a.next_node().unwrap();
         assert_eq!(node2a.element, "b".to_string());
         assert!(node2a.next_node().is_none());
+    }
+
+    #[test]
+    fn peek_and_move_to_back() {
+        let mut deque: Deque<String> = Deque::new(MainProbation);
+
+        let node1 = DeqNode::new("a".into());
+        deque.push_back(Box::new(node1));
+        let node2 = DeqNode::new("b".into());
+        let _ = deque.push_back(Box::new(node2));
+        let node3 = DeqNode::new("c".into());
+        let _ = deque.push_back(Box::new(node3));
+        // "a" -> "b" -> "c"
+
+        let node1a = deque.peek_front().unwrap();
+        assert_eq!(node1a.element, "a".to_string());
+        unsafe { deque.move_to_back(NonNull::from(node1a)) };
+        // "b" -> "c" -> "a"
+
+        let node2a = deque.peek_front().unwrap();
+        assert_eq!(node2a.element, "b".to_string());
+
+        let node3a = DeqNode::next_node(node2a).unwrap();
+        assert_eq!(node3a.element, "c".to_string());
+        unsafe { deque.move_to_back(NonNull::from(node3a)) };
+        // "b" -> "a" -> "c"
     }
 
     #[test]

--- a/src/common/timer_wheel.rs
+++ b/src/common/timer_wheel.rs
@@ -322,32 +322,20 @@ impl<K> TimerWheel<K> {
     }
 
     /// Reset the positions of the nodes in the queue at the given level and index.
+    /// When done, the sentinel is at the back of the queue.
     fn reset_timer_node_positions(&mut self, level: usize, index: usize) {
         let deque = &mut self.wheels[level][index];
-        if let Some(node) = deque.peek_back() {
-            if node.element.is_sentinel() {
-                // The sentinel is at the back of the queue. We are already set.
-                return;
-            }
-        } else {
-            panic!(
-                "BUG: The queue is empty. level: {}, index: {}",
-                level, index
-            )
-        }
+        debug_assert!(
+            deque.len() > 0,
+            "BUG: The queue is empty. level: {}, index: {}",
+            level,
+            index
+        );
 
         // Rotate the nodes in the queue until we see the sentinel at the back of the
         // queue.
-        loop {
-            // Safe to unwrap because we already checked the queue is not empty.
-            let node = deque.peek_front().unwrap();
-            let is_sentinel = node.element.is_sentinel();
+        while !deque.peek_back().unwrap().element.is_sentinel() {
             deque.move_front_to_back();
-
-            // If the node we just moved was the sentinel, we are done.
-            if is_sentinel {
-                break;
-            }
         }
     }
 

--- a/src/common/timer_wheel.rs
+++ b/src/common/timer_wheel.rs
@@ -311,18 +311,20 @@ impl<K> TimerWheel<K> {
     /// Returns a pointer to the timer event (cache entry) at the front of the queue.
     /// Returns `None` if the front node is a sentinel.
     fn pop_timer_node(&mut self, level: usize, index: usize) -> Option<Box<DeqNode<TimerNode<K>>>> {
-        if let Some(node) = self.wheels[level][index].peek_front() {
+        let deque = &mut self.wheels[level][index];
+        if let Some(node) = deque.peek_front() {
             if node.element.is_sentinel() {
                 return None;
             }
         }
 
-        self.wheels[level][index].pop_front()
+        deque.pop_front()
     }
 
     /// Reset the positions of the nodes in the queue at the given level and index.
     fn reset_timer_node_positions(&mut self, level: usize, index: usize) {
-        if let Some(node) = self.wheels[level][index].peek_back() {
+        let deque = &mut self.wheels[level][index];
+        if let Some(node) = deque.peek_back() {
             if node.element.is_sentinel() {
                 // The sentinel is at the back of the queue. We are already set.
                 return;
@@ -338,11 +340,9 @@ impl<K> TimerWheel<K> {
         // queue.
         loop {
             // Safe to unwrap because we already checked the queue is not empty.
-            let node = self.wheels[level][index].pop_front().unwrap();
+            let node = deque.peek_front().unwrap();
             let is_sentinel = node.element.is_sentinel();
-
-            // Move the front node to the back.
-            self.wheels[level][index].push_back(node);
+            deque.move_front_to_back();
 
             // If the node we just moved was the sentinel, we are done.
             if is_sentinel {

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1728,7 +1728,7 @@ where
             }
             if let Some(victim) = next_victim.take() {
                 next_victim = DeqNode::next_node_ptr(victim);
-                let vic_elem = &unsafe {victim.as_ref()}.element;
+                let vic_elem = &unsafe { victim.as_ref() }.element;
 
                 if let Some(vic_entry) = cache.get(vic_elem.hash(), |k| k == vic_elem.key()) {
                     victims.add_policy_weight(vic_entry.policy_weight());

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1682,10 +1682,6 @@ where
 
         // Move the skipped nodes to the back of the deque. We do not unlink (drop)
         // them because ValueEntries in the write op queue should be pointing them.
-        //
-        // TODO FIXME: This `move_to_back()` will be considered UB as violating the
-        // aliasing rule because these skipped nodes were acquired by `peek_front` or
-        // `next_node`. (They both return `&node` instead of `&mut node`).
         for node in skipped_nodes {
             unsafe { deqs.probation.move_to_back(node) };
         }
@@ -1723,7 +1719,7 @@ where
         let mut skipped_nodes = SmallVec::default();
 
         // Get first potential victim at the LRU position.
-        let mut next_victim = deqs.probation.peek_front();
+        let mut next_victim = deqs.probation.peek_front_ptr();
 
         // Aggregate potential victims.
         while victims.policy_weight < candidate.policy_weight {
@@ -1731,18 +1727,18 @@ where
                 break;
             }
             if let Some(victim) = next_victim.take() {
-                next_victim = victim.next_node();
-                let vic_elem = &victim.element;
+                next_victim = DeqNode::next_node_ptr(victim);
+                let vic_elem = &unsafe {victim.as_ref()}.element;
 
                 if let Some(vic_entry) = cache.get(vic_elem.hash(), |k| k == vic_elem.key()) {
                     victims.add_policy_weight(vic_entry.policy_weight());
                     victims.add_frequency(freq, vic_elem.hash());
-                    victim_nodes.push(NonNull::from(victim));
+                    victim_nodes.push(victim);
                     retries = 0;
                 } else {
                     // Could not get the victim from the cache (hash map). Skip this node
                     // as its ValueEntry might have been invalidated.
-                    skipped_nodes.push(NonNull::from(victim));
+                    skipped_nodes.push(victim);
 
                     retries += 1;
                     if retries > MAX_CONSECUTIVE_RETRIES {
@@ -2085,14 +2081,7 @@ where
             // invalidated ValueEntry (which should be still in the write op queue)
             // has a pointer to this node, move the node to the back of the deque
             // instead of popping (dropping) it.
-            //
-            // TODO FIXME: This `peek_front()` and `move_to_back()` combo will be
-            // considered UB as violating the aliasing rule. (`peek_front` returns
-            // `&node` instead of `&mut node`).
-            if let Some(node) = deq.peek_front() {
-                let node = NonNull::from(node);
-                unsafe { deq.move_to_back(node) };
-            }
+            deq.move_front_to_back();
             true
         }
     }
@@ -2157,14 +2146,7 @@ where
                 // invalidated ValueEntry (which should be still in the write op
                 // queue) has a pointer to this node, move the node to the back of
                 // the deque instead of popping (dropping) it.
-                //
-                // TODO FIXME: This `peek_front()` and `move_to_back()` combo will be
-                // considered UB as violating the aliasing rule (`peek_front` returns
-                // `&node` instead of `&mut node`).
-                if let Some(node) = deqs.write_order.peek_front() {
-                    let node = NonNull::from(node);
-                    unsafe { deqs.write_order.move_to_back(node) };
-                }
+                deqs.write_order.move_front_to_back();
             }
         }
     }


### PR DESCRIPTION
I found bugs in the `sync` and `future` caches; they were mutating an internal deque node through a `NonNull` pointer derived from a shared ref `&`. This PR fixes these bugs.

These bugs already existed from very early version of Moka but I could not find them until now. [Miri](https://github.com/rust-lang/miri) tests could have helped to find them, but we are not running Miri tests on the `sync_base` module who has the bugs. This is because the module uses some FFI calls that Miri does not support.

In commit https://github.com/moka-rs/moka/commit/03c75ff0ae7d39fc21f8d206ca0103ec59bbc7fb (included in this PR), I added a test to `deque` module to reproduce the bug and confirmed that Miri can catch it.

```console
$ cargo +nightly miri test deque

test common::deque::tests::peek_and_move_to_back ... error: Undefined Behavior: trying to retag from <506610> for Unique permission at alloc194760[0x0], but that tag only grants SharedReadOnly permission for this location
   --> /Users/tatsuya/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:427:18
    |
427 |         unsafe { &mut *self.as_ptr() }
    |                  ^^^^^^^^^^^^^^^^^^^
    |                  |
    |                  trying to retag from <506610> for Unique permission at alloc194760[0x0], but that tag only grants SharedReadOnly permission for this location
    |                  this error occurs as part of retag at alloc194760[0x0..0x28]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <506610> was created by a SharedReadOnly retag at offsets [0x0..0x28]
   --> src/common/deque.rs:733:37
    |
733 |         unsafe { deque.move_to_back(NonNull::from(node1a)) };
    |                                     ^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `std::ptr::NonNull::<common::deque::DeqNode<std::string::String>>::as_mut::<'_>` at /Users/tatsuya/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:427:18: 427:37
note: inside `common::deque::Deque::<std::string::String>::move_to_back`
   --> src/common/deque.rs:197:20
    |
197 |         let node = node.as_mut(); // this one is ours now, we can create an &mut.
    |                    ^^^^^^^^^^^^^
note: inside `common::deque::tests::peek_and_move_to_back`
   --> src/common/deque.rs:733:18
    |
733 |         unsafe { deque.move_to_back(NonNull::from(node1a)) };
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR fixes the bugs by not using a shared reference in these cases:

- Add `Deque::peek_front_ptr` method, which is similar to existing `peek_front` method. It returns a `NonNull` pointer to the front node, instead of a shared reference.
- Remove `DeqNode::next` method that returns a shared reference to the next node.
- Add `DeqNode::next_ptr` function that returns a `NonNull` pointers to the next node.
- Add `Deque::move_front_to_back` method that moves the front node to the back of the deque, instead of moving the node through a shared reference to the node.
- Modify the code in the `sync_base` module to use above methods when they need to mutate a `DeqNode`. 

This PR also adds the test mentioned above to `deque` module to ensure that the bugs are fixed.

I do not know if there were actual impacts of the bugs. I think the bugs were not triggered because the code never accesses the shared reference again after the mutable reference is created. Also the code is executed only when some corner cases are met.
