### PR TITLE
Fix Cilppy warnings and MSRV CI for v0.9.x

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -3,4 +3,5 @@
 set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
+cargo update -p dashmap --precise 5.4.0
 cargo update -p tempfile --precise 3.6.0

--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the MSRV.
+cargo update -p tempfile --precise 3.6.0

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the nightly toolchain.
+cargo update -p openssl --precise 0.10.39
+cargo update -p cc --precise 1.0.61

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ linux_arm64_task:
   # pin_deps_script: |
   #   if [ "v$RUST_VERSION" == "v1.60.0" ]; then
   #     echo 'Pinning some dependencies to specific versions'
-  #     cargo update -p <crate> --precise <version>
+  #     ./.ci_extras/pin-crate-vers-msrv.sh
   #   else
   #     echo 'Skipped'
   #   fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,13 +61,11 @@ jobs:
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
-        run: |
-          cargo update -p openssl --precise 0.10.39
+        run: ./.ci_extras/pin-crate-vers-nightly.sh
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.60.0' }}
-      #   run: |
-      #     cargo update -p <crate> --precise <version>
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.60.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -54,13 +54,11 @@ jobs:
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
-        run: |
-          cargo update -p openssl --precise 0.10.39
+        run: ./.ci_extras/pin-crate-vers-nightly.sh
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.60.0' }}
-      #   run: |
-      #     cargo update -p <crate> --precise <version>
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.60.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
+          - toolchain: stable
+          - toolchain: beta
+            rustflags: '--cfg beta_clippy'
 
     steps:
       - name: Checkout Moka
@@ -27,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust.toolchain }}
           override: true
           components: rustfmt, clippy
 
@@ -40,14 +41,15 @@ jobs:
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
-        if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --lib --tests --all-features --all-targets -- -D warnings
+        env:
+          RUSTFLAGS: ${{ matrix.rust.rustflags }}
 
       - name: Run Rustfmt
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.rust == 'stable' }}
+        if: ${{ matrix.rust.toolchain == 'stable' }}
         with:
           command: fmt
           args: --all -- --check

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -970,7 +970,7 @@ mod tests {
 
         for result in insert_threads
             .into_iter()
-            .chain(remove_threads.into_iter())
+            .chain(remove_threads)
             .map(|t| t.join())
         {
             assert!(result.is_ok());
@@ -1042,7 +1042,7 @@ mod tests {
 
         for result in insert_threads
             .into_iter()
-            .chain(remove_threads.into_iter())
+            .chain(remove_threads)
             .map(JoinHandle::join)
         {
             assert!(result.is_ok());

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -257,7 +257,7 @@ mod tests {
         let mut sketch = FrequencySketch::default();
         sketch.ensure_capacity(512);
         let mut indexes = std::collections::HashSet::new();
-        let hashes = vec![std::u64::MAX, 0, 1];
+        let hashes = [std::u64::MAX, 0, 1];
         for hash in hashes.iter() {
             for depth in 0..4 {
                 indexes.insert(sketch.index_of(*hash, depth));

--- a/src/notification/notifier.rs
+++ b/src/notification/notifier.rs
@@ -158,9 +158,13 @@ impl<K, V> ThreadPoolRemovalNotifier<K, V> {
             is_running: Default::default(),
             is_shutting_down: Default::default(),
         };
+
+        #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
+        let state = Arc::new(state);
+
         Self {
             snd,
-            state: Arc::new(state),
+            state,
             thread_pool,
         }
     }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2579,7 +2579,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -2661,7 +2661,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -2788,7 +2788,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -3056,7 +3056,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3195,7 +3195,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3324,7 +3324,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3453,7 +3453,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -3811,7 +3811,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3] {
+        for t in [thread1, thread2, thread3] {
             t.join().expect("Failed to join");
         }
 

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1417,7 +1417,7 @@ mod tests {
             })
         };
 
-        for t in vec![thread1, thread2, thread3, thread4, thread5] {
+        for t in [thread1, thread2, thread3, thread4, thread5] {
             t.join().expect("Failed to join");
         }
     }
@@ -1544,7 +1544,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7,
         ] {
             t.join().expect("Failed to join");
@@ -1682,7 +1682,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");
@@ -1811,7 +1811,7 @@ mod tests {
             })
         };
 
-        for t in vec![
+        for t in [
             thread1, thread2, thread3, thread4, thread5, thread6, thread7, thread8,
         ] {
             t.join().expect("Failed to join");

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -114,6 +114,7 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
+            #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }


### PR DESCRIPTION
## Fix Clippy warnings

- clippy 0.1.72 (a47f796a365 2023-07-22)
- Add a cfg flag called `clippy_beta` to allow a lint when Clippy beta is used.
    - This is needed because the same lint is not available in Clippy stable.

## Fix CI for the MSRV

When testing the MSRV (1.60.0) of `moka` 0.10.x, downgrade the following crates, so they will compile:

- Downgrade `dashmap` to v5.4.0
- Downgrade `tempfile` to v3.6.0.
