### PR TITLE
CI: Fix CI errors 2023-06

### DIFF
--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -29,9 +29,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # For now, use a specific version of nightly.
-          # https://github.com/moka-rs/moka/issues/269
-          toolchain: nightly-2023-05-24
+          toolchain: nightly
           override: true
           components: miri
 

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -409,9 +409,8 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
         H: BuildHasher,
     {
         // Ensure that the rehashing is not performed concurrently.
-        let lock;
-        match self.rehash_lock.try_lock() {
-            Ok(lk) => lock = lk,
+        let lock = match self.rehash_lock.try_lock() {
+            Ok(lk) => lk,
             Err(TryLockError::WouldBlock) => {
                 // Wait until the lock become available.
                 std::mem::drop(self.rehash_lock.lock());

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -245,7 +245,7 @@ where
             periodical_sync_job: Mutex::new(maybe_sync_job),
             periodical_sync_running,
             on_demand_sync_scheduled: Arc::new(AtomicBool::new(false)),
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -108,7 +108,7 @@ impl<T> Deque<T> {
             head: None,
             tail: None,
             cursor: None,
-            marker: PhantomData::default(),
+            marker: PhantomData,
         }
     }
 

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -120,7 +120,7 @@ where
             expiration_policy: self.expiration_policy,
             invalidator_enabled: self.invalidator_enabled,
             thread_pool_enabled: self.thread_pool_enabled,
-            cache_type: PhantomData::default(),
+            cache_type: PhantomData,
         }
     }
 

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -305,7 +305,7 @@ impl<K, V, S> ScanContext<K, V, S> {
             result: Mutex::new(None),
             is_running: AtomicBool::new(false),
             is_shutting_down: AtomicBool::new(false),
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 }


### PR DESCRIPTION
- Revert "Workaround a CI failure for Miri test by using a specific version"
    - Fixes #269
- Fix Clippy warnings.
    - clippy 0.1.71 (eff24c06d8f 2023-05-29)
