### PR TITLE
Tweak some examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.11.1
+
+### Added
+
+- Added some example programs to the `examples` directory. ([#268][gh-pull-0268], by
+  [@peter-scholtens][gh-peter-scholtens])
+
 ## Version 0.11.0
 
 ### Added
@@ -624,6 +631,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-Milo123459]: https://github.com/Milo123459
 [gh-messense]: https://github.com/messense
 [gh-paolobarbolini]: https://github.com/paolobarbolini
+[gh-peter-scholtens]: https://github.com/peter-scholtens
 [gh-saethlin]: https://github.com/saethlin
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
@@ -647,6 +655,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0268]: https://github.com/moka-rs/moka/pull/268/
 [gh-pull-0259]: https://github.com/moka-rs/moka/pull/259/
 [gh-pull-0251]: https://github.com/moka-rs/moka/pull/251/
 [gh-pull-0248]: https://github.com/moka-rs/moka/pull/248/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 rust-version = "1.60"  # Released on April 7, 2022, supporting 2021 edition.
 

--- a/examples/size_aware_eviction.rs
+++ b/examples/size_aware_eviction.rs
@@ -1,14 +1,12 @@
-use std::convert::TryInto;
 use moka::sync::Cache;
+use std::convert::TryInto;
 
 fn main() {
     let cache = Cache::builder()
         // A weigher closure takes &K and &V and returns a u32 representing the
         // relative size of the entry. Here, we use the byte length of the value
         // String as the size.
-        .weigher(|_key, value: &String| -> u32 {
-            value.len().try_into().unwrap_or(u32::MAX)
-        })
+        .weigher(|_key, value: &String| -> u32 { value.len().try_into().unwrap_or(u32::MAX) })
         // This cache will hold up to 32MiB of values.
         .max_capacity(32 * 1024 * 1024)
         .build();


### PR DESCRIPTION
- Bump the Moka version to v0.11.1.
- Reorder some cache operations in the `eviction_listener` example and add some comments.
- Apply `cargo fmt`.
- Update the change log.