### PR TITLE
CI: Disable some Cirrus CI jobs to avoid hitting the concurrency limit for community tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,8 +11,9 @@ linux_arm64_task:
     cpu: $NUM_CPUS
     matrix:
       - image: rust:slim  # docker's official latest rust stable version
-      - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
-      - image: rust:1.65.0-slim # MSRV
+      ## Disable jobs for nightly and the MSRV to avoid to hit the concurrency limit.
+      # - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
+      # - image: rust:1.65.0-slim # MSRV
       # no rust-beta image found in docker hub, won't be tested
 
   ## Disable caching as there is no Cargo.lock file in Moka repository.


### PR DESCRIPTION
Since we are on the free plan of Cirrus CI, we often hit the concurrency limit of Cirrus CI for community tasks. Disable CI jobs for Rust nightly and the MSRV.