### PR TITLE
CI: Workaround a CI failure for Miri test by using a specific version of Rust nightly

### DIFF
--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -29,7 +29,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          # For now, use a specific version of nightly.
+          # https://github.com/moka-rs/moka/issues/269
+          toolchain: nightly-2023-05-24
           override: true
           components: miri
 


### PR DESCRIPTION
To workaround the issue described by #269, use a specific version of Rust nightly for Miri test for now. We are going to use `nightly-2023-05-24`.

We will revert this change when the original issue is addressed.