### PR TITLE
Bump the minimum supported Rust version (MSRV) to 1.65 (Nov 3, 2022)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ linux_arm64_task:
     matrix:
       - image: rust:slim  # docker's official latest rust stable version
       - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
-      - image: rust:1.60.0-slim # MSRV
+      - image: rust:1.65.0-slim # MSRV
       # no rust-beta image found in docker hub, won't be tested
 
   ## Disable caching as there is no Cargo.lock file in Moka repository.
@@ -51,7 +51,7 @@ linux_arm64_task:
 
   # Pin some dependencies to specific versions (MSRV only)
   # pin_deps_script: |
-  #   if [ "v$RUST_VERSION" == "v1.60.0" ]; then
+  #   if [ "v$RUST_VERSION" == "v1.65.0" ]; then
   #     echo 'Pinning some dependencies to specific versions'
   #     cargo update -p <crate> --precise <version>
   #   else

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.60.0  # MSRV
+          - 1.65.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -66,7 +66,7 @@ jobs:
           cargo update -p cc --precise 1.0.61
 
       # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.60.0' }}
+      #   if: ${{ matrix.rust == '1.65.0' }}
       #   run: |
       #     cargo update -p <crate> --precise <version>
 

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.60.0  # MSRV
+          - 1.65.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -59,7 +59,7 @@ jobs:
           cargo update -p cc --precise 1.0.61
 
       # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.60.0' }}
+      #   if: ${{ matrix.rust == '1.65.0' }}
       #   run: |
       #     cargo update -p <crate> --precise <version>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.11.2
+
+Bumped the minimum supported Rust version (MSRV) to 1.65 (Nov 3, 2022).
+([#275][gh-issue-0275])
+
+
 ## Version 0.11.1
 
 ### Fixed
@@ -37,7 +43,7 @@
 
 ## Version 0.10.2
 
-Bumped the minimum supported Rust version (MSRV) to 1.60 (2022-04-07).
+Bumped the minimum supported Rust version (MSRV) to 1.60 (Apr 7, 2022).
 ([#252][gh-issue-0252])
 
 ### Changed
@@ -386,7 +392,7 @@ be frequently changed in next few releases.
 
 ## Version 0.7.2
 
-The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
+The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 
 ### Fixed
 
@@ -660,6 +666,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0275]: https://github.com/moka-rs/moka/pull/275/
 [gh-pull-0272]: https://github.com/moka-rs/moka/pull/272/
 [gh-pull-0268]: https://github.com/moka-rs/moka/pull/268/
 [gh-pull-0259]: https://github.com/moka-rs/moka/pull/259/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "moka"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2018"
-rust-version = "1.60"  # Released on April 7, 2022, supporting 2021 edition.
-
+# Rust 1.65 was released on November 3rd, 2022, is supporting 2021 edition.
+rust-version = "1.65"
 description = "A fast and concurrent cache library inspired by Java Caffeine"
 license = "MIT OR Apache-2.0"
 # homepage = "https://"

--- a/README.md
+++ b/README.md
@@ -437,10 +437,10 @@ section ([`sync::Cache`][doc-sync-cache-expiration],
 
 Moka's minimum supported Rust versions (MSRV) are the followings:
 
-| Feature          | MSRV                     |
-|:-----------------|:------------------------:|
-| default features | Rust 1.60.0 (2022-04-07) |
-| `future`         | Rust 1.60.0 (2022-04-07) |
+| Feature          | MSRV                      |
+|:-----------------|:-------------------------:|
+| default features | Rust 1.65.0 (Nov 3, 2022) |
+| `future`         | Rust 1.65.0 (Nov 3, 2022) |
 
 It will keep a rolling MSRV policy of at least 6 months. If only the default features
 are enabled, MSRV will be updated conservatively. When using other features, like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,10 @@
 //!
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
-//! | Feature          | MSRV                     |
-//! |:-----------------|:------------------------:|
-//! | default features | Rust 1.60.0 (2022-04-07) |
-//! | `future`         | Rust 1.60.0 (2022-04-07) |
+//! | Feature          | MSRV                      |
+//! |:-----------------|:-------------------------:|
+//! | default features | Rust 1.65.0 (Nov 3, 2022) |
+//! | `future`         | Rust 1.65.0 (Nov 3, 2022) |
 //!
 //! It will keep a rolling MSRV policy of at least 6 months. If only the default
 //! features are enabled, MSRV will be updated conservatively. When using other


### PR DESCRIPTION
Change the MSRV from 1.60 to 1.65. Rust 1.65 was released on Nov 3, 2022, seven months ago.

We need Rust 1.65 for the followings:

- #257
    - `std::thread::available_parallelism()` requires 1.64 in order to work reliably on some Linux platforms.
    - We can remove `num_cpus` crate.
- #265
    - Not mandatory, but it uses `if let — else`, which was introduced in 1.65.

Also this PR bumps the `moka` version to v0.11.2.