### PR TITLE
Fix Clippy warnings for v0.11.x

### DIFF
--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
+          - toolchain: stable
+          - toolchain: beta
+            rustflags: '--cfg beta_clippy'
 
     steps:
       - name: Checkout Moka
@@ -27,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust.toolchain }}
           override: true
           components: rustfmt, clippy
 
@@ -40,16 +41,15 @@ jobs:
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
-        if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Specify individual features until we remove `dash` feature.
-          # args: --lib --tests --all-features --all-targets -- -D warnings
-          args: --lib --tests --features 'future, logging, unstable-debug-counters' --all-targets -- -D warnings
+          args: --lib --tests --all-features --all-targets -- -D warnings
+        env:
+          RUSTFLAGS: ${{ matrix.rust.rustflags }}
 
       - name: Run Rustfmt
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.rust == 'stable' }}
+        if: ${{ matrix.rust.toolchain == 'stable' }}
         with:
           command: fmt
           args: --all -- --check

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -967,7 +967,7 @@ mod tests {
 
         for result in insert_threads
             .into_iter()
-            .chain(remove_threads.into_iter())
+            .chain(remove_threads)
             .map(|t| t.join())
         {
             assert!(result.is_ok());
@@ -1039,7 +1039,7 @@ mod tests {
 
         for result in insert_threads
             .into_iter()
-            .chain(remove_threads.into_iter())
+            .chain(remove_threads)
             .map(JoinHandle::join)
         {
             assert!(result.is_ok());

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -257,7 +257,7 @@ mod tests {
         let mut sketch = FrequencySketch::default();
         sketch.ensure_capacity(512);
         let mut indexes = std::collections::HashSet::new();
-        let hashes = vec![std::u64::MAX, 0, 1];
+        let hashes = [std::u64::MAX, 0, 1];
         for hash in hashes.iter() {
             for depth in 0..4 {
                 indexes.insert(sketch.index_of(*hash, depth));

--- a/src/notification/notifier.rs
+++ b/src/notification/notifier.rs
@@ -158,9 +158,13 @@ impl<K, V> ThreadPoolRemovalNotifier<K, V> {
             is_running: Default::default(),
             is_shutting_down: Default::default(),
         };
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let state = Arc::new(state);
+
         Self {
             snd,
-            state: Arc::new(state),
+            state,
             thread_pool,
         }
     }

--- a/src/notification/notifier.rs
+++ b/src/notification/notifier.rs
@@ -159,7 +159,7 @@ impl<K, V> ThreadPoolRemovalNotifier<K, V> {
             is_shutting_down: Default::default(),
         };
 
-        #[allow(clippy::arc_with_non_send_sync)]
+        #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
         let state = Arc::new(state);
 
         Self {

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -3208,7 +3208,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -3291,7 +3291,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -3426,7 +3426,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -3565,7 +3565,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -3704,7 +3704,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3843,7 +3843,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3972,7 +3972,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -4101,7 +4101,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -4459,7 +4459,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3] {
+        for t in [thread1, thread2, thread3] {
             t.join().expect("Failed to join");
         }
 

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1471,7 +1471,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -1598,7 +1598,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -1736,7 +1736,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -1865,7 +1865,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -176,6 +176,7 @@ where
         let (r_snd, r_rcv) = crossbeam_channel::bounded(r_size);
         let (w_snd, w_rcv) = crossbeam_channel::bounded(w_size);
 
+        #[allow(clippy::arc_with_non_send_sync)]
         let inner = Arc::new(Inner::new(
             name,
             max_capacity,
@@ -192,12 +193,13 @@ where
         if invalidator_enabled {
             inner.set_invalidator(&inner);
         }
-        let housekeeper = Housekeeper::new(Arc::downgrade(&inner), housekeeper_conf);
+        #[allow(clippy::arc_with_non_send_sync)]
+        let housekeeper = Arc::new(Housekeeper::new(Arc::downgrade(&inner), housekeeper_conf));
         Self {
             inner,
             read_op_ch: r_snd,
             write_op_ch: w_snd,
-            housekeeper: Some(Arc::new(housekeeper)),
+            housekeeper: Some(housekeeper),
         }
     }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -176,7 +176,6 @@ where
         let (r_snd, r_rcv) = crossbeam_channel::bounded(r_size);
         let (w_snd, w_rcv) = crossbeam_channel::bounded(w_size);
 
-        #[allow(clippy::arc_with_non_send_sync)]
         let inner = Arc::new(Inner::new(
             name,
             max_capacity,
@@ -193,13 +192,12 @@ where
         if invalidator_enabled {
             inner.set_invalidator(&inner);
         }
-        #[allow(clippy::arc_with_non_send_sync)]
-        let housekeeper = Arc::new(Housekeeper::new(Arc::downgrade(&inner), housekeeper_conf));
+        let housekeeper = Housekeeper::new(Arc::downgrade(&inner), housekeeper_conf);
         Self {
             inner,
             read_op_ch: r_snd,
             write_op_ch: w_snd,
-            housekeeper: Some(housekeeper),
+            housekeeper: Some(Arc::new(housekeeper)),
         }
     }
 

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -112,6 +112,7 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
+            #[allow(clippy::arc_with_non_send_sync)]
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -112,7 +112,7 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
-            #[allow(clippy::arc_with_non_send_sync)]
+            #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }


### PR DESCRIPTION
- Fix Clippy warnings.
    - clippy 0.1.72 (a47f796a365 2023-07-22)
- Add a cfg flag called `clippy_beta` to allow a lint when Clippy beta is used.
    - This is needed because the same lint is not available in Clippy stable.