### PR TITLE
Fix Cilppy warnings and MSRV CI for v0.10.x

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the MSRV.
+cargo update -p tempfile --precise 3.6.0

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the nightly toolchain.
+cargo update -p openssl --precise 0.10.39
+cargo update -p cc --precise 1.0.61

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,7 +54,7 @@ linux_arm64_task:
   # pin_deps_script: |
   #   if [ "v$RUST_VERSION" == "v1.60.0" ]; then
   #     echo 'Pinning some dependencies to specific versions'
-  #     cargo update -p <crate> --precise <version>
+  #     ./.ci_extras/pin-crate-vers-msrv.sh
   #   else
   #     echo 'Skipped'
   #   fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,14 +61,11 @@ jobs:
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
-        run: |
-          cargo update -p openssl --precise 0.10.39
-          cargo update -p cc --precise 1.0.61
+        run: ./.ci_extras/pin-crate-vers-nightly.sh
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.60.0' }}
-      #   run: |
-      #     cargo update -p <crate> --precise <version>
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.60.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -54,14 +54,11 @@ jobs:
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
-        run: |
-          cargo update -p openssl --precise 0.10.39
-          cargo update -p cc --precise 1.0.61
+        run: ./.ci_extras/pin-crate-vers-nightly.sh
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.60.0' }}
-      #   run: |
-      #     cargo update -p <crate> --precise <version>
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.60.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
+          - toolchain: stable
+          - toolchain: beta
+            rustflags: '--cfg beta_clippy'
 
     steps:
       - name: Checkout Moka
@@ -27,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust.toolchain }}
           override: true
           components: rustfmt, clippy
 
@@ -40,16 +41,17 @@ jobs:
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
-        if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Specify individual features until we remove `dash` feature.
           # args: --lib --tests --all-features --all-targets -- -D warnings
           args: --lib --tests --features 'future, logging, unstable-debug-counters' --all-targets -- -D warnings
+        env:
+          RUSTFLAGS: ${{ matrix.rust.rustflags }}
 
       - name: Run Rustfmt
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.rust == 'stable' }}
+        if: ${{ matrix.rust.toolchain == 'stable' }}
         with:
           command: fmt
           args: --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/moka-rs/moka"
 keywords = ["cache", "concurrent"]
 categories = ["caching", "concurrency"]
 readme = "README.md"
-exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
+exclude = [".ci_extras", ".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 build = "build.rs"
 
 [features]

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -970,7 +970,7 @@ mod tests {
 
         for result in insert_threads
             .into_iter()
-            .chain(remove_threads.into_iter())
+            .chain(remove_threads)
             .map(|t| t.join())
         {
             assert!(result.is_ok());
@@ -1042,7 +1042,7 @@ mod tests {
 
         for result in insert_threads
             .into_iter()
-            .chain(remove_threads.into_iter())
+            .chain(remove_threads)
             .map(JoinHandle::join)
         {
             assert!(result.is_ok());

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -257,7 +257,7 @@ mod tests {
         let mut sketch = FrequencySketch::default();
         sketch.ensure_capacity(512);
         let mut indexes = std::collections::HashSet::new();
-        let hashes = vec![std::u64::MAX, 0, 1];
+        let hashes = [std::u64::MAX, 0, 1];
         for hash in hashes.iter() {
             for depth in 0..4 {
                 indexes.insert(sketch.index_of(*hash, depth));

--- a/src/notification/notifier.rs
+++ b/src/notification/notifier.rs
@@ -158,9 +158,13 @@ impl<K, V> ThreadPoolRemovalNotifier<K, V> {
             is_running: Default::default(),
             is_shutting_down: Default::default(),
         };
+
+        #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
+        let state = Arc::new(state);
+
         Self {
             snd,
-            state: Arc::new(state),
+            state,
             thread_pool,
         }
     }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2706,7 +2706,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -2789,7 +2789,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -2924,7 +2924,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -3063,7 +3063,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -3202,7 +3202,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3341,7 +3341,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3470,7 +3470,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3599,7 +3599,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3957,7 +3957,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3] {
+        for t in [thread1, thread2, thread3] {
             t.join().expect("Failed to join");
         }
 

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1446,7 +1446,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -1573,7 +1573,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -1711,7 +1711,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -1840,7 +1840,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -114,6 +114,7 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
+            #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }


### PR DESCRIPTION
## Fix Clippy warnings

- clippy 0.1.72 (a47f796a365 2023-07-22)
- Add a cfg flag called `clippy_beta` to allow a lint when Clippy beta is used.
    - This is needed because the same lint is not available in Clippy stable.

## Fix CI for the MSRV

- When testing the MSRV (1.60.0) of `moka` 0.10.x, downgrade `tempfile` to v3.6.0 so it will compile.
