### PR TITLE
Misc back-port to v0.9.x branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,8 +8,9 @@ linux_arm64_task:
     cpu: $NUM_CPUS
     matrix:
       - image: rust:slim  # docker's official latest rust stable version
-      - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
-      - image: rust:1.51.0-slim # MSRV
+      ## Disable jobs for nightly and the MSRV to avoid to hit the concurrency limit.
+      # - image: rustlang/rust:nightly-slim # nightly hosted by rustlang
+      # - image: rust:1.60.0-slim # MSRV
       # no rust-beta image found in docker hub, won't be tested
 
   ## Disable caching as there is no Cargo.lock file in Moka repository.
@@ -47,18 +48,9 @@ linux_arm64_task:
 
   # Pin some dependencies to specific versions (MSRV only)
   pin_deps_script: |
-    if [ "v$RUST_VERSION" == "v1.51.0" ]; then
+    if [ "v$RUST_VERSION" == "v1.60.0" ]; then
       echo 'Pinning some dependencies to specific versions'
-      rm -f Cargo.lock
-      sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
-      cargo update -p dashmap --precise 5.2.0
-      cargo update -p indexmap --precise 1.8.2
-      cargo update -p hashbrown --precise 0.11.2
-      cargo update -p reqwest --precise 0.11.12
-      cargo update -p native-tls --precise 0.2.8
-      cargo update -p async-global-executor --precise 2.0.4
-      cargo update -p pulldown-cmark --precise 0.9.1
-      cargo update -p once_cell --precise 1.14.0
+      cargo update -p <crate> --precise <version>
     else
       echo 'Skipped'
     fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,13 +47,13 @@ linux_arm64_task:
     fi
 
   # Pin some dependencies to specific versions (MSRV only)
-  pin_deps_script: |
-    if [ "v$RUST_VERSION" == "v1.60.0" ]; then
-      echo 'Pinning some dependencies to specific versions'
-      cargo update -p <crate> --precise <version>
-    else
-      echo 'Skipped'
-    fi
+  # pin_deps_script: |
+  #   if [ "v$RUST_VERSION" == "v1.60.0" ]; then
+  #     echo 'Pinning some dependencies to specific versions'
+  #     cargo update -p <crate> --precise <version>
+  #   else
+  #     echo 'Skipped'
+  #   fi
 
   test_script:
     # Run tests (debug, sync feature)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.51.0  # MSRV
+          - 1.60.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -64,25 +64,10 @@ jobs:
         run: |
           cargo update -p openssl --precise 0.10.39
 
-      - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.51.0' }}
-        # hashbrown >= v0.12 requires Rust 2021 edition.
-        # reqwest >= v0.11.13 requires native-tls v0.2.10.
-        # native-tls >= v0.2.9 requires more recent Rust version.
-        # async-global-executor >= 2.1 requires Rust 2021 edition.
-        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
-        # once_cell >= 1.15.0 requires Rust 2021 edition.
-        run: |
-          rm -f Cargo.lock
-          sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
-          cargo update -p dashmap --precise 5.2.0
-          cargo update -p indexmap --precise 1.8.2
-          cargo update -p hashbrown --precise 0.11.2
-          cargo update -p reqwest --precise 0.11.12
-          cargo update -p native-tls --precise 0.2.8
-          cargo update -p async-global-executor --precise 2.0.4
-          cargo update -p pulldown-cmark --precise 0.9.1
-          cargo update -p once_cell --precise 1.14.0
+      # - name: Pin some dependencies to specific versions (MSRV only)
+      #   if: ${{ matrix.rust == '1.60.0' }}
+      #   run: |
+      #     cargo update -p <crate> --precise <version>
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.51.0  # MSRV
+          - 1.60.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -57,25 +57,10 @@ jobs:
         run: |
           cargo update -p openssl --precise 0.10.39
 
-      - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.51.0' }}
-        # hashbrown >= v0.12 requires Rust 2021 edition.
-        # reqwest >= v0.11.13 requires native-tls v0.2.10.
-        # native-tls >= v0.2.9 requires more recent Rust version.
-        # async-global-executor >= 2.1 requires Rust 2021 edition.
-        # pull-down-cmark >= 0.9.2 requires Rust 2021 edition.
-        # once_cell >= 1.15.0 requires Rust 2021 edition.
-        run: |
-          rm -f Cargo.lock
-          sed -i 's/ahash = ".*"/ahash = "=0.7.6"/g' Cargo.toml
-          cargo update -p dashmap --precise 5.2.0
-          cargo update -p indexmap --precise 1.8.2
-          cargo update -p hashbrown --precise 0.11.2
-          cargo update -p reqwest --precise 0.11.12
-          cargo update -p native-tls --precise 0.2.8
-          cargo update -p async-global-executor --precise 2.0.4
-          cargo update -p pulldown-cmark --precise 0.9.1
-          cargo update -p once_cell --precise 1.14.0
+      # - name: Pin some dependencies to specific versions (MSRV only)
+      #   if: ${{ matrix.rust == '1.60.0' }}
+      #   run: |
+      #     cargo update -p <crate> --precise <version>
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.9.8
+
+Bumped the minimum supported Rust version (MSRV) to 1.60 (Apr 7, 2022).
+([#282][gh-pull-0282])
+
+### Changed
+
+- Upgraded `quanta` crate to v0.11.0. ([#282][gh-pull-0282])
+    - This resolved "[RUSTSEC-2020-0168]: `mach` is unmaintained"
+      ([#243][gh-issue-0243]) by replacing `mach` with `mach2`.
+    - `quanta` v0.11.0's MSRV is 1.60, so we also bumped the MSRV of Moka to 1.60.
+- Update the minimum versions of `scheduled_thread_pool` to v0.2.7 to avoid
+  a deprecation warning. ([#282][gh-pull-0282])
+
+
 ## Version 0.9.7
 
 ### Fixed
@@ -556,6 +571,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0282]: https://github.com/moka-rs/moka/pull/282/
 [gh-pull-0216]: https://github.com/moka-rs/moka/pull/216/
 [gh-pull-0195]: https://github.com/moka-rs/moka/pull/195/
 [gh-pull-0190]: https://github.com/moka-rs/moka/pull/190/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "moka"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2018"
-rust-version = "1.51"
-
+# Rust 1.60 was released on Apr 7, 2022.
+rust-version = "1.60"
 description = "A fast and concurrent cache library inspired by Java Caffeine"
 license = "MIT OR Apache-2.0"
 # homepage = "https://"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ triomphe = { version = "0.1.3", default-features = false }
 
 # Optional dependencies (enabled by default)
 crossbeam-epoch = { version = "0.9.9", optional = true }
-quanta = { version = "0.10.0", optional = true }
+quanta = { version = "0.11.0", optional = true }
 thiserror = { version = "1.0", optional = true }
 uuid = { version = "1.1", features = ["v4"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ crossbeam-utils = "0.8"
 num_cpus = "1.13"
 once_cell = "1.7"
 parking_lot = "0.12"
-scheduled-thread-pool = "0.2.6"
+scheduled-thread-pool = "0.2.7"
 smallvec = "1.8"
 tagptr = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ available on crates.io, such as the [AHash][ahash-crate] crate.
 
 Moka's minimum supported Rust versions (MSRV) are the followings:
 
-| Feature          | MSRV                     |
-|:-----------------|:------------------------:|
-| default features | Rust 1.51.0 (2021-03-25) |
-| `future`         | Rust 1.51.0 (2021-03-25) |
+| Feature          | MSRV                      |
+|:-----------------|:-------------------------:|
+| default features | Rust 1.60.0 (Apr 7, 2022) |
+| `future`         | Rust 1.60.0 (Apr 7, 2022) |
 
 It will keep a rolling MSRV policy of at least 6 months. If only the default features
 are enabled, MSRV will be updated conservatively. When using other features, like
@@ -434,9 +434,7 @@ are enabled, MSRV will be updated conservatively. When using other features, lik
 cases, increasing MSRV is _not_ considered a semver-breaking change.
 
 <!--
-- tagptr 0.2.0 requires 1.51.
-- socket2 0.4.0 requires 1.46.
-- quanta requires 1.45.
+- quanta v0.11.0 requires 1.60.
 -->
 
 

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -409,9 +409,8 @@ impl<'g, K: 'g, V: 'g> BucketArray<K, V> {
         H: BuildHasher,
     {
         // Ensure that the rehashing is not performed concurrently.
-        let lock;
-        match self.rehash_lock.try_lock() {
-            Ok(lk) => lock = lk,
+        let lock = match self.rehash_lock.try_lock() {
+            Ok(lk) => lk,
             Err(TryLockError::WouldBlock) => {
                 // Wait until the lock become available.
                 std::mem::drop(self.rehash_lock.lock());

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -262,7 +262,7 @@ where
             periodical_sync_job: Mutex::new(maybe_sync_job),
             periodical_sync_running,
             on_demand_sync_scheduled: Arc::new(AtomicBool::new(false)),
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 

--- a/src/common/concurrent/thread_pool.rs
+++ b/src/common/concurrent/thread_pool.rs
@@ -35,7 +35,10 @@ pub(crate) struct ThreadPool {
 
 impl ThreadPool {
     fn new(name: PoolName, num_threads: usize) -> Self {
-        let pool = ScheduledThreadPool::with_name(name.thread_name_template(), num_threads);
+        let pool = ScheduledThreadPool::builder()
+            .num_threads(num_threads)
+            .thread_name_pattern(name.thread_name_template())
+            .build();
         Self {
             name,
             pool,

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -108,7 +108,7 @@ impl<T> Deque<T> {
             head: None,
             tail: None,
             cursor: None,
-            marker: PhantomData::default(),
+            marker: PhantomData,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,13 @@
 //!
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
-//! | Feature    | Enabled by default? | MSRV        |
-//! |:-----------|:-------------------:|:-----------:|
-//! | no feature |                     | Rust 1.51.0 |
-//! | `atomic64` |       yes           | Rust 1.51.0 |
-//! | `quanta`   |       yes           | Rust 1.51.0 |
-//! | `future`   |                     | Rust 1.51.0 |
-//! | `dash`     |                     | Rust 1.51.0 |
+//! | Feature    | Enabled by default? | MSRV                      |
+//! |:-----------|:-------------------:|:-------------------------:|
+//! | no feature |                     | Rust 1.60.0 (Apr 7, 2022) |
+//! | `atomic64` |       yes           | Rust 1.60.0 (Apr 7, 2022) |
+//! | `quanta`   |       yes           | Rust 1.60.0 (Apr 7, 2022) |
+//! | `future`   |                     | Rust 1.60.0 (Apr 7, 2022) |
+//! | `dash`     |                     | Rust 1.60.0 (Apr 7, 2022) |
 //!
 //! If only the default features are enabled, MSRV will be updated conservatively.
 //! When using other features, like `future`, MSRV might be updated more frequently,

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -121,7 +121,7 @@ where
             time_to_idle: self.time_to_idle,
             invalidator_enabled: self.invalidator_enabled,
             thread_pool_enabled: self.thread_pool_enabled,
-            cache_type: PhantomData::default(),
+            cache_type: PhantomData,
         }
     }
 

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -307,7 +307,7 @@ impl<K, V, S> ScanContext<K, V, S> {
             result: Mutex::new(None),
             is_running: AtomicBool::new(false),
             is_shutting_down: AtomicBool::new(false),
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 }


### PR DESCRIPTION
Back-port miscellaneous changes from v0.10.x and v0.11.x.

- Bump the minimum supported Rust version (MSRV) to 1.60 (Apr 7, 2022).
    - This is because `quanta` v0.11.0 requires it.
- Upgrade `quanta` to v0.11.0 to resolve [RUSTSEC-2020-0168: mach is unmaintained](https://github.com/moka-rs/moka/issues/243).
    - See #251 for Moka v0.10.2.
- Update the minimum version of `scheduled-thread-pool` to v0.2.7 and replace an usage of a deprecated function.
    - See #241 for Moka v0.10.1.
- Disable some Cirrus CI jobs.
    - See #276 for Moka v0.11.2.

Fix Clippy warnings.