### PR TITLE
Remove `num_cpus` crate from the dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## Version 0.11.2
 
 Bumped the minimum supported Rust version (MSRV) to 1.65 (Nov 3, 2022).
-([#275][gh-issue-0275])
+([#275][gh-pull-0275])
 
+### Removed
+
+- Removed `num_cpus` crate from the dependency. ([#277][gh-pull-0277])
 
 ## Version 0.11.1
 
@@ -666,6 +669,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0277]: https://github.com/moka-rs/moka/pull/277/
 [gh-pull-0275]: https://github.com/moka-rs/moka/pull/275/
 [gh-pull-0272]: https://github.com/moka-rs/moka/pull/272/
 [gh-pull-0268]: https://github.com/moka-rs/moka/pull/268/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "moka"
 version = "0.11.2"
 edition = "2018"
-# Rust 1.65 was released on November 3rd, 2022, is supporting 2021 edition.
+# Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"
 description = "A fast and concurrent cache library inspired by Java Caffeine"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,6 @@ _core = [
     "crossbeam-channel",
     "crossbeam-epoch",
     "crossbeam-utils",
-    "num_cpus",
     "once_cell",
     "parking_lot",
     "scheduled-thread-pool",
@@ -67,9 +66,6 @@ _core = [
 # The "_core" dependencies used by "sync" and "future" features.
 crossbeam-channel = { version = "0.5.5", optional = true }
 crossbeam-utils = { version = "0.8", optional = true }
-# TODO: Check if we can use `std::thread::available_parallelism` instead. (It was
-# introduced in Rust 1.59)
-num_cpus = { version = "1.13", optional = true }
 once_cell = { version = "1.7", optional = true }
 parking_lot = { version = "0.12", optional = true }
 scheduled-thread-pool = { version = "0.2.7", optional = true }

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -576,10 +576,7 @@ struct Segment<K, V> {
 
 #[cfg(test)]
 fn default_num_segments() -> usize {
-    // Some platforms may return 0. In that case, use 1.
-    // https://github.com/moka-rs/moka/pull/39#issuecomment-916888859
-    // https://github.com/seanmonstar/num_cpus/issues/69
-    num_cpus::get().max(1) * 2
+    crate::common::available_parallelism() * 2
 }
 
 #[cfg(test)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -51,3 +51,8 @@ impl PartialEq<usize> for CacheRegion {
 pub(crate) fn sketch_capacity(max_capacity: u64) -> u32 {
     max_capacity.try_into().unwrap_or(u32::MAX).max(128)
 }
+
+pub(crate) fn available_parallelism() -> usize {
+    use std::{num::NonZeroUsize, thread::available_parallelism};
+    available_parallelism().map(NonZeroUsize::get).unwrap_or(1)
+}

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -69,15 +69,7 @@ impl ThreadPoolRegistry {
                 // and insert a new pool.
                 let mut pools = REGISTRY.pools.write();
                 pools.entry(name).or_insert_with(|| {
-                    // TODO: When we upgrade the MSRV to 1.59 (2022-02-24) or newer,
-                    // replace num_cpus crate with `thread::available_parallelism` in
-                    // std.
-                    //
-                    // NOTE: On some platforms, `num_cpus::get` may return 0. In that
-                    // case, use 1.
-                    // https://github.com/moka-rs/moka/pull/39#issuecomment-916888859
-                    // https://github.com/seanmonstar/num_cpus/issues/69
-                    let num_threads = num_cpus::get().max(1);
+                    let num_threads = crate::common::available_parallelism();
                     let pool = ThreadPool::new(name, num_threads);
                     Arc::new(pool)
                 });


### PR DESCRIPTION
This PR replaces `num_cpus::get()` with `std::thread::available_concurrency()` introduced in Rust 1.59.0. (Fixes #257)

NOTE: `available_concurrency()` requires Rust 1.64.0 or newer to work reliably in some Linux container environment. See the descriptions of #257.
