### PR TITLE
Remove the thread pool from `future::Cache`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
         "Hasher",
         "Kawano",
         "mapref",
+        "Miri",
         "Moka",
         "mpsc",
         "MSRV",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.0 (Currently Beta)
+
+**IMPORTANT**: This release has major breaking changes.
+
+- `future::Cache`
+    - The thread pool was removed from `future::Cache`. It no longer spawns
+      background threads.
+    - The `notification::DeliveryMode` for eviction listener was changed from
+      `Queued` to `Immediate`.
+    - To support these changes, some of the APIs were changed. Please see the
+      [MIGRATION-GUIDE.md](./MIGRATION-GUIDE.md#migrating-to-v0120-from-a-prior-version)
+      for more details.
+- `sync::Cache` and `sync::SegmentedCache`
+    - As of 0.12.0-beta.1, no breaking changes have been made to these caches.
+    - However, the future beta releases will have the following changes:
+        - (Not in 0.12.0-beta.1) `sync` caches will be no longer enabled by default.
+          Use a crate feature `sync` to enable it.
+        - (Not in 0.12.0-beta.1) The thread pool will be disabled by default.
+
+### Changed
+
+- Remove the thread pool from `future::Cache`. ([#294][gh-pull-0294])
+- Add support for `Immediate` notification delivery mode to future cache.
+ ([#228][gh-issue-0228])
+
+
 ## Version 0.11.3
 
 ### Fixed
@@ -671,6 +697,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0243]: https://github.com/moka-rs/moka/issues/243/
 [gh-issue-0242]: https://github.com/moka-rs/moka/issues/242/
 [gh-issue-0230]: https://github.com/moka-rs/moka/issues/230/
+[gh-issue-0228]: https://github.com/moka-rs/moka/issues/228/
 [gh-issue-0212]: https://github.com/moka-rs/moka/issues/212/
 [gh-issue-0207]: https://github.com/moka-rs/moka/issues/207/
 [gh-issue-0162]: https://github.com/moka-rs/moka/issues/162/
@@ -686,6 +713,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
 [gh-pull-0295]: https://github.com/moka-rs/moka/pull/295/
+[gh-pull-0294]: https://github.com/moka-rs/moka/pull/294/
 [gh-pull-0277]: https://github.com/moka-rs/moka/pull/277/
 [gh-pull-0275]: https://github.com/moka-rs/moka/pull/275/
 [gh-pull-0272]: https://github.com/moka-rs/moka/pull/272/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ quanta = { version = "0.11.0", optional = true }
 scheduled-thread-pool = { version = "0.2.7", optional = true }
 
 # Optional dependencies (future)
-async-io = { version = "1.4", optional = true }
 async-lock = { version = "2.4", optional = true }
 async-trait = { version = "0.1.58", optional = true }
 futures-util = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.0"
+version = "0.12.0-beta.1"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["sync", "atomic64", "quanta"]
 sync = ["_core"]
 
 # Enable this feature to use `moka::future::Cache`.
-future = ["_core", "async-io", "async-lock", "futures-util"]
+future = ["_core", "async-io", "async-lock", "async-trait", "futures-util"]
 
 # Enable this feature to activate optional logging from caches.
 # Currently cache will emit log only when it encounters a panic in user provided
@@ -85,6 +85,7 @@ uuid = { version = "1.1", features = ["v4"], optional = true }
 # Optional dependencies (future)
 async-io = { version = "1.4", optional = true }
 async-lock = { version = "2.4", optional = true }
+async-trait = { version = "0.1.58", optional = true }
 futures-util = { version = "0.3", optional = true }
 
 # Optional dependencies (logging)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ futures-util = { version = "0.3", optional = true }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]
-actix-rt = { version = "2.7", default-features = false }
+actix-rt = "2.8"
 ahash = "0.8.3"
 anyhow = "1.0.19"
 async-std = { version = "1.11", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["sync", "atomic64", "quanta"]
 sync = ["_core"]
 
 # Enable this feature to use `moka::future::Cache`.
-future = ["_core", "async-io", "async-lock", "async-trait", "futures-util"]
+future = ["_core", "async-lock", "async-trait", "futures-util"]
 
 # Enable this feature to activate optional logging from caches.
 # Currently cache will emit log only when it encounters a panic in user provided

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ scheduled-thread-pool = { version = "0.2.7", optional = true }
 # Optional dependencies (future)
 async-lock = { version = "2.4", optional = true }
 async-trait = { version = "0.1.58", optional = true }
-futures-util = { version = "0.3", optional = true }
+futures-util = { version = "0.3.17", optional = true }
 
 # Optional dependencies (logging)
 log = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ default = ["sync", "atomic64", "quanta"]
 
 # This feature is enabled by default. Disable it when you do not need
 # `moka::sync::{Cache, SegmentedCache}`
-sync = ["_core"]
+sync = ["scheduled-thread-pool"]
 
 # Enable this feature to use `moka::future::Cache`.
-future = ["_core", "async-lock", "async-trait", "futures-util"]
+future = ["async-lock", "async-trait", "futures-util"]
 
 # Enable this feature to activate optional logging from caches.
 # Currently cache will emit log only when it encounters a panic in user provided
@@ -46,41 +46,26 @@ js = ["uuid/js"]
 # performance impacts and is intended for debugging purpose.
 unstable-debug-counters = ["future"]
 
-# A feature used internally.
-_core = [
-    "crossbeam-channel",
-    "crossbeam-epoch",
-    "crossbeam-utils",
-    "once_cell",
-    "parking_lot",
-    "scheduled-thread-pool",
-    "smallvec",
-    "tagptr",
-    "thiserror",
-    "triomphe",
-    "uuid",
-]
-
 [dependencies]
-
-# The "_core" dependencies used by "sync" and "future" features.
-crossbeam-channel = { version = "0.5.5", optional = true }
-crossbeam-utils = { version = "0.8", optional = true }
-once_cell = { version = "1.7", optional = true }
-parking_lot = { version = "0.12", optional = true }
-scheduled-thread-pool = { version = "0.2.7", optional = true }
-smallvec = { version = "1.8", optional = true }
-tagptr = { version = "0.2", optional = true }
+crossbeam-channel = { version = "0.5.5" }
+crossbeam-epoch = { version = "0.9.9" }
+crossbeam-utils = { version = "0.8" }
+once_cell = { version = "1.7" }
+parking_lot = { version = "0.12" }
+smallvec = { version = "1.8" }
+tagptr = { version = "0.2" }
+thiserror = { version = "1.0" }
+uuid = { version = "1.1", features = ["v4"] }
 
 # Opt-out serde and stable_deref_trait features
 # https://github.com/Manishearth/triomphe/pull/5
-triomphe = { version = "0.1.3", default-features = false, optional = true }
+triomphe = { version = "0.1.3", default-features = false }
 
 # Optional dependencies (enabled by default)
-crossbeam-epoch = { version = "0.9.9", optional = true }
 quanta = { version = "0.11.0", optional = true }
-thiserror = { version = "1.0", optional = true }
-uuid = { version = "1.1", features = ["v4"], optional = true }
+
+# Optional dependencies (sync)
+scheduled-thread-pool = { version = "0.2.7", optional = true }
 
 # Optional dependencies (future)
 async-io = { version = "1.4", optional = true }

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -7,7 +7,7 @@ describes the code changes required to migrate to v0.12.0.
 
 ### `future::Cache`
 
-- The thread pool was removed from `future::Cache`. The background threads are It no
+- The thread pool was removed from `future::Cache`. The background threads are no
   longer spawned.
 - The `notification::DeliveryMode` for eviction listener was changed from `Queued` to
   `Immediate`.
@@ -36,7 +36,7 @@ The following internal behavior changes were made:
    - See [Maintenance tasks](#maintenance-tasks) for more details.
 2. Now `future::Cache` only supports `Immediate` delivery mode for eviction listener.
    - In older versions, only `Queued` delivery mode was supported.
-       - If you need `Queued` delivery mode back, please file an issue.
+   - If you need `Queued` delivery mode back, please file an issue.
 
 #### Replacing the blocking API
 
@@ -114,9 +114,11 @@ async fn main() {
 
 #### Updating the eviction listener
 
-`eviction_listener_with_queued_delivery_mode` method of `future::CacheBuilder` was
-removed. Please use one of the new methods `eviction_listener` or
-`async_eviction_listener` instead.
+- The `notification::DeliveryMode` for eviction listener was changed from `Queued` to
+  `Immediate`.
+- `eviction_listener_with_queued_delivery_mode` method of `future::CacheBuilder` was
+  removed. Please use one of the new methods `eviction_listener` or
+  `async_eviction_listener` instead.
 
 ##### `eviction_listener` method
 

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -7,8 +7,8 @@ describes the code changes required to migrate to v0.12.0.
 
 ### `future::Cache`
 
-- The thread pool was removed from `future::Cache`. It no longer spawns background
-  threads.
+- The thread pool was removed from `future::Cache`. The background threads are It no
+  longer spawned.
 - The `notification::DeliveryMode` for eviction listener was changed from `Queued` to
   `Immediate`.
 
@@ -26,8 +26,8 @@ To support these changes, the following API changes were made:
      `async_eviction_listener` instead.
    - See [Updating the eviction listener](#updating-the-eviction-listener) for more
      details.
-5. `future::ConcurrentCacheExt::sync` method is renamed to
-   `future::Cache::run_pending_tasks`. It is also changed to `async fn`.
+5. `future::ConcurrentCacheExt::sync` method was renamed to
+   `future::Cache::run_pending_tasks`. It was also changed to `async fn`.
 
 The following internal behavior changes were made:
 
@@ -156,7 +156,7 @@ use moka::notification::ListenerFuture;
 // FutureExt trait provides the boxed method.
 use moka::future::FutureExt;
 
-let listener = move |k, v: PathBuf, cause| -> ListenerFuture {
+let eviction_listener = move |k, v: PathBuf, cause| -> ListenerFuture {
     println!(
         "\n== An entry has been evicted. k: {:?}, v: {:?}, cause: {:?}",
         k, v, cause
@@ -183,7 +183,7 @@ let listener = move |k, v: PathBuf, cause| -> ListenerFuture {
 let cache = Cache::builder()
     .max_capacity(100)
     .time_to_live(Duration::from_secs(2))
-    .async_eviction_listener(listener)
+    .async_eviction_listener(eviction_listener)
     .build();
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ high level of concurrency for concurrent access.
 
 - Thread-safe, highly concurrent in-memory cache implementations:
     - Synchronous caches that can be shared across OS threads.
-    - An asynchronous (futures aware) cache that can be accessed inside and outside
-      of asynchronous contexts.
+    - An asynchronous (futures aware) cache.
 - A cache can be bounded by one of the followings:
     - The maximum number of entries.
     - The total weighted size of entries. (Size aware eviction)
@@ -529,12 +528,15 @@ $ cargo +nightly -Z unstable-options --config 'build.rustdocflags="--cfg docsrs"
 - [x] Variable (per-entry) expiration, using a hierarchical timer wheel.
   (`v0.11.0` via [#248][gh-pull-248])
 - [ ] Cache statistics. (Hit rate, etc.)
+- [x] Remove background threads. (`v0.12.0` via [#294][gh-pull-294] and [#???][gh-pull-qqq])
 - [ ] Upgrade TinyLFU to Window-TinyLFU. ([details][tiny-lfu])
 
 [gh-pull-024]: https://github.com/moka-rs/moka/pull/24
 [gh-pull-105]: https://github.com/moka-rs/moka/pull/105
 [gh-pull-145]: https://github.com/moka-rs/moka/pull/145
 [gh-pull-248]: https://github.com/moka-rs/moka/pull/248
+[gh-pull-294]: https://github.com/moka-rs/moka/pull/294
+[gh-pull-qqq]: https://github.com/moka-rs/moka/pull/qqq
 
 
 ## About the Name

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and can be overkill for your use case. Sometimes simpler caches like
 
 The following table shows the trade-offs between the different cache implementations:
 
-| Feature | Moka v0.11 | Mini Moka v0.10 | Quick Cache v0.3 |
+| Feature | Moka v0.12 | Mini Moka v0.10 | Quick Cache v0.3 |
 |:------- |:---- |:--------- |:----------- |
 | Thread-safe, sync cache | ✅ | ✅ | ✅ |
 | Thread-safe, async cache | ✅ | ❌ | ✅ |
@@ -82,10 +82,10 @@ The following table shows the trade-offs between the different cache implementat
 | Lock-free, concurrent iterator | ✅ | ❌ | ❌ |
 | Lock-per-shard, concurrent iterator | ❌ | ✅ | ❌ |
 
-| Performance, etc. | Moka v0.11 | Mini Moka v0.10 | Quick Cache v0.3 |
+| Performance, etc. | Moka v0.12 | Mini Moka v0.10 | Quick Cache v0.3 |
 |:------- |:---- |:--------- |:----------- |
 | Small overhead compared to a concurrent hash table | ❌ | ❌ | ✅ |
-| Does not use background threads | ❌ Will be removed from v0.12 or v0.13 | ✅ | ✅ |
+| Does not use background threads | ❌ → ✅ Removed from v0.12 | ✅ | ✅ |
 | Small dependency tree | ❌ | ✅ | ✅ |
 
 [tiny-lfu]: https://github.com/moka-rs/moka/wiki#admission-and-eviction-policies
@@ -154,14 +154,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-moka = "0.11"
+moka = "0.12"
 ```
 
 To use the asynchronous cache, enable a crate feature called "future".
 
 ```toml
 [dependencies]
-moka = { version = "0.11", features = ["future"] }
+moka = { version = "0.12", features = ["future"] }
 ```
 
 
@@ -270,7 +270,7 @@ Here is a similar program to the previous example, but using asynchronous cache 
 // Cargo.toml
 //
 // [dependencies]
-// moka = { version = "0.11", features = ["future"] }
+// moka = { version = "0.12", features = ["future"] }
 // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 // futures-util = "0.3"
 
@@ -304,7 +304,7 @@ async fn main() {
                     // insert() is an async method, so await it.
                     my_cache.insert(key, value(key)).await;
                     // get() returns Option<String>, a clone of the stored value.
-                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                    assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
@@ -322,9 +322,9 @@ async fn main() {
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
         if key % 4 == 0 {
-            assert_eq!(cache.get(&key), None);
+            assert_eq!(cache.get(&key).await, None);
         } else {
-            assert_eq!(cache.get(&key), Some(value(key)));
+            assert_eq!(cache.get(&key).await, Some(value(key)));
         }
     }
 }
@@ -482,9 +482,9 @@ to the dependency declaration.
 
 ```toml:Cargo.toml
 [dependencies]
-moka = { version = "0.11", default-features = false, features = ["sync"] }
+moka = { version = "0.12", default-features = false, features = ["sync"] }
 # Or
-moka = { version = "0.11", default-features = false, features = ["future"] }
+moka = { version = "0.12", default-features = false, features = ["future"] }
 ```
 
 This will make Moka to switch to a fall-back implementation, so it will compile.

--- a/doc/migration-guide.md
+++ b/doc/migration-guide.md
@@ -1,0 +1,66 @@
+# Moka Cache &mdash; Migration Guide
+
+## Migrating to Moka v0.12
+
+Moka v0.12 had major breaking changes on the API and internal behavior.
+
+### `future::Cache`
+
+The thread-pool was removed from `future::Cache`.
+
+It caused the following API changes:
+
+1. `future::Cache::get` method is now `async fn`, so you must `.await` the result.
+2. `future::Cache::blocking()` method was removed.
+   - Use async runtime's blocking API instead.
+   - See [Replacing the Blocking API](#replacing-the-blocking-api) for more details.
+3. Now `or_insert_with_if` method of the entry API requires `Send` bound for the
+   `replace_if` closure.
+4. `future::CacheBuilder::eviction_listener_with_queued_delivery_mode` was removed.
+   - Use `future::CacheBuilder::eviction_listener` instead.
+5. The signature of eviction listener closure was changed. Now it should return
+   `future::ListenerFuture` instead of `()`.
+   - `ListenerFuture` is a type alias of `Pin<Box<dyn Future<Output = ()> + Send>>`.
+   - See [Updating the Eviction Listener](#updating-the-eviction-listener) for more
+     details.
+6. **TODO** `future::ConcurrentCacheExt::sync` is renamed to `future::Cache::flush`
+   and became `async fn`.
+
+Removing the thread-pool caused the following internal behavior changes:
+
+1. Housekeeping tasks such as evictions (removing expired entries) may not be
+   executed periodically anymore.
+   - See [Housekeeping Tasks](#housekeeping-tasks) for more details.
+2. Now `future::Cache` only supports `Immediate` delivery mode for eviction listener.
+   - With older versions, it only supported `Queued` delivery mode.
+   - If you need `Queued` delivery mode back, please file an issue.
+   - See [Updating the Eviction Listener](#updating-the-eviction-listener) for more
+     details.
+
+#### Replacing the Blocking API
+
+TODO
+
+#### Updating the Eviction Listener
+
+TODO
+
+#### Housekeeping Tasks
+
+Housekeeping are now executed only when certain cache APIs are called:
+
+- Cache writes: `insert`, `get_with`, `invalidate`, etc.
+- `get`
+- `flush`
+
+You can manually trigger the tasks by calling `flush` method.
+
+Housekeeping tasks include:
+
+TODO
+
+
+### `sync::Cache` and `sync::SegmentedCache`
+
+1. `sync` module is no longer enabled by default. Use `sync` feature to enable it.
+2. ... **TODO**

--- a/doc/migration-guide.md
+++ b/doc/migration-guide.md
@@ -1,66 +1,128 @@
 # Moka Cache &mdash; Migration Guide
 
-## Migrating to Moka v0.12
+## Migrating to v0.12 from a prior version
 
-Moka v0.12 had major breaking changes on the API and internal behavior.
+v0.12.0 has major breaking changes on the API and internal behavior. This section
+walks you through ...
 
 ### `future::Cache`
 
-The thread-pool was removed from `future::Cache`.
+- The thread pool was removed from `future::Cache`. It no longer spawns background
+  threads.
+- The `notification::DeliveryMode` for eviction listener was changed from `Queued` to
+  `Immediate`.
 
-It caused the following API changes:
+To support these changes, the following API changes were made:
 
-1. `future::Cache::get` method is now `async fn`, so you must `.await` the result.
-2. `future::Cache::blocking()` method was removed.
-   - Use async runtime's blocking API instead.
-   - See [Replacing the Blocking API](#replacing-the-blocking-api) for more details.
+1. `future::Cache::get` method is now `async fn`, so you must `await` for the result.
+2. `future::Cache::blocking` method was removed.
+   - You need to use async runtime's blocking API instead.
+   - See [Replacing the blocking API](#replacing-the-blocking-api) for more details.
 3. Now `or_insert_with_if` method of the entry API requires `Send` bound for the
    `replace_if` closure.
-4. `future::CacheBuilder::eviction_listener_with_queued_delivery_mode` was removed.
-   - Use `future::CacheBuilder::eviction_listener` instead.
-5. The signature of eviction listener closure was changed. Now it should return
+4. `future::CacheBuilder::eviction_listener_with_queued_delivery_mode` method was
+   removed.
+   - You need to use a new method `future::CacheBuilder::eviction_listener` instead.
+5. The signature of the eviction listener closure was changed. Now it should return
    `future::ListenerFuture` instead of `()`.
    - `ListenerFuture` is a type alias of `Pin<Box<dyn Future<Output = ()> + Send>>`.
-   - See [Updating the Eviction Listener](#updating-the-eviction-listener) for more
+   - See [Updating the eviction listener](#updating-the-eviction-listener) for more
      details.
-6. **TODO** `future::ConcurrentCacheExt::sync` is renamed to `future::Cache::flush`
-   and became `async fn`.
+6. `future::ConcurrentCacheExt::sync` method is renamed to
+   `future::Cache::run_pending_tasks`. It also changed to `async fn`.
 
-Removing the thread-pool caused the following internal behavior changes:
+The following internal behavior changes were made:
 
-1. Housekeeping tasks such as evictions (removing expired entries) may not be
-   executed periodically anymore.
-   - See [Housekeeping Tasks](#housekeeping-tasks) for more details.
+1. Maintenance tasks such as removing expired entries are not executed periodically
+   anymore.
+   - See [Maintenance tasks](#maintenance-tasks) for more details.
 2. Now `future::Cache` only supports `Immediate` delivery mode for eviction listener.
-   - With older versions, it only supported `Queued` delivery mode.
-   - If you need `Queued` delivery mode back, please file an issue.
-   - See [Updating the Eviction Listener](#updating-the-eviction-listener) for more
+   - In older versions, only `Queued` delivery mode was supported.
+       - If you need `Queued` delivery mode back, please file an issue.
+   - See [Updating the eviction listener](#updating-the-eviction-listener) for more
      details.
 
-#### Replacing the Blocking API
 
-TODO
+#### Replacing the blocking API
 
-#### Updating the Eviction Listener
+`future::Cache::blocking` method was removed. You need to use async runtime's
+blocking API instead.
 
-TODO
+**Tokio**
 
-#### Housekeeping Tasks
+```rust
 
-Housekeeping are now executed only when certain cache APIs are called:
+```
 
-- Cache writes: `insert`, `get_with`, `invalidate`, etc.
-- `get`
-- `flush`
+**async-std**
 
-You can manually trigger the tasks by calling `flush` method.
+```rust
 
-Housekeeping tasks include:
+```
 
-TODO
+**actix-rt**
+
+```rust
+
+```
+
+#### Updating the eviction listener
+
+The signature of the eviction listener closure was changed. Now it should return
+`future::ListenerFuture` instead of `()`. It is a type alias of
+`Pin<Box<dyn Future<Output = ()> + Send>>`.
+
+```rust
+
+```
+
+#### Maintenance tasks
+
+In older versions, the maintenance tasks needed by the cache were periodically
+executed in background by a global thread pool managed by `moka`. Now `future::Cache`
+does not use the thread pool anymore. Instead, those maintenance tasks are executed
+_sometimes_ in foreground when certain cache methods (`get`, `get_with`, `insert`,
+etc.) are called by user code.
+
+These maintenance tasks include:
+
+![The lifecycle of cached entries](https://github.com/moka-rs/moka/wiki/images/benchmarks/moka-tiny-lfu.png)
+
+1. Determine whether to admit a "temporary admitted" entry or not.
+2. Apply the recording of cache reads and writes to the internal data structures,
+   such as LFU filter, LRU queues, and timer wheels.
+3. Remove expired entries.
+4. Remove entries that have been invalidated by `invalidate_all` or
+   `invalidate_entries_if` methods.
+5. Deliver removal notifications to the eviction listener.
+
+They will be executed in the following cache methods when necessary:
+
+- All cache write methods: `insert`, `get_with`, `invalidate`, etc.
+- Some of the cache read methods: `get`
+- `run_pending_tasks` method, which executes the pending maintenance tasks
+  explicitly.
 
 
 ### `sync::Cache` and `sync::SegmentedCache`
 
-1. `sync` module is no longer enabled by default. Use `sync` feature to enable it.
-2. ... **TODO**
+1. `sync` module is no longer enabled by default. Use a crate feature `sync` to
+   enable it.
+2. The thread pool is disabled by default.
+   - In older versions, the thread pool was used to execute maintenance tasks in
+     background.
+   - When disabled:
+      - those maintenance tasks are executed _sometimes_ in foreground when certain
+        cache methods (`get`, `get_with`, `insert`, etc.) are called by user code
+      -  See [Maintenance tasks](#maintenance-tasks) for more details.
+   - To enable it, see [Enabling the thread pool](#enabling-the-thread-pool) for more
+     details.
+
+
+#### Enabling the thread pool
+
+To enable the thread pool, do the followings:
+
+- Specify a crate feature `thread-pool`.
+- Call ... at the cache build time.
+

--- a/doc/migration-guide.md
+++ b/doc/migration-guide.md
@@ -16,19 +16,17 @@ To support these changes, the following API changes were made:
 
 1. `future::Cache::get` method is now `async fn`, so you must `await` for the result.
 2. `future::Cache::blocking` method was removed.
-   - You need to use async runtime's blocking API instead.
+   - Please use async runtime's blocking API instead.
    - See [Replacing the blocking API](#replacing-the-blocking-api) for more details.
 3. Now `or_insert_with_if` method of the entry API requires `Send` bound for the
    `replace_if` closure.
 4. `future::CacheBuilder::eviction_listener_with_queued_delivery_mode` method was
    removed.
-   - You need to use a new method `future::CacheBuilder::eviction_listener` instead.
-5. The signature of the eviction listener closure was changed. Now it should return
-   `future::ListenerFuture` instead of `()`.
-   - `ListenerFuture` is a type alias of `Pin<Box<dyn Future<Output = ()> + Send>>`.
+   - Please use one of the new methods `eviction_listener` or
+     `async_eviction_listener` instead.
    - See [Updating the eviction listener](#updating-the-eviction-listener) for more
      details.
-6. `future::ConcurrentCacheExt::sync` method is renamed to
+5. `future::ConcurrentCacheExt::sync` method is renamed to
    `future::Cache::run_pending_tasks`. It also changed to `async fn`.
 
 The following internal behavior changes were made:
@@ -50,31 +48,146 @@ blocking API instead.
 
 **Tokio**
 
-```rust
+1. Call `tokio::runtime::Handle::current()` in async context to obtain a handle to
+   the current Tokio runtime.
+2. From outside async context, call cache's async function using `block_on` method of
+   the runtime.
 
+```rust
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() {
+    // Create a future cache.
+    let cache = Arc::new(moka::future::Cache::new(100));
+
+    // In async context, you can obtain a handle to the current Tokio runtime.
+    let rt = tokio::runtime::Handle::current();
+
+    // Spawn an OS thread. Pass the handle and cache.
+    let thread = {
+        let cache = Arc::clone(&cache);
+
+        std::thread::spawn(move || {
+            // Call async function using block_on method of Tokio runtime.
+            rt.block_on(cache.insert(0, 'a'));
+        })
+    };
+
+    // Wait for the threads to complete.
+    thread.join().unwrap();
+
+    // Check the result.
+    assert_eq!(cache.get(&0).await, Some('a'));
+}
 ```
 
 **async-std**
 
-```rust
-
-```
-
-**actix-rt**
+- From outside async context, call cache's async function using
+  `async_std::task::block_on` method.
 
 ```rust
+use std::sync::Arc;
 
+#[async_std::main]
+async fn main() {
+    // Create a future cache.
+    let cache = Arc::new(moka::future::Cache::new(100));
+
+    // Spawn an OS thread. Pass the cache.
+    let thread = {
+        let cache = Arc::clone(&cache);
+
+        std::thread::spawn(move || {
+            use async_std::task::block_on;
+
+            // Call async function using block_on method of async_std.
+            block_on(cache.insert(0, 'a'));
+        })
+    };
+
+    // Wait for the threads to complete.
+    thread.join().unwrap();
+
+    // Check the result.
+    assert_eq!(cache.get(&0).await, Some('a'));
+}
 ```
 
 #### Updating the eviction listener
 
-The signature of the eviction listener closure was changed. Now it should return
-`future::ListenerFuture` instead of `()`. It is a type alias of
-`Pin<Box<dyn Future<Output = ()> + Send>>`.
+`future::CacheBuilder::eviction_listener_with_queued_delivery_mode` method was
+removed. Please use one of the new methods `eviction_listener` or
+`async_eviction_listener` instead.
+
+##### `eviction_listener` method
+
+`eviction_listener` takes the same closure as the old method. If you do not need to
+`.await` anything in the eviction listener, use this method.
+
+This code snippet is borrowed from [an example][listener-ex1] in the document of `future::Cache`.
 
 ```rust
+let eviction_listener = |key, _value, cause| {
+    println!("Evicted key {key}. Cause: {cause:?}");
+};
 
+let cache = Cache::builder()
+    .max_capacity(100)
+    .expire_after(expiry)
+    .eviction_listener(eviction_listener)
+    .build();
 ```
+
+[listener-ex1]: https://docs.rs/moka/latest/moka/future/struct.Cache.html#per-entry-expiration-policy
+
+##### `async_eviction_listener` method
+
+`async_eviction_listener` takes a closure that returns a `Future`. If you need to
+`.await` something in the eviction listener, use this method. The actual return type
+of the closure is `future::ListenerFuture`, which is a type alias of
+`Pin<Box<dyn Future<Output = ()> + Send>>`. You can use the `boxed` method of
+`future::FutureExt` trait to convert a regular `Future` into this type.
+
+This code snippet is borrowed from [an example][listener-ex2] in the document of `future::Cache`.
+
+```rust
+use moka::{future::{Cache, FutureExt}, notification::ListenerFuture};
+
+let listener = move |k, v: PathBuf, cause| -> ListenerFuture {
+    // Try to remove the data file at the path `v`.
+    println!(
+        "\n== An entry has been evicted. k: {:?}, v: {:?}, cause: {:?}",
+        k, v, cause
+    );
+    let file_mgr2 = Arc::clone(&file_mgr1);
+
+    // Create a Future that removes the data file.
+    async move {
+        // Acquire the write lock of the DataFileManager.
+        let mut mgr = file_mgr2.write().await;
+        // Remove the data file. We must handle error cases here to
+        // prevent the listener from panicking.
+        if let Err(_e) = mgr.remove_data_file(v.as_path()).await {
+            eprintln!("Failed to remove a data file at {:?}", v);
+        }
+    }
+    // Convert the regular Future into ListenerFuture. This method is
+    // provided by moka::future::FutureExt trait.
+    .boxed()
+};
+
+// Create the cache. Set time to live for two seconds and set the
+// eviction listener.
+let cache = Cache::builder()
+    .max_capacity(100)
+    .time_to_live(Duration::from_secs(2))
+    .async_eviction_listener(listener)
+    .build();
+```
+
+[listener-ex1]: https://docs.rs/moka/latest/moka/future/struct.Cache.html#example-eviction-listener
 
 #### Maintenance tasks
 
@@ -84,9 +197,11 @@ does not use the thread pool anymore. Instead, those maintenance tasks are execu
 _sometimes_ in foreground when certain cache methods (`get`, `get_with`, `insert`,
 etc.) are called by user code.
 
-These maintenance tasks include:
-
 ![The lifecycle of cached entries](https://github.com/moka-rs/moka/wiki/images/benchmarks/moka-tiny-lfu.png)
+
+Figure 1. The lifecycle of cached entries
+
+These maintenance tasks include:
 
 1. Determine whether to admit a "temporary admitted" entry or not.
 2. Apply the recording of cache reads and writes to the internal data structures,

--- a/examples/async_example.rs
+++ b/examples/async_example.rs
@@ -28,7 +28,7 @@ async fn main() {
                     // insert() is an async method, so await it.
                     my_cache.insert(key, value(key)).await;
                     // get() returns Option<String>, a clone of the stored value.
-                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                    assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
@@ -46,9 +46,9 @@ async fn main() {
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
         if key % 4 == 0 {
-            assert_eq!(cache.get(&key), None);
+            assert_eq!(cache.get(&key).await, None);
         } else {
-            assert_eq!(cache.get(&key), Some(value(key)));
+            assert_eq!(cache.get(&key).await, Some(value(key)));
         }
     }
 }

--- a/src/cht.rs
+++ b/src/cht.rs
@@ -74,6 +74,9 @@
 pub(crate) mod map;
 pub(crate) mod segment;
 
+#[cfg(feature = "future")]
+pub(crate) mod iter;
+
 #[cfg(test)]
 #[macro_use]
 pub(crate) mod test_util;

--- a/src/cht/iter.rs
+++ b/src/cht/iter.rs
@@ -1,0 +1,103 @@
+use std::hash::Hash;
+
+pub(crate) trait ScanningGet<K, V>
+where
+    K: Clone,
+    V: Clone,
+{
+    /// Returns a _clone_ of the value corresponding to the key.
+    fn scanning_get(&self, key: &K) -> Option<V>;
+
+    /// Returns a vec of keys in a specified segment of the concurrent hash table.
+    fn keys(&self, cht_segment: usize) -> Option<Vec<K>>;
+}
+
+pub(crate) struct Iter<'i, K, V> {
+    keys: Option<Vec<K>>,
+    map: &'i dyn ScanningGet<K, V>,
+    num_segments: usize,
+    seg_index: usize,
+    is_done: bool,
+}
+
+impl<'i, K, V> Iter<'i, K, V> {
+    pub(crate) fn with_single_cache_segment(
+        map: &'i dyn ScanningGet<K, V>,
+        num_segments: usize,
+    ) -> Self {
+        Self {
+            keys: None,
+            map,
+            num_segments,
+            seg_index: 0,
+            is_done: false,
+        }
+    }
+}
+
+impl<'i, K, V> Iterator for Iter<'i, K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_done {
+            return None;
+        }
+
+        while let Some(key) = self.next_key() {
+            if let Some(v) = self.map.scanning_get(&key) {
+                return Some((key, v));
+            }
+        }
+
+        self.is_done = true;
+        None
+    }
+}
+
+impl<'i, K, V> Iter<'i, K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn next_key(&mut self) -> Option<K> {
+        while let Some(keys) = self.current_keys() {
+            if let key @ Some(_) = keys.pop() {
+                return key;
+            }
+        }
+        None
+    }
+
+    fn current_keys(&mut self) -> Option<&mut Vec<K>> {
+        // If keys is none or some but empty, try to get next keys.
+        while self.keys.as_ref().map_or(true, Vec::is_empty) {
+            // Adjust indices.
+            if self.seg_index >= self.num_segments {
+                return None;
+            }
+
+            self.keys = self.map.keys(self.seg_index);
+            self.seg_index += 1;
+        }
+
+        self.keys.as_mut()
+    }
+}
+
+unsafe impl<'a, 'i, K, V> Send for Iter<'i, K, V>
+where
+    K: 'a + Eq + Hash + Send,
+    V: 'a + Send,
+{
+}
+
+unsafe impl<'a, 'i, K, V> Sync for Iter<'i, K, V>
+where
+    K: 'a + Eq + Hash + Sync,
+    V: 'a + Sync,
+{
+}

--- a/src/cht/iter.rs
+++ b/src/cht/iter.rs
@@ -87,17 +87,3 @@ where
         self.keys.as_mut()
     }
 }
-
-unsafe impl<'a, 'i, K, V> Send for Iter<'i, K, V>
-where
-    K: 'a + Eq + Hash + Send,
-    V: 'a + Send,
-{
-}
-
-unsafe impl<'a, 'i, K, V> Sync for Iter<'i, K, V>
-where
-    K: 'a + Eq + Hash + Sync,
-    V: 'a + Sync,
-{
-}

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -35,6 +35,9 @@ use crate::cht::map::{
     DefaultHashBuilder,
 };
 
+#[cfg(feature = "future")]
+use super::iter::{Iter, ScanningGet};
+
 use std::{
     borrow::Borrow,
     hash::{BuildHasher, Hash},
@@ -203,7 +206,7 @@ impl<K, V, S> HashMap<K, V, S> {
     ///
     /// This method on its own is safe, but other threads can add or remove
     /// elements at any time.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "future"))]
     pub(crate) fn len(&self) -> usize {
         self.len.load(Ordering::Relaxed)
     }
@@ -214,7 +217,7 @@ impl<K, V, S> HashMap<K, V, S> {
     ///
     /// This method on its own is safe, but other threads can add or remove
     /// elements at any time.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "future"))]
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -249,6 +252,13 @@ impl<K, V, S> HashMap<K, V, S> {
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
+    #[cfg(feature = "future")]
+    #[inline]
+    pub(crate) fn contains_key(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> bool {
+        self.get_key_value_and_then(hash, eq, |_, _| Some(()))
+            .is_some()
+    }
+
     /// Returns a clone of the value corresponding to the key.
     #[inline]
     pub(crate) fn get(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<V>
@@ -289,7 +299,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     ///
     /// If the map did have this key present, both the key and value are
     /// updated.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "future"))]
     #[inline]
     pub fn insert_entry_and<T>(
         &self,
@@ -484,6 +494,15 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
         Some(bucket_array_ref.keys(with_key))
     }
 
+    #[cfg(feature = "future")]
+    pub(crate) fn iter(&self) -> Iter<'_, K, V>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        Iter::with_single_cache_segment(self, self.actual_num_segments())
+    }
+
     #[inline]
     pub(crate) fn hash<Q>(&self, key: &Q) -> u64
     where
@@ -491,6 +510,23 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
         K: Borrow<Q>,
     {
         bucket::hash(&self.build_hasher, key)
+    }
+}
+
+#[cfg(feature = "future")]
+impl<K, V, S> ScanningGet<K, V> for HashMap<K, V, S>
+where
+    K: Hash + Eq + Clone,
+    V: Clone,
+    S: BuildHasher,
+{
+    fn scanning_get(&self, key: &K) -> Option<V> {
+        let hash = self.hash(key);
+        self.get_key_value_and_then(hash, |k| k == key, |_k, v| Some(v.clone()))
+    }
+
+    fn keys(&self, cht_segment: usize) -> Option<Vec<K>> {
+        self.keys(cht_segment, Clone::clone)
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,6 +35,7 @@ impl From<usize> for CacheRegion {
     }
 }
 
+#[cfg(feature = "future")]
 impl CacheRegion {
     pub(crate) fn name(&self) -> &'static str {
         match self {
@@ -63,6 +64,7 @@ pub(crate) fn sketch_capacity(max_capacity: u64) -> u32 {
     max_capacity.try_into().unwrap_or(u32::MAX).max(128)
 }
 
+#[cfg(feature = "sync")]
 pub(crate) fn available_parallelism() -> usize {
     use std::{num::NonZeroUsize, thread::available_parallelism};
     available_parallelism().map(NonZeroUsize::get).unwrap_or(1)

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,6 +35,17 @@ impl From<usize> for CacheRegion {
     }
 }
 
+impl CacheRegion {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::Window => "window",
+            Self::MainProbation => "main probation",
+            Self::MainProtected => "main protected",
+            Self::Other => "other",
+        }
+    }
+}
+
 impl PartialEq<Self> for CacheRegion {
     fn eq(&self, other: &Self) -> bool {
         core::mem::discriminant(self) == core::mem::discriminant(other)

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,7 +64,7 @@ pub(crate) fn sketch_capacity(max_capacity: u64) -> u32 {
     max_capacity.try_into().unwrap_or(u32::MAX).max(128)
 }
 
-#[cfg(feature = "sync")]
+#[cfg(any(test, feature = "sync"))]
 pub(crate) fn available_parallelism() -> usize {
     use std::{num::NonZeroUsize, thread::available_parallelism};
     available_parallelism().map(NonZeroUsize::get).unwrap_or(1)

--- a/src/common/builder_utils.rs
+++ b/src/common/builder_utils.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+#[cfg(feature = "sync")]
 use super::concurrent::housekeeper;
 
 const YEAR_SECONDS: u64 = 365 * 24 * 3600;
@@ -17,6 +18,7 @@ pub(crate) fn ensure_expirations_or_panic(
     }
 }
 
+#[cfg(feature = "sync")]
 pub(crate) fn housekeeper_conf(thread_pool_enabled: bool) -> housekeeper::Configuration {
     if thread_pool_enabled {
         housekeeper::Configuration::new_thread_pool(true)

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -8,8 +8,14 @@ use triomphe::Arc as TrioArc;
 pub(crate) mod constants;
 pub(crate) mod deques;
 pub(crate) mod entry_info;
+
+#[cfg(feature = "sync")]
 pub(crate) mod housekeeper;
+
+#[cfg(feature = "sync")]
 pub(crate) mod thread_pool;
+
+#[cfg(feature = "sync")]
 pub(crate) mod unsafe_weak_pointer;
 
 // target_has_atomic is more convenient but yet unstable (Rust 1.55)

--- a/src/common/concurrent/constants.rs
+++ b/src/common/concurrent/constants.rs
@@ -1,14 +1,20 @@
 pub(crate) const MAX_SYNC_REPEATS: usize = 4;
 pub(crate) const PERIODICAL_SYNC_INITIAL_DELAY_MILLIS: u64 = 500;
-pub(crate) const PERIODICAL_SYNC_NORMAL_PACE_MILLIS: u64 = 300;
-pub(crate) const PERIODICAL_SYNC_FAST_PACE_NANOS: u64 = 500;
 
 pub(crate) const READ_LOG_FLUSH_POINT: usize = 512;
 pub(crate) const READ_LOG_SIZE: usize = READ_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2);
 
 pub(crate) const WRITE_LOG_FLUSH_POINT: usize = 512;
-pub(crate) const WRITE_LOG_LOW_WATER_MARK: usize = WRITE_LOG_FLUSH_POINT / 2;
-// pub(crate) const WRITE_LOG_HIGH_WATER_MARK: usize = WRITE_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS - 1);
 pub(crate) const WRITE_LOG_SIZE: usize = WRITE_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2);
 
+#[cfg(feature = "sync")]
+pub(crate) const WRITE_LOG_LOW_WATER_MARK: usize = WRITE_LOG_FLUSH_POINT / 2;
+
+#[cfg(feature = "sync")]
 pub(crate) const WRITE_RETRY_INTERVAL_MICROS: u64 = 50;
+
+#[cfg(feature = "sync")]
+pub(crate) const PERIODICAL_SYNC_NORMAL_PACE_MILLIS: u64 = 300;
+
+#[cfg(feature = "sync")]
+pub(crate) const PERIODICAL_SYNC_FAST_PACE_NANOS: u64 = 500;

--- a/src/common/concurrent/deques.rs
+++ b/src/common/concurrent/deques.rs
@@ -34,6 +34,18 @@ impl<K> Default for Deques<K> {
 }
 
 impl<K> Deques<K> {
+    pub(crate) fn select_mut(
+        &mut self,
+        selector: CacheRegion,
+    ) -> (&mut Deque<KeyHashDate<K>>, &mut Deque<KeyHashDate<K>>) {
+        match selector {
+            CacheRegion::Window => (&mut self.window, &mut self.write_order),
+            CacheRegion::MainProbation => (&mut self.probation, &mut self.write_order),
+            CacheRegion::MainProtected => (&mut self.protected, &mut self.write_order),
+            _ => unreachable!(),
+        }
+    }
+
     pub(crate) fn push_back_ao<V>(
         &mut self,
         region: CacheRegion,

--- a/src/common/concurrent/deques.rs
+++ b/src/common/concurrent/deques.rs
@@ -34,6 +34,7 @@ impl<K> Default for Deques<K> {
 }
 
 impl<K> Deques<K> {
+    #[cfg(feature = "future")]
     pub(crate) fn select_mut(
         &mut self,
         selector: CacheRegion,

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -140,8 +140,10 @@ mod test {
 
         use TargetArch::*;
 
+        #[allow(clippy::option_env_unwrap)]
         // e.g. "1.64"
-        let ver = option_env!("RUSTC_SEMVER").expect("RUSTC_SEMVER env var not set");
+        let ver =
+            option_env!("RUSTC_SEMVER").expect("RUSTC_SEMVER env var was not set at compile time");
         let is_quanta_enabled = cfg!(feature = "quanta");
         let arch = if cfg!(target_os = "linux") {
             if cfg!(target_pointer_width = "64") {

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -126,7 +126,7 @@ impl BlockingHousekeeper {
 
     #[inline]
     fn should_apply(&self, ch_len: usize, ch_flush_point: usize, now: Instant) -> bool {
-        ch_len >= ch_flush_point || self.sync_after.instant().unwrap() >= now
+        ch_len >= ch_flush_point || now >= self.sync_after.instant().unwrap()
     }
 
     fn try_sync<T: InnerSync>(&self, cache: &T) -> bool {

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -134,8 +134,8 @@ impl BlockingHousekeeper {
         match self.is_sync_running.compare_exchange(
             false,
             true,
+            Ordering::AcqRel,
             Ordering::Acquire,
-            Ordering::Relaxed,
         ) {
             Ok(_) => {
                 let now = cache.now();
@@ -298,8 +298,8 @@ where
         match self.on_demand_sync_scheduled.compare_exchange(
             false,
             true,
+            Ordering::AcqRel,
             Ordering::Acquire,
-            Ordering::Relaxed,
         ) {
             Ok(_) => {
                 let unsafe_weak_ptr = Arc::clone(&self.inner);

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -191,7 +191,7 @@ impl FrequencySketch {
 }
 
 // Methods only available for testing.
-#[cfg(all(test, feature = "sync"))]
+#[cfg(test)]
 impl FrequencySketch {
     pub(crate) fn table_len(&self) -> usize {
         self.table.len()

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -191,7 +191,7 @@ impl FrequencySketch {
 }
 
 // Methods only available for testing.
-#[cfg(test)]
+#[cfg(all(test, feature = "sync"))]
 impl FrequencySketch {
     pub(crate) fn table_len(&self) -> usize {
         self.table.len()

--- a/src/future.rs
+++ b/src/future.rs
@@ -3,7 +3,6 @@
 //!
 //! To use this module, enable a crate feature called "future".
 
-use async_trait::async_trait;
 use futures_util::future::BoxFuture;
 use std::{future::Future, hash::Hash, sync::Arc};
 
@@ -66,11 +65,4 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
-}
-
-/// Provides extra methods that will be useful for testing.
-#[async_trait]
-pub trait ConcurrentCacheExt<K, V> {
-    /// Performs any pending maintenance operations needed by the cache.
-    async fn flush(&self);
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -48,6 +48,9 @@ pub trait FutureExt: Future {
     }
 }
 
+/// Iterator visiting all key-value pairs in a cache in arbitrary order.
+///
+/// Call [`Cache::iter`](./struct.Cache.html#method.iter) method to obtain an `Iter`.
 pub struct Iter<'i, K, V>(crate::sync_base::iter::Iter<'i, K, V>);
 
 impl<'i, K, V> Iter<'i, K, V> {

--- a/src/future.rs
+++ b/src/future.rs
@@ -78,6 +78,6 @@ pub(crate) async fn may_yield() {
     // Acquire the lock then immediately release it. This `await` may yield to other
     // tasks.
     //
-    // TODO: This behavior is tested only with Tokio. Check other async runtimes.
+    // NOTE: This behavior was tested with Tokio and async-std.
     let _ = LOCK.lock().await;
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -3,7 +3,9 @@
 //!
 //! To use this module, enable a crate feature called "future".
 
+use async_lock::Mutex;
 use futures_util::future::BoxFuture;
+use once_cell::sync::Lazy;
 use std::{future::Future, hash::Hash, sync::Arc};
 
 mod base_cache;
@@ -64,4 +66,15 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
+}
+
+/// May yield to other async tasks.
+pub(crate) async fn may_yield() {
+    static LOCK: Lazy<Mutex<()>> = Lazy::new(Default::default);
+
+    // Acquire the lock then immediately release it. This `await` may yield to other
+    // tasks.
+    //
+    // TODO: This behavior is tested only with Tokio. Check other async runtimes.
+    let _ = LOCK.lock().await;
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -18,7 +18,6 @@ mod value_initializer;
 
 pub use {
     builder::CacheBuilder,
-    // cache::{BlockingOp, Cache},
     cache::Cache,
     entry_selector::{OwnedKeyEntrySelector, RefKeyEntrySelector},
 };

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -779,6 +779,10 @@ where
     pub(crate) async fn set_expiration_clock(&self, clock: Option<Clock>) {
         self.inner.set_expiration_clock(clock).await;
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.inner.key_locks_map_is_empty()
+    }
 }
 
 struct EvictionState<'a, K, V> {
@@ -2432,6 +2436,14 @@ where
                 .store(false, Ordering::SeqCst);
             *(self.clocks.expiration_clock.write()) = None;
         }
+    }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.key_locks
+            .as_ref()
+            .map(|m| m.is_empty())
+            // If key_locks is None, consider it is empty.
+            .unwrap_or(true)
     }
 }
 

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -1,7 +1,8 @@
 use super::{
-    invalidator::{GetOrRemoveEntry, InvalidationResult, Invalidator, KeyDateLite, PredicateFun},
-    iter::ScanningGet,
+    housekeeper::{Housekeeper, InnerSync},
+    invalidator::{GetOrRemoveEntry, Invalidator, KeyDateLite, PredicateFun},
     key_lock::{KeyLock, KeyLockMap},
+    notifier::RemovalNotifier,
     PredicateId,
 };
 
@@ -11,12 +12,10 @@ use crate::{
         concurrent::{
             atomic_time::AtomicInstant,
             constants::{
-                READ_LOG_FLUSH_POINT, READ_LOG_SIZE, WRITE_LOG_FLUSH_POINT,
-                WRITE_LOG_LOW_WATER_MARK, WRITE_LOG_SIZE,
+                READ_LOG_FLUSH_POINT, READ_LOG_SIZE, WRITE_LOG_FLUSH_POINT, WRITE_LOG_SIZE,
             },
             deques::Deques,
             entry_info::EntryInfo,
-            housekeeper::{self, Housekeeper, InnerSync, SyncPace},
             AccessTime, KeyHash, KeyHashDate, KvEntry, ReadOp, ValueEntry, Weigher, WriteOp,
         },
         deque::{DeqNode, Deque},
@@ -25,25 +24,26 @@ use crate::{
         timer_wheel::{ReschedulingResult, TimerWheel},
         CacheRegion,
     },
-    notification::{
-        self,
-        notifier::{RemovalNotifier, RemovedEntry},
-        EvictionListener, RemovalCause,
-    },
+    notification::{AsyncEvictionListener, RemovalCause},
     policy::ExpirationPolicy,
+    sync_base::iter::ScanningGet,
     Entry, Expiry, Policy, PredicateError,
 };
 
+#[cfg(feature = "unstable-debug-counters")]
+use common::concurrent::debug_counters::CacheDebugStats;
+
+use async_lock::{Mutex, MutexGuard, RwLock};
+use async_trait::async_trait;
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use crossbeam_utils::atomic::AtomicCell;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock as SyncRwLock;
 use smallvec::SmallVec;
 use std::{
     borrow::Borrow,
     collections::hash_map::RandomState,
     hash::{BuildHasher, Hash, Hasher},
     ptr::NonNull,
-    rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicU8, Ordering},
         Arc,
@@ -52,13 +52,13 @@ use std::{
 };
 use triomphe::Arc as TrioArc;
 
-pub(crate) type HouseKeeperArc<K, V, S> = Arc<Housekeeper<Inner<K, V, S>>>;
+pub(crate) type HouseKeeperArc = Arc<Housekeeper>;
 
 pub(crate) struct BaseCache<K, V, S = RandomState> {
     pub(crate) inner: Arc<Inner<K, V, S>>,
     read_op_ch: Sender<ReadOp<K, V>>,
     pub(crate) write_op_ch: Sender<WriteOp<K, V>>,
-    pub(crate) housekeeper: Option<HouseKeeperArc<K, V, S>>,
+    pub(crate) housekeeper: Option<HouseKeeperArc>,
 }
 
 impl<K, V, S> Clone for BaseCache<K, V, S> {
@@ -109,23 +109,28 @@ impl<K, V, S> BaseCache<K, V, S> {
         self.inner.is_removal_notifier_enabled()
     }
 
-    #[inline]
-    #[cfg(feature = "sync")]
-    pub(crate) fn is_blocking_removal_notification(&self) -> bool {
-        self.inner.is_blocking_removal_notification()
-    }
+    // #[inline]
+    // #[cfg(feature = "sync")]
+    // pub(crate) fn is_blocking_removal_notification(&self) -> bool {
+    //     self.inner.is_blocking_removal_notification()
+    // }
 
     #[inline]
     pub(crate) fn current_time_from_expiration_clock(&self) -> Instant {
         self.inner.current_time_from_expiration_clock()
     }
 
-    pub(crate) fn notify_invalidate(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>)
+    pub(crate) async fn notify_invalidate(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>)
     where
         K: Send + Sync + 'static,
         V: Clone + Send + Sync + 'static,
     {
-        self.inner.notify_invalidate(key, entry);
+        self.inner.notify_invalidate(key, entry).await;
+    }
+
+    #[cfg(feature = "unstable-debug-counters")]
+    pub async fn debug_stats(&self) -> CacheDebugStats {
+        self.inner.debug_stats().await
     }
 }
 
@@ -153,11 +158,9 @@ where
         initial_capacity: Option<usize>,
         build_hasher: S,
         weigher: Option<Weigher<K, V>>,
-        eviction_listener: Option<EvictionListener<K, V>>,
-        eviction_listener_conf: Option<notification::Configuration>,
+        eviction_listener: Option<AsyncEvictionListener<K, V>>,
         expiration_policy: ExpirationPolicy<K, V>,
         invalidator_enabled: bool,
-        housekeeper_conf: housekeeper::Configuration,
     ) -> Self {
         let (r_size, w_size) = if max_capacity == Some(0) {
             (0, 0)
@@ -175,21 +178,17 @@ where
             build_hasher,
             weigher,
             eviction_listener,
-            eviction_listener_conf,
             r_rcv,
             w_rcv,
             expiration_policy,
             invalidator_enabled,
         ));
-        if invalidator_enabled {
-            inner.set_invalidator(&inner);
-        }
-        let housekeeper = Housekeeper::new(Arc::downgrade(&inner), housekeeper_conf);
+
         Self {
             inner,
             read_op_ch: r_snd,
             write_op_ch: w_snd,
-            housekeeper: Some(Arc::new(housekeeper)),
+            housekeeper: Some(Arc::new(Housekeeper::default())),
         }
     }
 
@@ -221,69 +220,68 @@ where
             .unwrap_or_default() // `false` is the default for `bool` type.
     }
 
-    pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64, need_key: bool) -> Option<Entry<K, V>>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        // Define a closure to record a read op.
-        let record = |op, now| {
-            self.record_read_op(op, now)
-                .expect("Failed to record a get op");
-        };
-        let ignore_if = None as Option<&mut fn(&V) -> bool>;
-        self.do_get_with_hash(key, hash, record, ignore_if, need_key)
-    }
+    // pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64, need_key: bool) -> Option<Entry<K, V>>
+    // where
+    //     K: Borrow<Q>,
+    //     Q: Hash + Eq + ?Sized,
+    // {
+    //     // Define a closure to record a read op.
+    //     let record = |op, now| {
+    //         self.record_read_op(op, now)
+    //             .expect("Failed to record a get op");
+    //     };
+    //     let ignore_if = None as Option<&mut fn(&V) -> bool>;
+    //     self.do_get_with_hash(key, hash, record, ignore_if, need_key)
+    // }
 
-    pub(crate) fn get_with_hash_and_ignore_if<Q, I>(
+    // pub(crate) fn get_with_hash_and_ignore_if<Q, I>(
+    //     &self,
+    //     key: &Q,
+    //     hash: u64,
+    //     ignore_if: Option<&mut I>,
+    //     need_key: bool,
+    // ) -> Option<Entry<K, V>>
+    // where
+    //     K: Borrow<Q>,
+    //     Q: Hash + Eq + ?Sized,
+    //     I: FnMut(&V) -> bool,
+    // {
+    //     // Define a closure to record a read op.
+    //     let record = |op, now| {
+    //         self.record_read_op(op, now)
+    //             .expect("Failed to record a get op");
+    //     };
+    //     self.do_get_with_hash(key, hash, record, ignore_if, need_key)
+    // }
+
+    // pub(crate) async fn get_with_hash_without_recording<Q, I>(
+    //     &self,
+    //     key: &Q,
+    //     hash: u64,
+    //     ignore_if: Option<&mut I>,
+    // ) -> Option<V>
+    // where
+    //     K: Borrow<Q>,
+    //     Q: Hash + Eq + ?Sized,
+    //     I: FnMut(&V) -> bool,
+    // {
+    //     // Define a closure that skips to record a read op.
+    //     let record = |_op, _now| {};
+    //     self.do_get_with_hash(key, hash, record, ignore_if, false)
+    //         .map(Entry::into_value)
+    // }
+
+    pub(crate) async fn get_with_hash<Q, I>(
         &self,
         key: &Q,
         hash: u64,
-        ignore_if: Option<&mut I>,
-        need_key: bool,
-    ) -> Option<Entry<K, V>>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-        I: FnMut(&V) -> bool,
-    {
-        // Define a closure to record a read op.
-        let record = |op, now| {
-            self.record_read_op(op, now)
-                .expect("Failed to record a get op");
-        };
-        self.do_get_with_hash(key, hash, record, ignore_if, need_key)
-    }
-
-    pub(crate) fn get_with_hash_without_recording<Q, I>(
-        &self,
-        key: &Q,
-        hash: u64,
-        ignore_if: Option<&mut I>,
-    ) -> Option<V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-        I: FnMut(&V) -> bool,
-    {
-        // Define a closure that skips to record a read op.
-        let record = |_op, _now| {};
-        self.do_get_with_hash(key, hash, record, ignore_if, false)
-            .map(Entry::into_value)
-    }
-
-    fn do_get_with_hash<Q, R, I>(
-        &self,
-        key: &Q,
-        hash: u64,
-        read_recorder: R,
         mut ignore_if: Option<&mut I>,
         need_key: bool,
+        record_read: bool,
     ) -> Option<Entry<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
-        R: Fn(ReadOp<K, V>, Instant),
         I: FnMut(&V) -> bool,
     {
         if self.is_map_disabled() {
@@ -292,7 +290,7 @@ where
 
         let mut now = self.current_time_from_expiration_clock();
 
-        let maybe_entry = self
+        let maybe_kv_and_op = self
             .inner
             .get_key_value_and_then(key, hash, move |k, entry| {
                 if let Some(ignore_if) = &mut ignore_if {
@@ -314,79 +312,85 @@ where
                     None
                 } else {
                     // Valid entry.
+                    let mut is_expiry_modified = false;
+
+                    // Call the user supplied `expire_after_read` method if any.
+                    if let Some(expiry) = &self.inner.expiration_policy.expiry() {
+                        let lm = entry.last_modified().expect("Last modified is not set");
+                        // Check if the `last_modified` of entry is earlier than or equals to
+                        // `now`. If not, update the `now` to `last_modified`. This is needed
+                        // because there is a small chance that other threads have inserted
+                        // the entry _after_ we obtained `now`.
+                        now = now.max(lm);
+
+                        // Convert `last_modified` from `moka::common::time::Instant` to
+                        // `std::time::Instant`.
+                        let lm = self.inner.clocks().to_std_instant(lm);
+
+                        // Call the user supplied `expire_after_read` method.
+                        //
+                        // We will put the return value (`is_expiry_modified: bool`) to a
+                        // `ReadOp` so that `apply_reads` method can determine whether or not
+                        // to reschedule the timer for the entry.
+                        //
+                        // NOTE: It is not guaranteed that the `ReadOp` is passed to
+                        // `apply_reads`. Here are the corner cases that the `ReadOp` will
+                        // not be passed to `apply_reads`:
+                        //
+                        // - If the bounded `read_op_ch` channel is full, the `ReadOp` will
+                        //   be discarded.
+                        // - If we were called by `get_with_hash_without_recording` method,
+                        //   the `ReadOp` will not be recorded at all.
+                        //
+                        // These cases are okay because when the timer wheel tries to expire
+                        // the entry, it will check if the entry is actually expired. If not,
+                        // the timer wheel will reschedule the expiration timer for the
+                        // entry.
+                        is_expiry_modified = Self::expire_after_read_or_update(
+                            |k, v, t, d| expiry.expire_after_read(k, v, t, d, lm),
+                            &entry.entry_info().key_hash().key,
+                            entry,
+                            self.inner.expiration_policy.time_to_live(),
+                            self.inner.expiration_policy.time_to_idle(),
+                            now,
+                            self.inner.clocks(),
+                        );
+                    }
+
                     let maybe_key = if need_key { Some(Arc::clone(k)) } else { None };
-                    Some((maybe_key, TrioArc::clone(entry)))
+                    let ent = Entry::new(maybe_key, entry.value.clone(), false);
+                    let maybe_op = if record_read {
+                        Some(ReadOp::Hit {
+                            value_entry: TrioArc::clone(entry),
+                            timestamp: now,
+                            is_expiry_modified,
+                        })
+                    } else {
+                        None
+                    };
+
+                    Some((ent, maybe_op, now))
                 }
             });
 
-        if let Some((maybe_key, entry)) = maybe_entry {
-            let mut is_expiry_modified = false;
-
-            // Call the user supplied `expire_after_read` method if any.
-            if let Some(expiry) = &self.inner.expiration_policy.expiry() {
-                let lm = entry.last_modified().expect("Last modified is not set");
-                // Check if the `last_modified` of entry is earlier than or equals to
-                // `now`. If not, update the `now` to `last_modified`. This is needed
-                // because there is a small chance that other threads have inserted
-                // the entry _after_ we obtained `now`.
-                now = now.max(lm);
-
-                // Convert `last_modified` from `moka::common::time::Instant` to
-                // `std::time::Instant`.
-                let lm = self.inner.clocks().to_std_instant(lm);
-
-                // Call the user supplied `expire_after_read` method.
-                //
-                // We will put the return value (`is_expiry_modified: bool`) to a
-                // `ReadOp` so that `apply_reads` method can determine whether or not
-                // to reschedule the timer for the entry.
-                //
-                // NOTE: It is not guaranteed that the `ReadOp` is passed to
-                // `apply_reads`. Here are the corner cases that the `ReadOp` will
-                // not be passed to `apply_reads`:
-                //
-                // - If the bounded `read_op_ch` channel is full, the `ReadOp` will
-                //   be discarded.
-                // - If we were called by `get_with_hash_without_recording` method,
-                //   the `ReadOp` will not be recorded at all.
-                //
-                // These cases are okay because when the timer wheel tries to expire
-                // the entry, it will check if the entry is actually expired. If not,
-                // the timer wheel will reschedule the expiration timer for the
-                // entry.
-                is_expiry_modified = Self::expire_after_read_or_update(
-                    |k, v, t, d| expiry.expire_after_read(k, v, t, d, lm),
-                    &entry.entry_info().key_hash().key,
-                    &entry,
-                    self.inner.expiration_policy.time_to_live(),
-                    self.inner.expiration_policy.time_to_idle(),
-                    now,
-                    self.inner.clocks(),
-                );
+        match maybe_kv_and_op {
+            Some((ent, maybe_op, now)) => {
+                if let Some(op) = maybe_op {
+                    self.record_read_op(op, now)
+                        .await
+                        .expect("Failed to record a get op");
+                }
+                Some(ent)
             }
-
-            let v = entry.value.clone();
-            let op = ReadOp::Hit {
-                value_entry: entry,
-                timestamp: now,
-                is_expiry_modified,
-            };
-            read_recorder(op, now);
-            Some(Entry::new(maybe_key, v, false))
-        } else {
-            read_recorder(ReadOp::Miss(hash), now);
-            None
+            None => {
+                if record_read {
+                    self.record_read_op(ReadOp::Miss(hash), now)
+                        .await
+                        .expect("Failed to record a get op");
+                }
+                None
+            }
         }
-    }
-
-    #[cfg(feature = "sync")]
-    pub(crate) fn get_key_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<Arc<K>>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        self.inner
-            .get_key_value_and(key, hash, |k, _entry| Arc::clone(k))
     }
 
     #[inline]
@@ -399,17 +403,17 @@ where
     }
 
     #[inline]
-    pub(crate) fn apply_reads_writes_if_needed(
+    pub(crate) async fn apply_reads_writes_if_needed(
         inner: &impl InnerSync,
         ch: &Sender<WriteOp<K, V>>,
         now: Instant,
-        housekeeper: Option<&HouseKeeperArc<K, V, S>>,
+        housekeeper: Option<&HouseKeeperArc>,
     ) {
         let w_len = ch.len();
 
         if let Some(hk) = housekeeper {
             if Self::should_apply_writes(hk, w_len, now) {
-                hk.try_sync(inner);
+                hk.try_sync(inner).await;
             }
         }
     }
@@ -477,12 +481,12 @@ where
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
     #[inline]
-    fn record_read_op(
+    async fn record_read_op(
         &self,
         op: ReadOp<K, V>,
         now: Instant,
     ) -> Result<(), TrySendError<ReadOp<K, V>>> {
-        self.apply_reads_if_needed(&self.inner, now);
+        self.apply_reads_if_needed(&self.inner, now).await;
         let ch = &self.read_op_ch;
         match ch.try_send(op) {
             // Discard the ReadOp when the channel is full.
@@ -492,7 +496,7 @@ where
     }
 
     #[inline]
-    pub(crate) fn do_insert_with_hash(
+    pub(crate) async fn do_insert_with_hash(
         &self,
         key: Arc<K>,
         hash: u64,
@@ -500,14 +504,18 @@ where
     ) -> (WriteOp<K, V>, Instant) {
         let ts = self.current_time_from_expiration_clock();
         let weight = self.inner.weigh(&key, &value);
-        let op_cnt1 = Rc::new(AtomicU8::new(0));
-        let op_cnt2 = Rc::clone(&op_cnt1);
+        let op_cnt1 = Arc::new(AtomicU8::new(0));
+        let op_cnt2 = Arc::clone(&op_cnt1);
         let mut op1 = None;
         let mut op2 = None;
 
         // Lock the key for update if blocking removal notification is enabled.
         let kl = self.maybe_key_lock(&key);
-        let _klg = &kl.as_ref().map(|kl| kl.lock());
+        let _klg = if let Some(lock) = &kl {
+            Some(lock.lock().await)
+        } else {
+            None
+        };
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation
@@ -587,7 +595,8 @@ where
 
                 if self.is_removal_notifier_enabled() {
                     self.inner
-                        .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified);
+                        .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified)
+                        .await;
                 }
                 crossbeam_epoch::pin().flush();
                 (upd_op, ts)
@@ -625,12 +634,9 @@ where
                     }
 
                     if self.is_removal_notifier_enabled() {
-                        self.inner.notify_upsert(
-                            key,
-                            &old_entry,
-                            old_last_accessed,
-                            old_last_modified,
-                        );
+                        self.inner
+                            .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified)
+                            .await;
                     }
                     crossbeam_epoch::pin().flush();
                     (upd_op, ts)
@@ -641,23 +647,23 @@ where
     }
 
     #[inline]
-    fn apply_reads_if_needed(&self, inner: &Inner<K, V, S>, now: Instant) {
+    async fn apply_reads_if_needed(&self, inner: &Inner<K, V, S>, now: Instant) {
         let len = self.read_op_ch.len();
 
         if let Some(hk) = &self.housekeeper {
             if Self::should_apply_reads(hk, len, now) {
-                hk.try_sync(inner);
+                hk.try_sync(inner).await;
             }
         }
     }
 
     #[inline]
-    fn should_apply_reads(hk: &HouseKeeperArc<K, V, S>, ch_len: usize, now: Instant) -> bool {
+    fn should_apply_reads(hk: &HouseKeeperArc, ch_len: usize, now: Instant) -> bool {
         hk.should_apply_reads(ch_len, now)
     }
 
     #[inline]
-    fn should_apply_writes(hk: &HouseKeeperArc<K, V, S>, ch_len: usize, now: Instant) -> bool {
+    fn should_apply_writes(hk: &HouseKeeperArc, ch_len: usize, now: Instant) -> bool {
         hk.should_apply_writes(ch_len, now)
     }
 }
@@ -765,24 +771,19 @@ where
         self.inner.invalidation_predicate_count()
     }
 
-    pub(crate) fn reconfigure_for_testing(&mut self) {
-        // Stop the housekeeping job that may cause sync() method to return earlier.
-        if let Some(housekeeper) = &self.housekeeper {
-            housekeeper.stop_periodical_sync_job();
-        }
+    pub(crate) async fn reconfigure_for_testing(&mut self) {
         // Enable the frequency sketch.
-        self.inner.enable_frequency_sketch_for_testing();
+        self.inner.enable_frequency_sketch_for_testing().await;
     }
 
-    pub(crate) fn set_expiration_clock(&self, clock: Option<Clock>) {
-        self.inner.set_expiration_clock(clock);
+    pub(crate) async fn set_expiration_clock(&self, clock: Option<Clock>) {
+        self.inner.set_expiration_clock(clock).await;
     }
 }
 
 struct EvictionState<'a, K, V> {
     counters: EvictionCounters,
     notifier: Option<&'a RemovalNotifier<K, V>>,
-    removed_entries: Option<Vec<RemovedEntry<K, V>>>,
 }
 
 impl<'a, K, V> EvictionState<'a, K, V> {
@@ -791,18 +792,9 @@ impl<'a, K, V> EvictionState<'a, K, V> {
         weighted_size: u64,
         notifier: Option<&'a RemovalNotifier<K, V>>,
     ) -> Self {
-        let removed_entries = notifier.and_then(|n| {
-            if n.is_batching_supported() {
-                Some(Vec::new())
-            } else {
-                None
-            }
-        });
-
         Self {
             counters: EvictionCounters::new(entry_count, weighted_size),
             notifier,
-            removed_entries,
         }
     }
 
@@ -810,7 +802,7 @@ impl<'a, K, V> EvictionState<'a, K, V> {
         self.notifier.is_some()
     }
 
-    fn add_removed_entry(
+    async fn add_removed_entry(
         &mut self,
         key: Arc<K>,
         entry: &TrioArc<ValueEntry<K, V>>,
@@ -821,21 +813,8 @@ impl<'a, K, V> EvictionState<'a, K, V> {
     {
         debug_assert!(self.is_notifier_enabled());
 
-        if let Some(removed) = &mut self.removed_entries {
-            removed.push(RemovedEntry::new(key, entry.value.clone(), cause));
-        } else if let Some(notifier) = self.notifier {
-            notifier.notify(key, entry.value.clone(), cause);
-        }
-    }
-
-    fn notify_multiple_removals(&mut self)
-    where
-        K: Send + Sync + 'static,
-        V: Send + Sync + 'static,
-    {
-        if let (Some(notifier), Some(removed)) = (self.notifier, self.removed_entries.take()) {
-            notifier.batch_notify(removed);
-            notifier.sync();
+        if let Some(notifier) = self.notifier {
+            notifier.notify(key, entry.value.clone(), cause).await;
         }
     }
 }
@@ -897,31 +876,31 @@ type AoqNode<K> = NonNull<DeqNode<KeyHashDate<K>>>;
 
 enum AdmissionResult<K> {
     Admitted {
-        victim_nodes: SmallVec<[AoqNode<K>; 8]>,
-        skipped_nodes: SmallVec<[AoqNode<K>; 4]>,
+        victim_khs: SmallVec<[KeyHash<K>; 8]>,
     },
-    Rejected {
-        skipped_nodes: SmallVec<[AoqNode<K>; 4]>,
-    },
+    Rejected,
 }
 
 type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<Arc<K>, TrioArc<ValueEntry<K, V>>, S>;
 
 struct Clocks {
+    // Lock for this Clocks instance. Used when the `expiration_clock` is set.
+    _lock: Mutex<()>,
     has_expiration_clock: AtomicBool,
-    expiration_clock: RwLock<Option<Clock>>,
+    expiration_clock: SyncRwLock<Option<Clock>>,
     /// The time (`moka::common::time`) when this timer wheel was created.
     origin: Instant,
     /// The time (`StdInstant`) when this timer wheel was created.
     origin_std: StdInstant,
     /// Mutable version of `origin` and `origin_std`. Used when the
     /// `expiration_clock` is set.
-    mutable_origin: RwLock<Option<(Instant, StdInstant)>>,
+    mutable_origin: SyncRwLock<Option<(Instant, StdInstant)>>,
 }
 
 impl Clocks {
     fn new(time: Instant, std_time: StdInstant) -> Self {
         Self {
+            _lock: Default::default(),
             has_expiration_clock: Default::default(),
             expiration_clock: Default::default(),
             origin: time,
@@ -965,8 +944,7 @@ pub(crate) struct Inner<K, V, S> {
     weigher: Option<Weigher<K, V>>,
     removal_notifier: Option<RemovalNotifier<K, V>>,
     key_locks: Option<KeyLockMap<K, S>>,
-    invalidator_enabled: bool,
-    invalidator: RwLock<Option<Invalidator<K, V, S>>>,
+    invalidator: Option<Invalidator<K, V, S>>,
     clocks: Clocks,
 }
 
@@ -999,21 +977,25 @@ impl<K, V, S> Inner<K, V, S> {
         self.removal_notifier.is_some()
     }
 
-    #[inline]
-    #[cfg(feature = "sync")]
-    fn is_blocking_removal_notification(&self) -> bool {
-        self.removal_notifier
-            .as_ref()
-            .map(|rn| rn.is_blocking())
-            .unwrap_or_default()
-    }
+    // #[inline]
+    // fn is_blocking_removal_notification(&self) -> bool {
+    //     self.removal_notifier
+    //         .as_ref()
+    //         .map(|rn| rn.is_blocking())
+    //         .unwrap_or_default()
+    // }
 
-    fn maybe_key_lock(&self, key: &Arc<K>) -> Option<KeyLock<'_, K, S>>
-    where
-        K: Hash + Eq,
-        S: BuildHasher,
-    {
-        self.key_locks.as_ref().map(|kls| kls.key_lock(key))
+    #[cfg(feature = "unstable-debug-counters")]
+    pub async fn debug_stats(&self) -> CacheDebugStats {
+        let ec = self.entry_count.load();
+        let ws = self.weighted_size.load();
+
+        CacheDebugStats::new(
+            ec,
+            ws,
+            (self.cache.capacity() * 2) as u64,
+            self.frequency_sketch.read().await.table_size(),
+        )
     }
 
     #[inline]
@@ -1058,7 +1040,7 @@ impl<K, V, S> Inner<K, V, S> {
 
     #[inline]
     fn is_write_order_queue_enabled(&self) -> bool {
-        self.expiration_policy.time_to_live().is_some() || self.invalidator_enabled
+        self.expiration_policy.time_to_live().is_some() || self.invalidator.is_some()
     }
 
     #[inline]
@@ -1079,6 +1061,20 @@ impl<K, V, S> Inner<K, V, S> {
 
 impl<K, V, S> Inner<K, V, S>
 where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
+    fn maybe_key_lock(&self, key: &Arc<K>) -> Option<KeyLock<'_, K, S>>
+    where
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        self.key_locks.as_ref().map(|kls| kls.key_lock(key))
+    }
+}
+
+impl<K, V, S> Inner<K, V, S>
+where
     K: Hash + Eq + Send + Sync + 'static,
     V: Send + Sync + 'static,
     S: BuildHasher + Clone,
@@ -1092,8 +1088,7 @@ where
         initial_capacity: Option<usize>,
         build_hasher: S,
         weigher: Option<Weigher<K, V>>,
-        eviction_listener: Option<EvictionListener<K, V>>,
-        eviction_listener_conf: Option<notification::Configuration>,
+        eviction_listener: Option<AsyncEvictionListener<K, V>>,
         read_op_ch: Receiver<ReadOp<K, V>>,
         write_op_ch: Receiver<WriteOp<K, V>>,
         expiration_policy: ExpirationPolicy<K, V>,
@@ -1121,19 +1116,16 @@ where
         let timer_wheel = Mutex::new(TimerWheel::new(now));
 
         let (removal_notifier, key_locks) = if let Some(listener) = eviction_listener {
-            let rn = RemovalNotifier::new(
-                listener,
-                eviction_listener_conf.unwrap_or_default(),
-                name.clone(),
-            );
-            if rn.is_blocking() {
-                let kl = KeyLockMap::with_hasher(build_hasher.clone());
-                (Some(rn), Some(kl))
-            } else {
-                (Some(rn), None)
-            }
+            let rn = RemovalNotifier::new(listener, name.clone());
+            let kl = KeyLockMap::with_hasher(build_hasher.clone());
+            (Some(rn), Some(kl))
         } else {
             (None, None)
+        };
+        let invalidator = if invalidator_enabled {
+            Some(Invalidator::new(build_hasher.clone()))
+        } else {
+            None
         };
 
         Self {
@@ -1154,15 +1146,9 @@ where
             weigher,
             removal_notifier,
             key_locks,
-            invalidator_enabled,
-            // When enabled, this field will be set later via the set_invalidator method.
-            invalidator: Default::default(),
+            invalidator,
             clocks,
         }
-    }
-
-    fn set_invalidator(&self, self_ref: &Arc<Self>) {
-        *self.invalidator.write() = Some(Invalidator::new(Arc::downgrade(&Arc::clone(self_ref))));
     }
 
     #[inline]
@@ -1224,7 +1210,7 @@ where
         predicate: PredicateFun<K, V>,
         registered_at: Instant,
     ) -> Result<PredicateId, PredicateError> {
-        if let Some(inv) = &*self.invalidator.read() {
+        if let Some(inv) = &self.invalidator {
             inv.register_predicate(predicate, registered_at)
         } else {
             Err(PredicateError::InvalidationClosuresDisabled)
@@ -1233,11 +1219,12 @@ where
 
     /// Returns `true` if the entry is invalidated by `invalidate_entries_if` method.
     #[inline]
-    fn is_invalidated_entry(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>) -> bool {
-        if self.invalidator_enabled {
-            if let Some(inv) = &*self.invalidator.read() {
-                return inv.apply_predicates(key, entry);
-            }
+    fn is_invalidated_entry(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>) -> bool
+    where
+        V: Clone,
+    {
+        if let Some(inv) = &self.invalidator {
+            return inv.apply_predicates(key, entry);
         }
         false
     }
@@ -1248,33 +1235,40 @@ where
     }
 }
 
-impl<K, V, S> GetOrRemoveEntry<K, V> for Arc<Inner<K, V, S>>
+#[async_trait]
+impl<K, V, S> GetOrRemoveEntry<K, V> for Inner<K, V, S>
 where
     K: Hash + Eq,
-    S: BuildHasher,
+    S: BuildHasher + Send + Sync + 'static,
 {
     fn get_value_entry(&self, key: &Arc<K>, hash: u64) -> Option<TrioArc<ValueEntry<K, V>>> {
         self.cache.get(hash, |k| k == key)
     }
 
-    fn remove_key_value_if(
+    async fn remove_key_value_if<F>(
         &self,
         key: &Arc<K>,
         hash: u64,
-        condition: impl FnMut(&Arc<K>, &TrioArc<ValueEntry<K, V>>) -> bool,
+        condition: F,
     ) -> Option<TrioArc<ValueEntry<K, V>>>
     where
         K: Send + Sync + 'static,
         V: Clone + Send + Sync + 'static,
+        F: for<'a, 'b> FnMut(&'a Arc<K>, &'b TrioArc<ValueEntry<K, V>>) -> bool + Send,
     {
         // Lock the key for removal if blocking removal notification is enabled.
         let kl = self.maybe_key_lock(key);
-        let _klg = &kl.as_ref().map(|kl| kl.lock());
+        let _klg = if let Some(lock) = &kl {
+            Some(lock.lock().await)
+        } else {
+            None
+        };
 
         let maybe_entry = self.cache.remove_if(hash, |k| k == key, condition);
         if let Some(entry) = &maybe_entry {
             if self.is_removal_notifier_enabled() {
-                self.notify_single_removal(Arc::clone(key), entry, RemovalCause::Explicit);
+                self.notify_single_removal(Arc::clone(key), entry, RemovalCause::Explicit)
+                    .await;
             }
         }
         maybe_entry
@@ -1299,19 +1293,35 @@ mod batch_size {
 // - sync_writes
 // - evict
 // - invalidate_entries
+#[async_trait]
 impl<K, V, S> InnerSync for Inner<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
-    fn sync(&self, max_repeats: usize) -> Option<SyncPace> {
+    async fn flush(&self, max_repeats: usize) {
+        self.flush(max_repeats).await;
+    }
+
+    fn now(&self) -> Instant {
+        self.current_time_from_expiration_clock()
+    }
+}
+
+impl<K, V, S> Inner<K, V, S>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    async fn flush(&self, max_repeats: usize) {
         if self.max_capacity == Some(0) {
-            return None;
+            return;
         }
 
-        let mut deqs = self.deques.lock();
-        let mut timer_wheel = self.timer_wheel.lock();
+        let mut deqs = self.deques.lock().await;
+        let mut timer_wheel = self.timer_wheel.lock().await;
         let mut calls = 0;
         let current_ec = self.entry_count.load();
         let current_ws = self.weighted_size.load();
@@ -1323,16 +1333,17 @@ where
         while should_process_logs && calls <= max_repeats {
             let r_len = self.read_op_ch.len();
             if r_len > 0 {
-                self.apply_reads(&mut deqs, &mut timer_wheel, r_len);
+                self.apply_reads(&mut deqs, &mut timer_wheel, r_len).await;
             }
 
             let w_len = self.write_op_ch.len();
             if w_len > 0 {
-                self.apply_writes(&mut deqs, &mut timer_wheel, w_len, &mut eviction_state);
+                self.apply_writes(&mut deqs, &mut timer_wheel, w_len, &mut eviction_state)
+                    .await;
             }
 
             if self.should_enable_frequency_sketch(&eviction_state.counters) {
-                self.enable_frequency_sketch(&eviction_state.counters);
+                self.enable_frequency_sketch(&eviction_state.counters).await;
             }
 
             calls += 1;
@@ -1345,7 +1356,8 @@ where
                 &mut timer_wheel,
                 &mut deqs,
                 &mut eviction_state,
-            );
+            )
+            .await;
         }
 
         if self.has_expiry() || self.has_valid_after() {
@@ -1354,20 +1366,20 @@ where
                 &mut timer_wheel,
                 batch_size::EVICTION_BATCH_SIZE,
                 &mut eviction_state,
-            );
+            )
+            .await;
         }
 
-        if self.invalidator_enabled {
-            if let Some(invalidator) = &*self.invalidator.read() {
-                if !invalidator.is_empty() && !invalidator.is_task_running() {
-                    self.invalidate_entries(
-                        invalidator,
-                        &mut deqs,
-                        &mut timer_wheel,
-                        batch_size::INVALIDATION_BATCH_SIZE,
-                        &mut eviction_state,
-                    );
-                }
+        if let Some(invalidator) = &self.invalidator {
+            if !invalidator.is_empty() {
+                self.invalidate_entries(
+                    invalidator,
+                    &mut deqs,
+                    &mut timer_wheel,
+                    batch_size::INVALIDATION_BATCH_SIZE,
+                    &mut eviction_state,
+                )
+                .await;
             }
         }
 
@@ -1380,10 +1392,9 @@ where
                 batch_size::EVICTION_BATCH_SIZE,
                 weights_to_evict,
                 &mut eviction_state,
-            );
+            )
+            .await;
         }
-
-        eviction_state.notify_multiple_removals();
 
         debug_assert_eq!(self.entry_count.load(), current_ec);
         debug_assert_eq!(self.weighted_size.load(), current_ws);
@@ -1392,19 +1403,6 @@ where
             .store(eviction_state.counters.weighted_size);
 
         crossbeam_epoch::pin().flush();
-
-        if should_process_logs {
-            Some(SyncPace::Fast)
-        } else if self.write_op_ch.len() <= WRITE_LOG_LOW_WATER_MARK {
-            Some(SyncPace::Normal)
-        } else {
-            // Keep the current pace.
-            None
-        }
-    }
-
-    fn now(&self) -> Instant {
-        self.current_time_from_expiration_clock()
     }
 }
 
@@ -1444,7 +1442,7 @@ where
     }
 
     #[inline]
-    fn enable_frequency_sketch(&self, counters: &EvictionCounters) {
+    async fn enable_frequency_sketch(&self, counters: &EvictionCounters) {
         if let Some(max_cap) = self.max_capacity {
             let c = counters;
             let cap = if self.weigher.is_none() {
@@ -1452,27 +1450,35 @@ where
             } else {
                 (c.entry_count as f64 * (c.weighted_size as f64 / max_cap as f64)) as u64
             };
-            self.do_enable_frequency_sketch(cap);
+            self.do_enable_frequency_sketch(cap).await;
         }
     }
 
     #[cfg(test)]
-    fn enable_frequency_sketch_for_testing(&self) {
+    async fn enable_frequency_sketch_for_testing(&self) {
         if let Some(max_cap) = self.max_capacity {
-            self.do_enable_frequency_sketch(max_cap);
+            self.do_enable_frequency_sketch(max_cap).await;
         }
     }
 
     #[inline]
-    fn do_enable_frequency_sketch(&self, cache_capacity: u64) {
+    async fn do_enable_frequency_sketch(&self, cache_capacity: u64) {
         let skt_capacity = common::sketch_capacity(cache_capacity);
-        self.frequency_sketch.write().ensure_capacity(skt_capacity);
+        self.frequency_sketch
+            .write()
+            .await
+            .ensure_capacity(skt_capacity);
         self.frequency_sketch_enabled.store(true, Ordering::Release);
     }
 
-    fn apply_reads(&self, deqs: &mut Deques<K>, timer_wheel: &mut TimerWheel<K>, count: usize) {
+    async fn apply_reads(
+        &self,
+        deqs: &mut Deques<K>,
+        timer_wheel: &mut TimerWheel<K>,
+        count: usize,
+    ) {
         use ReadOp::*;
-        let mut freq = self.frequency_sketch.write();
+        let mut freq = self.frequency_sketch.write().await;
         let ch = &self.read_op_ch;
         for _ in 0..count {
             match ch.try_recv() {
@@ -1495,7 +1501,7 @@ where
         }
     }
 
-    fn apply_writes(
+    async fn apply_writes(
         &self,
         deqs: &mut Deques<K>,
         timer_wheel: &mut TimerWheel<K>,
@@ -1505,7 +1511,7 @@ where
         V: Clone,
     {
         use WriteOp::*;
-        let freq = self.frequency_sketch.read();
+        let freq = self.frequency_sketch.read().await;
         let ch = &self.write_op_ch;
 
         for _ in 0..count {
@@ -1515,16 +1521,19 @@ where
                     value_entry: entry,
                     old_weight,
                     new_weight,
-                }) => self.handle_upsert(
-                    kh,
-                    entry,
-                    old_weight,
-                    new_weight,
-                    deqs,
-                    timer_wheel,
-                    &freq,
-                    eviction_state,
-                ),
+                }) => {
+                    self.handle_upsert(
+                        kh,
+                        entry,
+                        old_weight,
+                        new_weight,
+                        deqs,
+                        timer_wheel,
+                        &freq,
+                        eviction_state,
+                    )
+                    .await
+                }
                 Ok(Remove(KvEntry { key: _key, entry })) => {
                     Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters)
                 }
@@ -1534,7 +1543,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn handle_upsert(
+    async fn handle_upsert(
         &self,
         kh: KeyHash<K>,
         entry: TrioArc<ValueEntry<K, V>>,
@@ -1576,47 +1585,55 @@ where
 
                 // Lock the key for removal if blocking removal notification is enabled.
                 let kl = self.maybe_key_lock(&kh.key);
-                let _klg = &kl.as_ref().map(|kl| kl.lock());
+                let _klg = if let Some(lock) = &kl {
+                    Some(lock.lock().await)
+                } else {
+                    None
+                };
 
                 let removed = self.cache.remove(kh.hash, |k| k == &kh.key);
                 if let Some(entry) = removed {
                     if eviction_state.is_notifier_enabled() {
                         let key = Arc::clone(&kh.key);
-                        eviction_state.add_removed_entry(key, &entry, RemovalCause::Size);
+                        eviction_state
+                            .add_removed_entry(key, &entry, RemovalCause::Size)
+                            .await;
                     }
                 }
                 return;
             }
         }
 
-        let skipped_nodes;
         let mut candidate = EntrySizeAndFrequency::new(new_weight);
         candidate.add_frequency(freq, kh.hash);
 
         // Try to admit the candidate.
-        match Self::admit(&candidate, &self.cache, deqs, freq) {
+        //
+        // NOTE: We need to call `admin` here, instead of a part of the `match`
+        // expression. Otherwise the future returned from this `handle_upsert` method
+        // will not be `Send`.
+        let admission_result = Self::admit(&candidate, &self.cache, deqs, freq);
+        match admission_result {
             AdmissionResult::Admitted {
-                victim_nodes,
-                skipped_nodes: mut skipped,
+                victim_khs: victims,
             } => {
                 // Try to remove the victims from the cache (hash map).
-                for victim in victim_nodes {
-                    let element = unsafe { &victim.as_ref().element };
-
+                for vic_kh in victims {
                     // Lock the key for removal if blocking removal notification is enabled.
-                    let kl = self.maybe_key_lock(element.key());
-                    let _klg = &kl.as_ref().map(|kl| kl.lock());
+                    let kl = self.maybe_key_lock(&vic_kh.key);
+                    let _klg = if let Some(lock) = &kl {
+                        Some(lock.lock().await)
+                    } else {
+                        None
+                    };
 
-                    if let Some((vic_key, vic_entry)) = self
-                        .cache
-                        .remove_entry(element.hash(), |k| k == element.key())
+                    if let Some((vic_key, vic_entry)) =
+                        self.cache.remove_entry(vic_kh.hash, |k| k == &vic_kh.key)
                     {
                         if eviction_state.is_notifier_enabled() {
-                            eviction_state.add_removed_entry(
-                                vic_key,
-                                &vic_entry,
-                                RemovalCause::Size,
-                            );
+                            eviction_state
+                                .add_removed_entry(vic_key, &vic_entry, RemovalCause::Size)
+                                .await;
                         }
                         // And then remove the victim from the deques.
                         Self::handle_remove(
@@ -1625,15 +1642,8 @@ where
                             vic_entry,
                             &mut eviction_state.counters,
                         );
-                    } else {
-                        // Could not remove the victim from the cache. Skip this
-                        // victim node as its ValueEntry might have been
-                        // invalidated. Add it to the skipped nodes.
-                        skipped.push(victim);
                     }
                 }
-                skipped_nodes = skipped;
-
                 // Add the candidate to the deques.
                 self.handle_admit(
                     &entry,
@@ -1643,26 +1653,24 @@ where
                     &mut eviction_state.counters,
                 );
             }
-            AdmissionResult::Rejected { skipped_nodes: s } => {
-                skipped_nodes = s;
-
+            AdmissionResult::Rejected => {
                 // Lock the key for removal if blocking removal notification is enabled.
                 let kl = self.maybe_key_lock(&kh.key);
-                let _klg = &kl.as_ref().map(|kl| kl.lock());
+                let _klg = if let Some(lock) = &kl {
+                    Some(lock.lock().await)
+                } else {
+                    None
+                };
 
                 // Remove the candidate from the cache (hash map).
                 let key = Arc::clone(&kh.key);
                 self.cache.remove(kh.hash, |k| k == &key);
                 if eviction_state.is_notifier_enabled() {
-                    eviction_state.add_removed_entry(key, &entry, RemovalCause::Size);
+                    eviction_state
+                        .add_removed_entry(key, &entry, RemovalCause::Size)
+                        .await;
                 }
             }
-        };
-
-        // Move the skipped nodes to the back of the deque. We do not unlink (drop)
-        // them because ValueEntries in the write op queue should be pointing them.
-        for node in skipped_nodes {
-            unsafe { deqs.probation.move_to_back(node) };
         }
     }
 
@@ -1687,15 +1695,15 @@ where
     fn admit(
         candidate: &EntrySizeAndFrequency,
         cache: &CacheStore<K, V, S>,
-        deqs: &Deques<K>,
+        deqs: &mut Deques<K>,
         freq: &FrequencySketch,
     ) -> AdmissionResult<K> {
         const MAX_CONSECUTIVE_RETRIES: usize = 5;
         let mut retries = 0;
 
         let mut victims = EntrySizeAndFrequency::default();
-        let mut victim_nodes = SmallVec::default();
-        let mut skipped_nodes = SmallVec::default();
+        let mut victim_nodes: SmallVec<[AoqNode<K>; 8]> = SmallVec::default();
+        let mut skipped_nodes: SmallVec<[AoqNode<K>; 8]> = SmallVec::default();
 
         // Get first potential victim at the LRU position.
         let mut next_victim = deqs.probation.peek_front_ptr();
@@ -1730,18 +1738,34 @@ where
             }
         }
 
+        for skipped in skipped_nodes {
+            // Move the skipped node to the back of the deque.
+            unsafe { deqs.probation.move_to_back(skipped) };
+        }
+
         // Admit or reject the candidate.
 
         // TODO: Implement some randomness to mitigate hash DoS attack.
         // See Caffeine's implementation.
 
         if victims.policy_weight >= candidate.policy_weight && candidate.freq > victims.freq {
-            AdmissionResult::Admitted {
-                victim_nodes,
-                skipped_nodes,
+            let mut victim_khs: SmallVec<[KeyHash<K>; 8]> = SmallVec::default();
+            for victim in victim_nodes {
+                let vic_elem = &unsafe { victim.as_ref() }.element;
+                let vic_kh = KeyHash::new(Arc::clone(vic_elem.key()), vic_elem.hash());
+                victim_khs.push(vic_kh);
+
+                // Move the victim to the back of the deque. It will be removed from the
+                // cache (hash map) later and then removed from the deque. But we are
+                // still moving it to the back now because the victim's ValueEntry can be
+                // invalidated by another thread before it is removed by us. In that
+                // case, we will have to keep the victim in the deque.
+                unsafe { deqs.probation.move_to_back(victim) }
             }
+
+            AdmissionResult::Admitted { victim_khs }
         } else {
-            AdmissionResult::Rejected { skipped_nodes }
+            AdmissionResult::Rejected
         }
     }
 
@@ -1868,7 +1892,7 @@ where
         }
     }
 
-    fn evict_expired_entries_using_timers(
+    async fn evict_expired_entries_using_timers(
         &self,
         timer_wheel: &mut TimerWheel<K>,
         deqs: &mut Deques<K>,
@@ -1882,90 +1906,89 @@ where
 
         // NOTE: When necessary, the iterator returned from advance() will unset the
         // timer node pointer in the `ValueEntry`, so we do not have to do it here.
-        for event in timer_wheel.advance(now) {
-            // We do not have to do anything if event is `TimerEvent::Descheduled(_)`
-            // or `TimerEvent::Rescheduled(_)`.
-            if let TimerEvent::Expired(node) = event {
-                let entry_info = node.element.entry_info();
-                let kh = entry_info.key_hash();
-                let key = &kh.key;
-                let hash = kh.hash;
-
-                // Lock the key for removal if blocking removal notification is
-                // enabled.
-                let kl = self.maybe_key_lock(key);
-                let _klg = &kl.as_ref().map(|kl| kl.lock());
-
-                // Remove the key from the map only when the entry is really
-                // expired.
-                let maybe_entry = self.cache.remove_if(
-                    hash,
-                    |k| k == key,
-                    |_, v| is_expired_by_per_entry_ttl(v.entry_info(), now),
-                );
-
-                if let Some(entry) = maybe_entry {
-                    if eviction_state.is_notifier_enabled() {
-                        let key = Arc::clone(key);
-                        eviction_state.add_removed_entry(key, &entry, RemovalCause::Expired);
-                    }
-                    Self::handle_remove_without_timer_wheel(
-                        deqs,
-                        entry,
-                        &mut eviction_state.counters,
-                    );
+        let expired_keys = timer_wheel
+            .advance(now)
+            .filter_map(|event| {
+                // We do not have to do anything if event is `TimerEvent::Descheduled(_)`
+                // or `TimerEvent::Rescheduled(_)`.
+                if let TimerEvent::Expired(node) = event {
+                    let entry_info = node.element.entry_info();
+                    let kh = entry_info.key_hash();
+                    Some((Arc::clone(&kh.key), kh.hash))
                 } else {
-                    // Other thread might have updated or invalidated the entry
-                    // already. We have nothing to do here as the `advance()`
-                    // iterator has unset the timer node pointer in the old
-                    // `ValueEntry`. (In the case of update, the timer node will be
-                    // recreated for the new `ValueEntry` when it is processed by the
-                    // `handle_upsert` method.)
+                    None
                 }
+            })
+            .collect::<Vec<_>>();
+
+        for (key, hash) in expired_keys {
+            // Lock the key for removal if blocking removal notification is
+            // enabled.
+            let kl = self.maybe_key_lock(&key);
+            let _klg = if let Some(lock) = &kl {
+                Some(lock.lock().await)
+            } else {
+                None
+            };
+
+            // Remove the key from the map only when the entry is really
+            // expired.
+            let maybe_entry = self.cache.remove_if(
+                hash,
+                |k| k == &key,
+                |_, v| is_expired_by_per_entry_ttl(v.entry_info(), now),
+            );
+
+            if let Some(entry) = maybe_entry {
+                if eviction_state.is_notifier_enabled() {
+                    eviction_state
+                        .add_removed_entry(key, &entry, RemovalCause::Expired)
+                        .await;
+                }
+                Self::handle_remove_without_timer_wheel(deqs, entry, &mut eviction_state.counters);
+            } else {
+                // Other thread might have updated or invalidated the entry
+                // already. We have nothing to do here as the `advance()`
+                // iterator has unset the timer node pointer in the old
+                // `ValueEntry`. (In the case of update, the timer node will be
+                // recreated for the new `ValueEntry` when it is processed by the
+                // `handle_upsert` method.)
             }
         }
     }
 
-    fn evict_expired_entries_using_deqs(
+    async fn evict_expired_entries_using_deqs(
         &self,
-        deqs: &mut Deques<K>,
+        deqs: &mut MutexGuard<'_, Deques<K>>,
         timer_wheel: &mut TimerWheel<K>,
         batch_size: usize,
-        eviction_state: &mut EvictionState<'_, K, V>,
+        state: &mut EvictionState<'_, K, V>,
     ) where
         V: Clone,
     {
+        use CacheRegion::{MainProbation as Probation, MainProtected as Protected, Window};
+
         let now = self.current_time_from_expiration_clock();
 
         if self.is_write_order_queue_enabled() {
-            self.remove_expired_wo(deqs, timer_wheel, batch_size, now, eviction_state);
+            self.remove_expired_wo(deqs, timer_wheel, batch_size, now, state)
+                .await;
         }
 
-        if self.expiration_policy.time_to_idle().is_some() || self.has_valid_after() {
-            let (window, probation, protected, wo) = (
-                &mut deqs.window,
-                &mut deqs.probation,
-                &mut deqs.protected,
-                &mut deqs.write_order,
-            );
-
-            let mut rm_expired_ao = |name, deq| {
-                self.remove_expired_ao(name, deq, wo, timer_wheel, batch_size, now, eviction_state)
-            };
-
-            rm_expired_ao("window", window);
-            rm_expired_ao("probation", probation);
-            rm_expired_ao("protected", protected);
-        }
+        self.remove_expired_ao(Window, deqs, timer_wheel, batch_size, now, state)
+            .await;
+        self.remove_expired_ao(Probation, deqs, timer_wheel, batch_size, now, state)
+            .await;
+        self.remove_expired_ao(Protected, deqs, timer_wheel, batch_size, now, state)
+            .await;
     }
 
     #[allow(clippy::too_many_arguments)]
     #[inline]
-    fn remove_expired_ao(
+    async fn remove_expired_ao(
         &self,
-        deq_name: &str,
-        deq: &mut Deque<KeyHashDate<K>>,
-        write_order_deq: &mut Deque<KeyHashDate<K>>,
+        cache_region: CacheRegion,
+        deqs: &mut MutexGuard<'_, Deques<K>>,
         timer_wheel: &mut TimerWheel<K>,
         batch_size: usize,
         now: Instant,
@@ -1975,24 +1998,29 @@ where
     {
         let tti = &self.expiration_policy.time_to_idle();
         let va = &self.valid_after();
+        let deq_name = cache_region.name();
         for _ in 0..batch_size {
             // Peek the front node of the deque and check if it is expired.
-            let key_hash_cause = deq.peek_front().and_then(|node| {
-                // TODO: Skip the entry if it is dirty. See `evict_lru_entries` method as an example.
-                match is_entry_expired_ao_or_invalid(tti, va, node, now) {
-                    (true, _) => Some((
-                        Arc::clone(node.element.key()),
-                        node.element.hash(),
-                        RemovalCause::Expired,
-                    )),
-                    (false, true) => Some((
-                        Arc::clone(node.element.key()),
-                        node.element.hash(),
-                        RemovalCause::Explicit,
-                    )),
-                    (false, false) => None,
-                }
-            });
+            let key_hash_cause = deqs
+                .select_mut(cache_region)
+                .0
+                .peek_front()
+                .and_then(|node| {
+                    // TODO: Skip the entry if it is dirty. See `evict_lru_entries` method as an example.
+                    match is_entry_expired_ao_or_invalid(tti, va, node, now) {
+                        (true, _) => Some((
+                            Arc::clone(node.element.key()),
+                            node.element.hash(),
+                            RemovalCause::Expired,
+                        )),
+                        (false, true) => Some((
+                            Arc::clone(node.element.key()),
+                            node.element.hash(),
+                            RemovalCause::Explicit,
+                        )),
+                        (false, false) => None,
+                    }
+                });
 
             if key_hash_cause.is_none() {
                 break;
@@ -2005,7 +2033,11 @@ where
 
             // Lock the key for removal if blocking removal notification is enabled.
             let kl = self.maybe_key_lock(key);
-            let _klg = &kl.as_ref().map(|kl| kl.lock());
+            let _klg = if let Some(lock) = &kl {
+                Some(lock.lock().await)
+            } else {
+                None
+            };
 
             // Remove the key from the map only when the entry is really
             // expired. This check is needed because it is possible that the entry in
@@ -2020,18 +2052,22 @@ where
             if let Some(entry) = maybe_entry {
                 if eviction_state.is_notifier_enabled() {
                     let key = Arc::clone(key);
-                    eviction_state.add_removed_entry(key, &entry, cause);
+                    eviction_state.add_removed_entry(key, &entry, cause).await;
                 }
+                let (ao_deq, wo_deq) = deqs.select_mut(cache_region);
                 Self::handle_remove_with_deques(
-                    deq_name,
-                    deq,
-                    write_order_deq,
+                    cache_region.name(),
+                    ao_deq,
+                    wo_deq,
                     timer_wheel,
                     entry,
                     &mut eviction_state.counters,
                 );
-            } else if !self.try_skip_updated_entry(key, hash, deq_name, deq, write_order_deq) {
-                break;
+            } else {
+                let (ao_deq, wo_deq) = deqs.select_mut(cache_region);
+                if !self.try_skip_updated_entry(key, hash, deq_name, ao_deq, wo_deq) {
+                    break;
+                }
             }
         }
     }
@@ -2066,7 +2102,7 @@ where
     }
 
     #[inline]
-    fn remove_expired_wo(
+    async fn remove_expired_wo(
         &self,
         deqs: &mut Deques<K>,
         timer_wheel: &mut TimerWheel<K>,
@@ -2097,7 +2133,11 @@ where
 
             // Lock the key for removal if blocking removal notification is enabled.
             let kl = self.maybe_key_lock(key);
-            let _klg = &kl.as_ref().map(|kl| kl.lock());
+            let _klg = if let Some(lock) = &kl {
+                Some(lock.lock().await)
+            } else {
+                None
+            };
 
             let maybe_entry = self.cache.remove_if(
                 hash,
@@ -2108,7 +2148,7 @@ where
             if let Some(entry) = maybe_entry {
                 if eviction_state.is_notifier_enabled() {
                     let key = Arc::clone(key);
-                    eviction_state.add_removed_entry(key, &entry, *cause);
+                    eviction_state.add_removed_entry(key, &entry, *cause).await;
                 }
                 Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
             } else if let Some(entry) = self.cache.get(hash, |k| k == key) {
@@ -2130,48 +2170,13 @@ where
         }
     }
 
-    fn invalidate_entries(
+    async fn invalidate_entries(
         &self,
         invalidator: &Invalidator<K, V, S>,
         deqs: &mut Deques<K>,
         timer_wheel: &mut TimerWheel<K>,
         batch_size: usize,
         eviction_state: &mut EvictionState<'_, K, V>,
-    ) where
-        V: Clone,
-    {
-        self.process_invalidation_result(invalidator, deqs, timer_wheel, eviction_state);
-        self.submit_invalidation_task(invalidator, &mut deqs.write_order, batch_size);
-    }
-
-    fn process_invalidation_result(
-        &self,
-        invalidator: &Invalidator<K, V, S>,
-        deqs: &mut Deques<K>,
-        timer_wheel: &mut TimerWheel<K>,
-        eviction_state: &mut EvictionState<'_, K, V>,
-    ) where
-        V: Clone,
-    {
-        if let Some(InvalidationResult {
-            invalidated,
-            is_done,
-        }) = invalidator.task_result()
-        {
-            for KvEntry { key: _key, entry } in invalidated {
-                Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
-            }
-            if is_done {
-                deqs.write_order.reset_cursor();
-            }
-        }
-    }
-
-    fn submit_invalidation_task(
-        &self,
-        invalidator: &Invalidator<K, V, S>,
-        write_order: &mut Deque<KeyHashDate<K>>,
-        batch_size: usize,
     ) where
         V: Clone,
     {
@@ -2179,37 +2184,53 @@ where
 
         // If the write order queue is empty, we are done and can remove the predicates
         // that have been registered by now.
-        if write_order.len() == 0 {
-            invalidator.remove_predicates_registered_before(now);
+        if deqs.write_order.len() == 0 {
+            invalidator.remove_predicates_registered_before(now).await;
             return;
         }
 
         let mut candidates = Vec::with_capacity(batch_size);
-        let mut iter = write_order.peekable();
         let mut len = 0;
+        let has_next;
+        {
+            let iter = &mut deqs.write_order.peekable();
 
-        while len < batch_size {
-            if let Some(kd) = iter.next() {
-                if !kd.is_dirty() {
-                    if let Some(ts) = kd.last_modified() {
-                        let key = kd.key();
-                        let hash = self.hash(key);
-                        candidates.push(KeyDateLite::new(key, hash, ts));
-                        len += 1;
+            while len < batch_size {
+                if let Some(kd) = iter.next() {
+                    if !kd.is_dirty() {
+                        if let Some(ts) = kd.last_modified() {
+                            let key = kd.key();
+                            let hash = self.hash(key);
+                            candidates.push(KeyDateLite::new(key, hash, ts));
+                            len += 1;
+                        }
                     }
+                } else {
+                    break;
                 }
-            } else {
-                break;
             }
+
+            has_next = iter.peek().is_some();
         }
 
-        if len > 0 {
-            let is_truncated = len == batch_size && iter.peek().is_some();
-            invalidator.submit_task(candidates, is_truncated);
+        if len == 0 {
+            return;
+        }
+
+        let is_truncated = len == batch_size && has_next;
+        let (invalidated, is_done) = invalidator
+            .scan_and_invalidate(self, candidates, is_truncated)
+            .await;
+
+        for KvEntry { key: _key, entry } in invalidated {
+            Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
+        }
+        if is_done {
+            deqs.write_order.reset_cursor();
         }
     }
 
-    fn evict_lru_entries(
+    async fn evict_lru_entries(
         &self,
         deqs: &mut Deques<K>,
         timer_wheel: &mut TimerWheel<K>,
@@ -2221,22 +2242,25 @@ where
     {
         const DEQ_NAME: &str = "probation";
         let mut evicted = 0u64;
-        let (deq, write_order_deq) = (&mut deqs.probation, &mut deqs.write_order);
 
         for _ in 0..batch_size {
             if evicted >= weights_to_evict {
                 break;
             }
 
-            let maybe_key_hash_ts = deq.peek_front().map(|node| {
-                let entry_info = node.element.entry_info();
-                (
-                    Arc::clone(node.element.key()),
-                    node.element.hash(),
-                    entry_info.is_dirty(),
-                    entry_info.last_modified(),
-                )
-            });
+            let maybe_key_hash_ts = deqs
+                .select_mut(CacheRegion::MainProbation)
+                .0
+                .peek_front()
+                .map(|node| {
+                    let entry_info = node.element.entry_info();
+                    (
+                        Arc::clone(node.element.key()),
+                        node.element.hash(),
+                        entry_info.is_dirty(),
+                        entry_info.last_modified(),
+                    )
+                });
 
             let (key, hash, ts) = match maybe_key_hash_ts {
                 Some((key, hash, false, Some(ts))) => (key, hash, ts),
@@ -2244,6 +2268,7 @@ where
                 // `last_modified` and `last_accessed` in `EntryInfo` from `Option<Instant>` to
                 // `Instant`.
                 Some((key, hash, true, _)) | Some((key, hash, false, None)) => {
+                    let (deq, write_order_deq) = deqs.select_mut(CacheRegion::MainProbation);
                     if self.try_skip_updated_entry(&key, hash, DEQ_NAME, deq, write_order_deq) {
                         continue;
                     } else {
@@ -2255,7 +2280,11 @@ where
 
             // Lock the key for removal if blocking removal notification is enabled.
             let kl = self.maybe_key_lock(&key);
-            let _klg = &kl.as_ref().map(|kl| kl.lock());
+            let _klg = if let Some(lock) = &kl {
+                Some(lock.lock().await)
+            } else {
+                None
+            };
 
             let maybe_entry = self.cache.remove_if(
                 hash,
@@ -2271,9 +2300,12 @@ where
 
             if let Some(entry) = maybe_entry {
                 if eviction_state.is_notifier_enabled() {
-                    eviction_state.add_removed_entry(key, &entry, RemovalCause::Size);
+                    eviction_state
+                        .add_removed_entry(key, &entry, RemovalCause::Size)
+                        .await;
                 }
                 let weight = entry.policy_weight();
+                let (deq, write_order_deq) = deqs.select_mut(CacheRegion::MainProbation);
                 Self::handle_remove_with_deques(
                     DEQ_NAME,
                     deq,
@@ -2283,8 +2315,11 @@ where
                     &mut eviction_state.counters,
                 );
                 evicted = evicted.saturating_add(weight as u64);
-            } else if !self.try_skip_updated_entry(&key, hash, DEQ_NAME, deq, write_order_deq) {
-                break;
+            } else {
+                let (deq, write_order_deq) = deqs.select_mut(CacheRegion::MainProbation);
+                if !self.try_skip_updated_entry(&key, hash, DEQ_NAME, deq, write_order_deq) {
+                    break;
+                }
             }
         }
     }
@@ -2295,19 +2330,19 @@ where
     K: Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
 {
-    fn notify_single_removal(
+    async fn notify_single_removal(
         &self,
         key: Arc<K>,
         entry: &TrioArc<ValueEntry<K, V>>,
         cause: RemovalCause,
     ) {
         if let Some(notifier) = &self.removal_notifier {
-            notifier.notify(key, entry.value.clone(), cause)
+            notifier.notify(key, entry.value.clone(), cause).await
         }
     }
 
     #[inline]
-    fn notify_upsert(
+    async fn notify_upsert(
         &self,
         key: Arc<K>,
         entry: &TrioArc<ValueEntry<K, V>>,
@@ -2333,11 +2368,11 @@ where
             }
         }
 
-        self.notify_single_removal(key, entry, cause);
+        self.notify_single_removal(key, entry, cause).await;
     }
 
     #[inline]
-    fn notify_invalidate(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>) {
+    async fn notify_invalidate(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>) {
         let now = self.current_time_from_expiration_clock();
         let exp = &self.expiration_policy;
 
@@ -2355,7 +2390,8 @@ where
             }
         }
 
-        self.notify_single_removal(Arc::clone(key), entry, cause);
+        self.notify_single_removal(Arc::clone(key), entry, cause)
+            .await;
     }
 }
 
@@ -2369,29 +2405,32 @@ where
     S: BuildHasher + Clone,
 {
     fn invalidation_predicate_count(&self) -> usize {
-        self.invalidator
-            .read()
-            .as_ref()
-            .map(|inv| inv.predicate_count())
-            .unwrap_or(0)
+        if let Some(inv) = &self.invalidator {
+            inv.predicate_count()
+        } else {
+            0
+        }
     }
 
-    fn set_expiration_clock(&self, clock: Option<Clock>) {
-        let mut exp_clock = self.clocks.expiration_clock.write();
+    async fn set_expiration_clock(&self, clock: Option<Clock>) {
+        // Acquire the lock for the clocks to prevent other threads from
+        // updating the expiration clock while we are setting it.
+        let _clocks_lock = self.clocks._lock.lock();
+
         if let Some(clock) = clock {
             let std_now = StdInstant::now();
             let now = Instant::new(clock.now());
-            *exp_clock = Some(clock);
+            *(self.clocks.expiration_clock.write()) = Some(clock);
             self.clocks
                 .has_expiration_clock
                 .store(true, Ordering::SeqCst);
             self.clocks.set_origin(now, std_now);
-            self.timer_wheel.lock().set_origin(now);
+            self.timer_wheel.lock().await.set_origin(now);
         } else {
             self.clocks
                 .has_expiration_clock
                 .store(false, Ordering::SeqCst);
-            *exp_clock = None;
+            *(self.clocks.expiration_clock.write()) = None;
         }
     }
 }
@@ -2519,801 +2558,797 @@ fn is_expired_by_ttl(
     false
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::{common::concurrent::housekeeper, policy::ExpirationPolicy};
-
-    use super::BaseCache;
-
-    #[cfg_attr(target_pointer_width = "16", ignore)]
-    #[test]
-    fn test_skt_capacity_will_not_overflow() {
-        use std::collections::hash_map::RandomState;
-
-        // power of two
-        let pot = |exp| 2u64.pow(exp);
-
-        let ensure_sketch_len = |max_capacity, len, name| {
-            let cache = BaseCache::<u8, u8>::new(
-                None,
-                Some(max_capacity),
-                None,
-                RandomState::default(),
-                None,
-                None,
-                None,
-                Default::default(),
-                false,
-                housekeeper::Configuration::new_thread_pool(true),
-            );
-            cache.inner.enable_frequency_sketch_for_testing();
-            assert_eq!(
-                cache.inner.frequency_sketch.read().table_len(),
-                len as usize,
-                "{}",
-                name
-            );
-        };
-
-        if cfg!(target_pointer_width = "32") {
-            let pot24 = pot(24);
-            let pot16 = pot(16);
-            ensure_sketch_len(0, 128, "0");
-            ensure_sketch_len(128, 128, "128");
-            ensure_sketch_len(pot16, pot16, "pot16");
-            // due to ceiling to next_power_of_two
-            ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
-            // due to ceiling to next_power_of_two
-            ensure_sketch_len(pot24 - 1, pot24, "pot24 - 1");
-            ensure_sketch_len(pot24, pot24, "pot24");
-            ensure_sketch_len(pot(27), pot24, "pot(27)");
-            ensure_sketch_len(u32::MAX as u64, pot24, "u32::MAX");
-        } else {
-            // target_pointer_width: 64 or larger.
-            let pot30 = pot(30);
-            let pot16 = pot(16);
-            ensure_sketch_len(0, 128, "0");
-            ensure_sketch_len(128, 128, "128");
-            ensure_sketch_len(pot16, pot16, "pot16");
-            // due to ceiling to next_power_of_two
-            ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
-
-            // The following tests will allocate large memory (~8GiB).
-            // Skip when running on Circle CI.
-            if !cfg!(circleci) {
-                // due to ceiling to next_power_of_two
-                ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
-                ensure_sketch_len(pot30, pot30, "pot30");
-                ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
-            }
-        };
-    }
-
-    #[test]
-    fn test_per_entry_expiration() {
-        use super::InnerSync;
-        use crate::{common::time::Clock, Entry, Expiry};
-
-        use std::{
-            collections::hash_map::RandomState,
-            sync::{Arc, Mutex},
-            time::{Duration, Instant as StdInstant},
-        };
-
-        type Key = u32;
-        type Value = char;
-
-        fn current_time(cache: &BaseCache<Key, Value>) -> StdInstant {
-            cache
-                .inner
-                .clocks()
-                .to_std_instant(cache.current_time_from_expiration_clock())
-        }
-
-        fn insert(cache: &BaseCache<Key, Value>, key: Key, hash: u64, value: Value) {
-            let (op, _now) = cache.do_insert_with_hash(Arc::new(key), hash, value);
-            cache.write_op_ch.send(op).expect("Failed to send");
-        }
-
-        macro_rules! assert_params_eq {
-            ($left:expr, $right:expr, $param_name:expr, $line:expr) => {
-                assert_eq!(
-                    $left, $right,
-                    "Mismatched `{}`s. line: {}",
-                    $param_name, $line
-                );
-            };
-        }
-
-        macro_rules! assert_expiry {
-            ($cache:ident, $key:ident, $hash:ident, $mock:ident, $duration_secs:expr) => {
-                // Increment the time.
-                $mock.increment(Duration::from_millis($duration_secs * 1000 - 1));
-                $cache.inner.sync(1);
-                assert!($cache.contains_key_with_hash(&$key, $hash));
-                assert_eq!($cache.entry_count(), 1);
-
-                // Increment the time by 1ms (3). The entry should be expired.
-                $mock.increment(Duration::from_millis(1));
-                $cache.inner.sync(1);
-                assert!(!$cache.contains_key_with_hash(&$key, $hash));
-
-                // Increment the time again to ensure the entry has been evicted from the
-                // cache.
-                $mock.increment(Duration::from_secs(1));
-                $cache.inner.sync(1);
-                assert_eq!($cache.entry_count(), 0);
-            };
-        }
-
-        /// Contains expected call parameters and also a return value.
-        #[derive(Debug)]
-        enum ExpiryExpectation {
-            NoCall,
-            AfterCreate {
-                caller_line: u32,
-                key: Key,
-                value: Value,
-                current_time: StdInstant,
-                new_duration_secs: Option<u64>,
-            },
-            AfterRead {
-                caller_line: u32,
-                key: Key,
-                value: Value,
-                current_time: StdInstant,
-                current_duration_secs: Option<u64>,
-                last_modified_at: StdInstant,
-                new_duration_secs: Option<u64>,
-            },
-            AfterUpdate {
-                caller_line: u32,
-                key: Key,
-                value: Value,
-                current_time: StdInstant,
-                current_duration_secs: Option<u64>,
-                new_duration_secs: Option<u64>,
-            },
-        }
-
-        impl ExpiryExpectation {
-            fn after_create(
-                caller_line: u32,
-                key: Key,
-                value: Value,
-                current_time: StdInstant,
-                new_duration_secs: Option<u64>,
-            ) -> Self {
-                Self::AfterCreate {
-                    caller_line,
-                    key,
-                    value,
-                    current_time,
-                    new_duration_secs,
-                }
-            }
-
-            fn after_read(
-                caller_line: u32,
-                key: Key,
-                value: Value,
-                current_time: StdInstant,
-                current_duration_secs: Option<u64>,
-                last_modified_at: StdInstant,
-                new_duration_secs: Option<u64>,
-            ) -> Self {
-                Self::AfterRead {
-                    caller_line,
-                    key,
-                    value,
-                    current_time,
-                    current_duration_secs,
-                    last_modified_at,
-                    new_duration_secs,
-                }
-            }
-
-            fn after_update(
-                caller_line: u32,
-                key: Key,
-                value: Value,
-                current_time: StdInstant,
-                current_duration_secs: Option<u64>,
-                new_duration_secs: Option<u64>,
-            ) -> Self {
-                Self::AfterUpdate {
-                    caller_line,
-                    key,
-                    value,
-                    current_time,
-                    current_duration_secs,
-                    new_duration_secs,
-                }
-            }
-        }
-
-        let expectation = Arc::new(Mutex::new(ExpiryExpectation::NoCall));
-
-        struct MyExpiry {
-            expectation: Arc<Mutex<ExpiryExpectation>>,
-        }
-
-        impl Expiry<u32, char> for MyExpiry {
-            fn expire_after_create(
-                &self,
-                actual_key: &u32,
-                actual_value: &char,
-                actual_current_time: StdInstant,
-            ) -> Option<Duration> {
-                use ExpiryExpectation::*;
-
-                let lock = &mut *self.expectation.lock().unwrap();
-                let expected = std::mem::replace(lock, NoCall);
-                match expected {
-                    AfterCreate {
-                        caller_line,
-                        key,
-                        value,
-                        current_time,
-                        new_duration_secs: new_duration,
-                    } => {
-                        assert_params_eq!(*actual_key, key, "key", caller_line);
-                        assert_params_eq!(*actual_value, value, "value", caller_line);
-                        assert_params_eq!(
-                            actual_current_time,
-                            current_time,
-                            "current_time",
-                            caller_line
-                        );
-                        new_duration.map(Duration::from_secs)
-                    }
-                    expected => {
-                        panic!("Unexpected call to expire_after_create: caller_line {}, expected: {:?}",
-                            line!(), expected
-                        );
-                    }
-                }
-            }
-
-            fn expire_after_read(
-                &self,
-                actual_key: &u32,
-                actual_value: &char,
-                actual_current_time: StdInstant,
-                actual_current_duration: Option<Duration>,
-                actual_last_modified_at: StdInstant,
-            ) -> Option<Duration> {
-                use ExpiryExpectation::*;
-
-                let lock = &mut *self.expectation.lock().unwrap();
-                let expected = std::mem::replace(lock, NoCall);
-                match expected {
-                    AfterRead {
-                        caller_line,
-                        key,
-                        value,
-                        current_time,
-                        current_duration_secs,
-                        last_modified_at,
-                        new_duration_secs,
-                    } => {
-                        assert_params_eq!(*actual_key, key, "key", caller_line);
-                        assert_params_eq!(*actual_value, value, "value", caller_line);
-                        assert_params_eq!(
-                            actual_current_time,
-                            current_time,
-                            "current_time",
-                            caller_line
-                        );
-                        assert_params_eq!(
-                            actual_current_duration,
-                            current_duration_secs.map(Duration::from_secs),
-                            "current_duration",
-                            caller_line
-                        );
-                        assert_params_eq!(
-                            actual_last_modified_at,
-                            last_modified_at,
-                            "last_modified_at",
-                            caller_line
-                        );
-                        new_duration_secs.map(Duration::from_secs)
-                    }
-                    expected => {
-                        panic!(
-                            "Unexpected call to expire_after_read: caller_line {}, expected: {:?}",
-                            line!(),
-                            expected
-                        );
-                    }
-                }
-            }
-
-            fn expire_after_update(
-                &self,
-                actual_key: &u32,
-                actual_value: &char,
-                actual_current_time: StdInstant,
-                actual_current_duration: Option<Duration>,
-            ) -> Option<Duration> {
-                use ExpiryExpectation::*;
-
-                let lock = &mut *self.expectation.lock().unwrap();
-                let expected = std::mem::replace(lock, NoCall);
-                match expected {
-                    AfterUpdate {
-                        caller_line,
-                        key,
-                        value,
-                        current_time,
-                        current_duration_secs,
-                        new_duration_secs,
-                    } => {
-                        assert_params_eq!(*actual_key, key, "key", caller_line);
-                        assert_params_eq!(*actual_value, value, "value", caller_line);
-                        assert_params_eq!(
-                            actual_current_time,
-                            current_time,
-                            "current_time",
-                            caller_line
-                        );
-                        assert_params_eq!(
-                            actual_current_duration,
-                            current_duration_secs.map(Duration::from_secs),
-                            "current_duration",
-                            caller_line
-                        );
-                        new_duration_secs.map(Duration::from_secs)
-                    }
-                    expected => {
-                        panic!("Unexpected call to expire_after_update: caller_line {}, expected: {:?}",
-                            line!(), expected
-                        );
-                    }
-                }
-            }
-        }
-
-        const TTL: u64 = 16;
-        const TTI: u64 = 7;
-        let expiry: Option<Arc<dyn Expiry<_, _> + Send + Sync + 'static>> =
-            Some(Arc::new(MyExpiry {
-                expectation: Arc::clone(&expectation),
-            }));
-
-        let mut cache = BaseCache::<Key, Value>::new(
-            None,
-            None,
-            None,
-            RandomState::default(),
-            None,
-            None,
-            None,
-            ExpirationPolicy::new(
-                Some(Duration::from_secs(TTL)),
-                Some(Duration::from_secs(TTI)),
-                expiry,
-            ),
-            false,
-            housekeeper::Configuration::new_blocking(),
-        );
-        cache.reconfigure_for_testing();
-
-        let (clock, mock) = Clock::mock();
-        cache.set_expiration_clock(Some(clock));
-
-        // Make the cache exterior immutable.
-        let cache = cache;
-
-        mock.increment(Duration::from_millis(10));
-
-        // ----------------------------------------------------
-        // Case 1
-        //
-        // 1.  0s: Insert with per-entry TTL 1s.
-        // 2. +1s: Expires.
-        // ----------------------------------------------------
-
-        // Insert an entry (1). It will have a per-entry TTL of 1 second.
-        let key = 1;
-        let hash = cache.hash(&key);
-        let value = 'a';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(1));
-
-        insert(&cache, key, hash, value);
-        // Run a sync to register the entry to the internal data structures including
-        // the timer wheel.
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        assert_expiry!(cache, key, hash, mock, 1);
-
-        // ----------------------------------------------------
-        // Case 2
-        //
-        // 1.  0s: Insert with no per-entry TTL.
-        // 2. +1s: Get with per-entry TTL 3s.
-        // 3. +3s: Expires.
-        // ----------------------------------------------------
-
-        // Insert an entry (1).
-        let key = 2;
-        let hash = cache.hash(&key);
-        let value = 'b';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), None);
-        let inserted_at = current_time(&cache);
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(1));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-
-        // Read the entry (2).
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 1),
-            inserted_at,
-            Some(3),
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        assert_expiry!(cache, key, hash, mock, 3);
-
-        // ----------------------------------------------------
-        // Case 3
-        //
-        // 1.  0s: Insert with no per-entry TTL.
-        // 2. +1s: Get with no per-entry TTL.
-        // 3. +2s: Update with per-entry TTL 3s.
-        // 4. +3s: Expires.
-        // ----------------------------------------------------
-
-        // Insert an entry (1).
-        let key = 3;
-        let hash = cache.hash(&key);
-        let value = 'c';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), None);
-        let inserted_at = current_time(&cache);
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(1));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-
-        // Read the entry (2).
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 1),
-            inserted_at,
-            None,
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(2));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Update the entry (3).
-        *expectation.lock().unwrap() = ExpiryExpectation::after_update(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            // TTI should be reset by this update.
-            Some(TTI),
-            Some(3),
-        );
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        assert_expiry!(cache, key, hash, mock, 3);
-
-        // ----------------------------------------------------
-        // Case 4
-        //
-        // 1.  0s: Insert with no per-entry TTL.
-        // 2. +1s: Get with no per-entry TTL.
-        // 3. +2s: Update with no per-entry TTL.
-        // 4. +7s: Expires by TTI (7s from step 3).
-        // ----------------------------------------------------
-
-        // Insert an entry (1).
-        let key = 4;
-        let hash = cache.hash(&key);
-        let value = 'd';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), None);
-        let inserted_at = current_time(&cache);
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(1));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Read the entry (2).
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 1),
-            inserted_at,
-            None,
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(2));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Update the entry (3).
-        *expectation.lock().unwrap() = ExpiryExpectation::after_update(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            // TTI should be reset by this update.
-            Some(TTI),
-            None,
-        );
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        assert_expiry!(cache, key, hash, mock, 7);
-
-        // ----------------------------------------------------
-        // Case 5
-        //
-        // 1.  0s: Insert with per-entry TTL 8s.
-        // 2. +5s: Get with per-entry TTL 8s.
-        // 3. +7s: Expires by TTI (7s).
-        // ----------------------------------------------------
-
-        // Insert an entry.
-        let key = 5;
-        let hash = cache.hash(&key);
-        let value = 'e';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(8));
-        let inserted_at = current_time(&cache);
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(5));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Read the entry.
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 5),
-            inserted_at,
-            Some(8),
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        assert_expiry!(cache, key, hash, mock, 7);
-
-        // ----------------------------------------------------
-        // Case 6
-        //
-        // 1.  0s: Insert with per-entry TTL 8s.
-        // 2. +5s: Get with per-entry TTL 9s.
-        // 3. +6s: Get with per-entry TTL 10s.
-        // 4. +5s: Expires by TTL (16s).
-        // ----------------------------------------------------
-
-        // Insert an entry.
-        let key = 6;
-        let hash = cache.hash(&key);
-        let value = 'f';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(8));
-        let inserted_at = current_time(&cache);
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(5));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Read the entry.
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 5),
-            inserted_at,
-            Some(9),
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(6));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Read the entry.
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 6),
-            inserted_at,
-            Some(10),
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        assert_expiry!(cache, key, hash, mock, 5);
-
-        // ----------------------------------------------------
-        // Case 7
-        //
-        // 1.   0s: Insert with per-entry TTL 9s.
-        // 2.  +6s: Update with per-entry TTL 8s.
-        // 3.  +6s: Get with per-entry TTL 9s
-        // 4.  +6s: Get with per-entry TTL 5s.
-        // 5.  +4s: Expires by TTL (16s from step 2).
-        // ----------------------------------------------------
-        // Insert an entry.
-        let key = 7;
-        let hash = cache.hash(&key);
-        let value = 'g';
-
-        *expectation.lock().unwrap() =
-            ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(9));
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(6));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Update the entry (3).
-        *expectation.lock().unwrap() = ExpiryExpectation::after_update(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            // From the per-entry TTL.
-            Some(9 - 6),
-            Some(8),
-        );
-        let updated_at = current_time(&cache);
-        insert(&cache, key, hash, value);
-        cache.inner.sync(1);
-        assert_eq!(cache.entry_count(), 1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(6));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Read the entry.
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 6),
-            updated_at,
-            Some(9),
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        // Increment the time.
-        mock.increment(Duration::from_secs(6));
-        cache.inner.sync(1);
-        assert!(cache.contains_key_with_hash(&key, hash));
-        assert_eq!(cache.entry_count(), 1);
-
-        // Read the entry.
-        *expectation.lock().unwrap() = ExpiryExpectation::after_read(
-            line!(),
-            key,
-            value,
-            current_time(&cache),
-            Some(TTI - 6),
-            updated_at,
-            Some(5),
-        );
-        assert_eq!(
-            cache
-                .get_with_hash(&key, hash, false)
-                .map(Entry::into_value),
-            Some(value)
-        );
-        cache.inner.sync(1);
-
-        assert_expiry!(cache, key, hash, mock, 4);
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use crate::{future::housekeeper, policy::ExpirationPolicy};
+
+//     use super::BaseCache;
+
+//     #[cfg_attr(target_pointer_width = "16", ignore)]
+//     #[tokio::test]
+//     async fn test_skt_capacity_will_not_overflow() {
+//         use std::collections::hash_map::RandomState;
+
+//         // power of two
+//         let pot = |exp| 2u64.pow(exp);
+
+//         let ensure_sketch_len = |max_capacity, len, name| {
+//             let cache = BaseCache::<u8, u8>::new(
+//                 None,
+//                 Some(max_capacity),
+//                 None,
+//                 RandomState::default(),
+//                 None,
+//                 None,
+//                 Default::default(),
+//                 false,
+//             );
+//             cache.inner.enable_frequency_sketch_for_testing();
+//             assert_eq!(
+//                 cache.inner.frequency_sketch.read().await.table_len(),
+//                 len as usize,
+//                 "{}",
+//                 name
+//             );
+//         };
+
+//         if cfg!(target_pointer_width = "32") {
+//             let pot24 = pot(24);
+//             let pot16 = pot(16);
+//             ensure_sketch_len(0, 128, "0");
+//             ensure_sketch_len(128, 128, "128");
+//             ensure_sketch_len(pot16, pot16, "pot16");
+//             // due to ceiling to next_power_of_two
+//             ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
+//             // due to ceiling to next_power_of_two
+//             ensure_sketch_len(pot24 - 1, pot24, "pot24 - 1");
+//             ensure_sketch_len(pot24, pot24, "pot24");
+//             ensure_sketch_len(pot(27), pot24, "pot(27)");
+//             ensure_sketch_len(u32::MAX as u64, pot24, "u32::MAX");
+//         } else {
+//             // target_pointer_width: 64 or larger.
+//             let pot30 = pot(30);
+//             let pot16 = pot(16);
+//             ensure_sketch_len(0, 128, "0");
+//             ensure_sketch_len(128, 128, "128");
+//             ensure_sketch_len(pot16, pot16, "pot16");
+//             // due to ceiling to next_power_of_two
+//             ensure_sketch_len(pot16 + 1, pot(17), "pot16 + 1");
+
+//             // The following tests will allocate large memory (~8GiB).
+//             // Skip when running on Circle CI.
+//             if !cfg!(circleci) {
+//                 // due to ceiling to next_power_of_two
+//                 ensure_sketch_len(pot30 - 1, pot30, "pot30- 1");
+//                 ensure_sketch_len(pot30, pot30, "pot30");
+//                 ensure_sketch_len(u64::MAX, pot30, "u64::MAX");
+//             }
+//         };
+//     }
+
+//     #[test]
+//     fn test_per_entry_expiration() {
+//         use super::InnerSync;
+//         use crate::{common::time::Clock, Entry, Expiry};
+
+//         use std::{
+//             collections::hash_map::RandomState,
+//             sync::{Arc, Mutex},
+//             time::{Duration, Instant as StdInstant},
+//         };
+
+//         type Key = u32;
+//         type Value = char;
+
+//         fn current_time(cache: &BaseCache<Key, Value>) -> StdInstant {
+//             cache
+//                 .inner
+//                 .clocks()
+//                 .to_std_instant(cache.current_time_from_expiration_clock())
+//         }
+
+//         fn insert(cache: &BaseCache<Key, Value>, key: Key, hash: u64, value: Value) {
+//             let (op, _now) = cache.do_insert_with_hash(Arc::new(key), hash, value);
+//             cache.write_op_ch.send(op).expect("Failed to send");
+//         }
+
+//         macro_rules! assert_params_eq {
+//             ($left:expr, $right:expr, $param_name:expr, $line:expr) => {
+//                 assert_eq!(
+//                     $left, $right,
+//                     "Mismatched `{}`s. line: {}",
+//                     $param_name, $line
+//                 );
+//             };
+//         }
+
+//         macro_rules! assert_expiry {
+//             ($cache:ident, $key:ident, $hash:ident, $mock:ident, $duration_secs:expr) => {
+//                 // Increment the time.
+//                 $mock.increment(Duration::from_millis($duration_secs * 1000 - 1));
+//                 $cache.inner.flush(1).await;
+//                 assert!($cache.contains_key_with_hash(&$key, $hash));
+//                 assert_eq!($cache.entry_count(), 1);
+
+//                 // Increment the time by 1ms (3). The entry should be expired.
+//                 $mock.increment(Duration::from_millis(1));
+//                 $cache.inner.flush(1).await;
+//                 assert!(!$cache.contains_key_with_hash(&$key, $hash));
+
+//                 // Increment the time again to ensure the entry has been evicted from the
+//                 // cache.
+//                 $mock.increment(Duration::from_secs(1));
+//                 $cache.inner.flush(1).await;
+//                 assert_eq!($cache.entry_count(), 0);
+//             };
+//         }
+
+//         /// Contains expected call parameters and also a return value.
+//         #[derive(Debug)]
+//         enum ExpiryExpectation {
+//             NoCall,
+//             AfterCreate {
+//                 caller_line: u32,
+//                 key: Key,
+//                 value: Value,
+//                 current_time: StdInstant,
+//                 new_duration_secs: Option<u64>,
+//             },
+//             AfterRead {
+//                 caller_line: u32,
+//                 key: Key,
+//                 value: Value,
+//                 current_time: StdInstant,
+//                 current_duration_secs: Option<u64>,
+//                 last_modified_at: StdInstant,
+//                 new_duration_secs: Option<u64>,
+//             },
+//             AfterUpdate {
+//                 caller_line: u32,
+//                 key: Key,
+//                 value: Value,
+//                 current_time: StdInstant,
+//                 current_duration_secs: Option<u64>,
+//                 new_duration_secs: Option<u64>,
+//             },
+//         }
+
+//         impl ExpiryExpectation {
+//             fn after_create(
+//                 caller_line: u32,
+//                 key: Key,
+//                 value: Value,
+//                 current_time: StdInstant,
+//                 new_duration_secs: Option<u64>,
+//             ) -> Self {
+//                 Self::AfterCreate {
+//                     caller_line,
+//                     key,
+//                     value,
+//                     current_time,
+//                     new_duration_secs,
+//                 }
+//             }
+
+//             fn after_read(
+//                 caller_line: u32,
+//                 key: Key,
+//                 value: Value,
+//                 current_time: StdInstant,
+//                 current_duration_secs: Option<u64>,
+//                 last_modified_at: StdInstant,
+//                 new_duration_secs: Option<u64>,
+//             ) -> Self {
+//                 Self::AfterRead {
+//                     caller_line,
+//                     key,
+//                     value,
+//                     current_time,
+//                     current_duration_secs,
+//                     last_modified_at,
+//                     new_duration_secs,
+//                 }
+//             }
+
+//             fn after_update(
+//                 caller_line: u32,
+//                 key: Key,
+//                 value: Value,
+//                 current_time: StdInstant,
+//                 current_duration_secs: Option<u64>,
+//                 new_duration_secs: Option<u64>,
+//             ) -> Self {
+//                 Self::AfterUpdate {
+//                     caller_line,
+//                     key,
+//                     value,
+//                     current_time,
+//                     current_duration_secs,
+//                     new_duration_secs,
+//                 }
+//             }
+//         }
+
+//         let expectation = Arc::new(Mutex::new(ExpiryExpectation::NoCall));
+
+//         struct MyExpiry {
+//             expectation: Arc<Mutex<ExpiryExpectation>>,
+//         }
+
+//         impl Expiry<u32, char> for MyExpiry {
+//             fn expire_after_create(
+//                 &self,
+//                 actual_key: &u32,
+//                 actual_value: &char,
+//                 actual_current_time: StdInstant,
+//             ) -> Option<Duration> {
+//                 use ExpiryExpectation::*;
+
+//                 let lock = &mut *self.expectation.lock().unwrap();
+//                 let expected = std::mem::replace(lock, NoCall);
+//                 match expected {
+//                     AfterCreate {
+//                         caller_line,
+//                         key,
+//                         value,
+//                         current_time,
+//                         new_duration_secs: new_duration,
+//                     } => {
+//                         assert_params_eq!(*actual_key, key, "key", caller_line);
+//                         assert_params_eq!(*actual_value, value, "value", caller_line);
+//                         assert_params_eq!(
+//                             actual_current_time,
+//                             current_time,
+//                             "current_time",
+//                             caller_line
+//                         );
+//                         new_duration.map(Duration::from_secs)
+//                     }
+//                     expected => {
+//                         panic!("Unexpected call to expire_after_create: caller_line {}, expected: {:?}",
+//                             line!(), expected
+//                         );
+//                     }
+//                 }
+//             }
+
+//             fn expire_after_read(
+//                 &self,
+//                 actual_key: &u32,
+//                 actual_value: &char,
+//                 actual_current_time: StdInstant,
+//                 actual_current_duration: Option<Duration>,
+//                 actual_last_modified_at: StdInstant,
+//             ) -> Option<Duration> {
+//                 use ExpiryExpectation::*;
+
+//                 let lock = &mut *self.expectation.lock().unwrap();
+//                 let expected = std::mem::replace(lock, NoCall);
+//                 match expected {
+//                     AfterRead {
+//                         caller_line,
+//                         key,
+//                         value,
+//                         current_time,
+//                         current_duration_secs,
+//                         last_modified_at,
+//                         new_duration_secs,
+//                     } => {
+//                         assert_params_eq!(*actual_key, key, "key", caller_line);
+//                         assert_params_eq!(*actual_value, value, "value", caller_line);
+//                         assert_params_eq!(
+//                             actual_current_time,
+//                             current_time,
+//                             "current_time",
+//                             caller_line
+//                         );
+//                         assert_params_eq!(
+//                             actual_current_duration,
+//                             current_duration_secs.map(Duration::from_secs),
+//                             "current_duration",
+//                             caller_line
+//                         );
+//                         assert_params_eq!(
+//                             actual_last_modified_at,
+//                             last_modified_at,
+//                             "last_modified_at",
+//                             caller_line
+//                         );
+//                         new_duration_secs.map(Duration::from_secs)
+//                     }
+//                     expected => {
+//                         panic!(
+//                             "Unexpected call to expire_after_read: caller_line {}, expected: {:?}",
+//                             line!(),
+//                             expected
+//                         );
+//                     }
+//                 }
+//             }
+
+//             fn expire_after_update(
+//                 &self,
+//                 actual_key: &u32,
+//                 actual_value: &char,
+//                 actual_current_time: StdInstant,
+//                 actual_current_duration: Option<Duration>,
+//             ) -> Option<Duration> {
+//                 use ExpiryExpectation::*;
+
+//                 let lock = &mut *self.expectation.lock().unwrap();
+//                 let expected = std::mem::replace(lock, NoCall);
+//                 match expected {
+//                     AfterUpdate {
+//                         caller_line,
+//                         key,
+//                         value,
+//                         current_time,
+//                         current_duration_secs,
+//                         new_duration_secs,
+//                     } => {
+//                         assert_params_eq!(*actual_key, key, "key", caller_line);
+//                         assert_params_eq!(*actual_value, value, "value", caller_line);
+//                         assert_params_eq!(
+//                             actual_current_time,
+//                             current_time,
+//                             "current_time",
+//                             caller_line
+//                         );
+//                         assert_params_eq!(
+//                             actual_current_duration,
+//                             current_duration_secs.map(Duration::from_secs),
+//                             "current_duration",
+//                             caller_line
+//                         );
+//                         new_duration_secs.map(Duration::from_secs)
+//                     }
+//                     expected => {
+//                         panic!("Unexpected call to expire_after_update: caller_line {}, expected: {:?}",
+//                             line!(), expected
+//                         );
+//                     }
+//                 }
+//             }
+//         }
+
+//         const TTL: u64 = 16;
+//         const TTI: u64 = 7;
+//         let expiry: Option<Arc<dyn Expiry<_, _> + Send + Sync + 'static>> =
+//             Some(Arc::new(MyExpiry {
+//                 expectation: Arc::clone(&expectation),
+//             }));
+
+//         let mut cache = BaseCache::<Key, Value>::new(
+//             None,
+//             None,
+//             None,
+//             RandomState::default(),
+//             None,
+//             None,
+//             ExpirationPolicy::new(
+//                 Some(Duration::from_secs(TTL)),
+//                 Some(Duration::from_secs(TTI)),
+//                 expiry,
+//             ),
+//             false,
+//         );
+//         cache.reconfigure_for_testing();
+
+//         let (clock, mock) = Clock::mock();
+//         cache.set_expiration_clock(Some(clock));
+
+//         // Make the cache exterior immutable.
+//         let cache = cache;
+
+//         mock.increment(Duration::from_millis(10));
+
+//         // ----------------------------------------------------
+//         // Case 1
+//         //
+//         // 1.  0s: Insert with per-entry TTL 1s.
+//         // 2. +1s: Expires.
+//         // ----------------------------------------------------
+
+//         // Insert an entry (1). It will have a per-entry TTL of 1 second.
+//         let key = 1;
+//         let hash = cache.hash(&key);
+//         let value = 'a';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(1));
+
+//         insert(&cache, key, hash, value);
+//         // Run a sync to register the entry to the internal data structures including
+//         // the timer wheel.
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         assert_expiry!(cache, key, hash, mock, 1);
+
+//         // ----------------------------------------------------
+//         // Case 2
+//         //
+//         // 1.  0s: Insert with no per-entry TTL.
+//         // 2. +1s: Get with per-entry TTL 3s.
+//         // 3. +3s: Expires.
+//         // ----------------------------------------------------
+
+//         // Insert an entry (1).
+//         let key = 2;
+//         let hash = cache.hash(&key);
+//         let value = 'b';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), None);
+//         let inserted_at = current_time(&cache);
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(1));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+
+//         // Read the entry (2).
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 1),
+//             inserted_at,
+//             Some(3),
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         assert_expiry!(cache, key, hash, mock, 3);
+
+//         // ----------------------------------------------------
+//         // Case 3
+//         //
+//         // 1.  0s: Insert with no per-entry TTL.
+//         // 2. +1s: Get with no per-entry TTL.
+//         // 3. +2s: Update with per-entry TTL 3s.
+//         // 4. +3s: Expires.
+//         // ----------------------------------------------------
+
+//         // Insert an entry (1).
+//         let key = 3;
+//         let hash = cache.hash(&key);
+//         let value = 'c';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), None);
+//         let inserted_at = current_time(&cache);
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(1));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+
+//         // Read the entry (2).
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 1),
+//             inserted_at,
+//             None,
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(2));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Update the entry (3).
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_update(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             // TTI should be reset by this update.
+//             Some(TTI),
+//             Some(3),
+//         );
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         assert_expiry!(cache, key, hash, mock, 3);
+
+//         // ----------------------------------------------------
+//         // Case 4
+//         //
+//         // 1.  0s: Insert with no per-entry TTL.
+//         // 2. +1s: Get with no per-entry TTL.
+//         // 3. +2s: Update with no per-entry TTL.
+//         // 4. +7s: Expires by TTI (7s from step 3).
+//         // ----------------------------------------------------
+
+//         // Insert an entry (1).
+//         let key = 4;
+//         let hash = cache.hash(&key);
+//         let value = 'd';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), None);
+//         let inserted_at = current_time(&cache);
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(1));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Read the entry (2).
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 1),
+//             inserted_at,
+//             None,
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(2));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Update the entry (3).
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_update(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             // TTI should be reset by this update.
+//             Some(TTI),
+//             None,
+//         );
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         assert_expiry!(cache, key, hash, mock, 7);
+
+//         // ----------------------------------------------------
+//         // Case 5
+//         //
+//         // 1.  0s: Insert with per-entry TTL 8s.
+//         // 2. +5s: Get with per-entry TTL 8s.
+//         // 3. +7s: Expires by TTI (7s).
+//         // ----------------------------------------------------
+
+//         // Insert an entry.
+//         let key = 5;
+//         let hash = cache.hash(&key);
+//         let value = 'e';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(8));
+//         let inserted_at = current_time(&cache);
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(5));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Read the entry.
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 5),
+//             inserted_at,
+//             Some(8),
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         assert_expiry!(cache, key, hash, mock, 7);
+
+//         // ----------------------------------------------------
+//         // Case 6
+//         //
+//         // 1.  0s: Insert with per-entry TTL 8s.
+//         // 2. +5s: Get with per-entry TTL 9s.
+//         // 3. +6s: Get with per-entry TTL 10s.
+//         // 4. +5s: Expires by TTL (16s).
+//         // ----------------------------------------------------
+
+//         // Insert an entry.
+//         let key = 6;
+//         let hash = cache.hash(&key);
+//         let value = 'f';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(8));
+//         let inserted_at = current_time(&cache);
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(5));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Read the entry.
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 5),
+//             inserted_at,
+//             Some(9),
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(6));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Read the entry.
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 6),
+//             inserted_at,
+//             Some(10),
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         assert_expiry!(cache, key, hash, mock, 5);
+
+//         // ----------------------------------------------------
+//         // Case 7
+//         //
+//         // 1.   0s: Insert with per-entry TTL 9s.
+//         // 2.  +6s: Update with per-entry TTL 8s.
+//         // 3.  +6s: Get with per-entry TTL 9s
+//         // 4.  +6s: Get with per-entry TTL 5s.
+//         // 5.  +4s: Expires by TTL (16s from step 2).
+//         // ----------------------------------------------------
+//         // Insert an entry.
+//         let key = 7;
+//         let hash = cache.hash(&key);
+//         let value = 'g';
+
+//         *expectation.lock().unwrap() =
+//             ExpiryExpectation::after_create(line!(), key, value, current_time(&cache), Some(9));
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(6));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Update the entry (3).
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_update(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             // From the per-entry TTL.
+//             Some(9 - 6),
+//             Some(8),
+//         );
+//         let updated_at = current_time(&cache);
+//         insert(&cache, key, hash, value);
+//         cache.inner.flush(1).await;
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(6));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Read the entry.
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 6),
+//             updated_at,
+//             Some(9),
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         // Increment the time.
+//         mock.increment(Duration::from_secs(6));
+//         cache.inner.flush(1).await;
+//         assert!(cache.contains_key_with_hash(&key, hash));
+//         assert_eq!(cache.entry_count(), 1);
+
+//         // Read the entry.
+//         *expectation.lock().unwrap() = ExpiryExpectation::after_read(
+//             line!(),
+//             key,
+//             value,
+//             current_time(&cache),
+//             Some(TTI - 6),
+//             updated_at,
+//             Some(5),
+//         );
+//         assert_eq!(
+//             cache
+//                 .get_with_hash(&key, hash, false)
+//                 .map(Entry::into_value),
+//             Some(value)
+//         );
+//         cache.inner.flush(1).await;
+
+//         assert_expiry!(cache, key, hash, mock, 4);
+//     }
+// }

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -489,9 +489,10 @@ where
             // on_modify
             |_k, old_entry| {
                 // NOTES on `new_value_entry_from` method:
-                // 1. The internal EntryInfo will be shared between the old and new ValueEntries.
-                // 2. This method will set the last_accessed and last_modified to the max value to
-                //    prevent this new ValueEntry from being evicted by an expiration policy.
+                // 1. The internal EntryInfo will be shared between the old and new
+                //    ValueEntries.
+                // 2. This method will set the is_dirty to prevent this new
+                //    ValueEntry from being evicted by an expiration policy.
                 // 3. This method will update the policy_weight with the new weight.
                 let old_weight = old_entry.policy_weight();
                 let old_timestamps = (old_entry.last_accessed(), old_entry.last_modified());
@@ -1231,12 +1232,6 @@ mod batch_size {
     pub(crate) const INVALIDATION_BATCH_SIZE: usize = 500;
 }
 
-// TODO: Divide this method into smaller methods so that unit tests can do more
-// precise testing.
-// - sync_reads
-// - sync_writes
-// - evict
-// - invalidate_entries
 #[async_trait]
 impl<K, V, S> InnerSync for Inner<K, V, S>
 where

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -2081,8 +2081,7 @@ where
                 }
                 Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
             } else if let Some(entry) = self.cache.get(hash, |k| k == key) {
-                // TODO: CHECKME: Should we check `entry.is_dirty()` instead?
-                if entry.last_modified().is_none() {
+                if entry.is_dirty() {
                     deqs.move_to_back_ao(&entry);
                     deqs.move_to_back_wo(&entry);
                 } else {

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -262,8 +262,16 @@ impl<K, V, C> CacheBuilder<K, V, C> {
     ///
     /// See [this example][example] for a usage of eviction listener.
     ///
-    /// If you want to use an asynchronous listener, use
-    /// [`async_eviction_listener`](#method.async_eviction_listener) instead.
+    /// # Sync or Async Eviction Listener
+    ///
+    /// The closure can be either synchronous or asynchronous, and `CacheBuilder`
+    /// provides two methods for setting the eviction listener closure:
+    ///
+    /// - If you do not need to `.await` anything in the eviction listener, use this
+    ///   `eviction_listener` method.
+    /// - If you need to `.await` something in the eviction listener, use
+    ///   [`async_eviction_listener`](#method.async_eviction_listener) method
+    ///   instead.
     ///
     /// # Panics
     ///
@@ -297,8 +305,15 @@ impl<K, V, C> CacheBuilder<K, V, C> {
     ///
     /// See [this example][example] for a usage of asynchronous eviction listener.
     ///
-    /// If you want to use a synchronous listener, use
-    /// [`eviction_listener`](#method.eviction_listener) instead.
+    /// # Sync or Async Eviction Listener
+    ///
+    /// The closure can be either synchronous or asynchronous, and `CacheBuilder`
+    /// provides two methods for setting the eviction listener closure:
+    ///
+    /// - If you do not need to `.await` anything in the eviction listener, use
+    ///   [`eviction_listener`](#method.eviction_listener) method instead.
+    /// - If you need to `.await` something in the eviction listener, use
+    ///   this method.
     ///
     /// # Panics
     ///

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -24,7 +24,7 @@ use std::{
 /// // Cargo.toml
 /// //
 /// // [dependencies]
-/// // moka = { version = "0.11", features = ["future"] }
+/// // moka = { version = "0.12", features = ["future"] }
 /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 /// // futures = "0.3"
 ///

--- a/src/future/builder.rs
+++ b/src/future/builder.rs
@@ -279,7 +279,14 @@ impl<K, V, C> CacheBuilder<K, V, C> {
     where
         F: Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static,
     {
-        let async_listener = move |k, v, c| std::future::ready(listener(k, v, c)).boxed();
+        let async_listener = move |k, v, c| {
+            {
+                listener(k, v, c);
+                std::future::ready(())
+            }
+            .boxed()
+        };
+
         self.async_eviction_listener(async_listener)
     }
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -33,10 +33,8 @@ use std::{
 /// A thread-safe, futures-aware concurrent in-memory cache.
 ///
 /// `Cache` supports full concurrency of retrievals and a high expected concurrency
-/// for updates. It can be accessed inside and outside of asynchronous contexts.
-///
-/// `Cache` utilizes a lock-free concurrent hash table as the central key-value
-/// storage. `Cache` performs a best-effort bounding of the map using an entry
+/// for updates.It utilizes a lock-free concurrent hash table as the central
+/// key-value storage. It performs a best-effort bounding of the map using an entry
 /// replacement algorithm to determine which entries to evict when the capacity is
 /// exceeded.
 ///
@@ -386,9 +384,8 @@ use std::{
 ///     // eviction listener.
 ///     let expiry = MyExpiry;
 ///
-///     let eviction_listener = |key, _value, cause| -> ListenerFuture {
+///     let eviction_listener = |key, _value, cause| {
 ///         println!("Evicted key {key}. Cause: {cause:?}");
-///         async move {}.boxed()
 ///     };
 ///
 ///     let cache = Cache::builder()
@@ -575,7 +572,7 @@ use std::{
 ///     let cache = Cache::builder()
 ///         .max_capacity(100)
 ///         .time_to_live(Duration::from_secs(2))
-///         .eviction_listener(listener)
+///         .async_eviction_listener(listener)
 ///         .build();
 ///
 ///     // Insert an entry to the cache.
@@ -2032,7 +2029,7 @@ mod tests {
         // Create a cache with the eviction listener.
         let mut cache = Cache::builder()
             .max_capacity(3)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2134,7 +2131,7 @@ mod tests {
         let mut cache = Cache::builder()
             .max_capacity(31)
             .weigher(weigher)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2303,7 +2300,7 @@ mod tests {
         // Create a cache with the eviction listener.
         let mut cache = Cache::builder()
             .max_capacity(100)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2380,7 +2377,7 @@ mod tests {
         let mut cache = Cache::builder()
             .max_capacity(100)
             .support_invalidation_closures()
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2484,7 +2481,7 @@ mod tests {
         let mut cache = Cache::builder()
             .max_capacity(100)
             .time_to_live(Duration::from_secs(10))
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2572,7 +2569,7 @@ mod tests {
         let mut cache = Cache::builder()
             .max_capacity(100)
             .time_to_idle(Duration::from_secs(10))
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2695,7 +2692,7 @@ mod tests {
         let mut cache = Cache::builder()
             .max_capacity(100)
             .expire_after(expiry)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -2816,7 +2813,7 @@ mod tests {
         let mut cache = Cache::builder()
             .max_capacity(100)
             .expire_after(expiry)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -4171,7 +4168,7 @@ mod tests {
         // Create a cache with the eviction listener.
         let mut cache = Cache::builder()
             .max_capacity(3)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -4235,7 +4232,7 @@ mod tests {
 
         // Create a cache with the eviction listener and also TTL and TTI.
         let mut cache = Cache::builder()
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .time_to_live(Duration::from_secs(7))
             .time_to_idle(Duration::from_secs(5))
             .build();
@@ -4346,7 +4343,7 @@ mod tests {
         // Create a cache with the eviction listener.
         let mut cache = Cache::builder()
             .name("My Future Cache")
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 
@@ -4424,7 +4421,7 @@ mod tests {
 
         let mut cache = Cache::builder()
             .max_capacity(MAX_CAPACITY as u64)
-            .eviction_listener(listener)
+            .async_eviction_listener(listener)
             .build();
         cache.reconfigure_for_testing().await;
 

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -195,7 +195,7 @@ where
     pub async fn or_insert_with_if(
         self,
         init: impl Future<Output = V>,
-        replace_if: impl FnMut(&V) -> bool,
+        replace_if: impl FnMut(&V) -> bool + Send,
     ) -> Entry<K, V> {
         futures_util::pin_mut!(init);
         let key = Arc::new(self.owned_key);
@@ -543,7 +543,7 @@ where
     pub async fn or_insert_with_if(
         self,
         init: impl Future<Output = V>,
-        replace_if: impl FnMut(&V) -> bool,
+        replace_if: impl FnMut(&V) -> bool + Send,
     ) -> Entry<K, V> {
         futures_util::pin_mut!(init);
         self.cache

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -52,7 +52,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -94,7 +94,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -135,7 +135,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -218,7 +218,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -293,7 +293,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -403,7 +403,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -444,7 +444,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -484,7 +484,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -571,7 +571,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -645,7 +645,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.11", features = ["future"] }
+    /// // moka = { version = "0.12", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;

--- a/src/future/housekeeper.rs
+++ b/src/future/housekeeper.rs
@@ -55,8 +55,8 @@ impl Housekeeper {
         match self.is_sync_running.compare_exchange(
             false,
             true,
+            Ordering::AcqRel,
             Ordering::Acquire,
-            Ordering::Relaxed,
         ) {
             Ok(_) => {
                 let now = cache.now();

--- a/src/future/housekeeper.rs
+++ b/src/future/housekeeper.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 
 #[async_trait]
 pub(crate) trait InnerSync {
-    async fn flush(&self, max_sync_repeats: usize);
+    async fn run_pending_tasks(&self, max_sync_repeats: usize);
     fn now(&self) -> Instant;
 }
 
@@ -62,7 +62,7 @@ impl Housekeeper {
                 let now = cache.now();
                 self.sync_after.set_instant(Self::sync_after(now));
 
-                cache.flush(MAX_SYNC_REPEATS).await;
+                cache.run_pending_tasks(MAX_SYNC_REPEATS).await;
 
                 self.is_sync_running.store(false, Ordering::Release);
                 true

--- a/src/future/housekeeper.rs
+++ b/src/future/housekeeper.rs
@@ -1,0 +1,81 @@
+use crate::common::{
+    concurrent::{
+        atomic_time::AtomicInstant,
+        constants::{
+            MAX_SYNC_REPEATS, PERIODICAL_SYNC_INITIAL_DELAY_MILLIS, READ_LOG_FLUSH_POINT,
+            WRITE_LOG_FLUSH_POINT,
+        },
+    },
+    time::{CheckedTimeOps, Instant},
+};
+
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+
+#[async_trait]
+pub(crate) trait InnerSync {
+    async fn flush(&self, max_sync_repeats: usize);
+    fn now(&self) -> Instant;
+}
+
+pub(crate) struct Housekeeper {
+    is_sync_running: AtomicBool,
+    sync_after: AtomicInstant,
+}
+
+impl Default for Housekeeper {
+    fn default() -> Self {
+        Self {
+            is_sync_running: Default::default(),
+            sync_after: AtomicInstant::new(Self::sync_after(Instant::now())),
+        }
+    }
+}
+
+impl Housekeeper {
+    pub(crate) fn should_apply_reads(&self, ch_len: usize, now: Instant) -> bool {
+        self.should_apply(ch_len, READ_LOG_FLUSH_POINT / 8, now)
+    }
+
+    pub(crate) fn should_apply_writes(&self, ch_len: usize, now: Instant) -> bool {
+        self.should_apply(ch_len, WRITE_LOG_FLUSH_POINT / 8, now)
+    }
+
+    #[inline]
+    fn should_apply(&self, ch_len: usize, ch_flush_point: usize, now: Instant) -> bool {
+        ch_len >= ch_flush_point || self.sync_after.instant().unwrap() >= now
+    }
+
+    pub(crate) async fn try_sync<T: InnerSync>(&self, cache: &T) -> bool {
+        // Try to flip the value of sync_scheduled from false to true.
+        match self.is_sync_running.compare_exchange(
+            false,
+            true,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => {
+                let now = cache.now();
+                self.sync_after.set_instant(Self::sync_after(now));
+
+                cache.flush(MAX_SYNC_REPEATS).await;
+
+                self.is_sync_running.store(false, Ordering::Release);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    fn sync_after(now: Instant) -> Instant {
+        let dur = Duration::from_millis(PERIODICAL_SYNC_INITIAL_DELAY_MILLIS);
+        let ts = now.checked_add(dur);
+        // Assuming that `now` is current wall clock time, this should never fail at
+        // least next millions of years.
+        ts.expect("Timestamp overflow")
+    }
+}

--- a/src/future/invalidator.rs
+++ b/src/future/invalidator.rs
@@ -1,0 +1,392 @@
+use super::{PredicateId, PredicateIdStr};
+use crate::{
+    common::{
+        concurrent::{AccessTime, KvEntry, ValueEntry},
+        time::Instant,
+    },
+    PredicateError,
+};
+
+use async_lock::{Mutex, MutexGuard};
+use async_trait::async_trait;
+use std::{
+    hash::{BuildHasher, Hash},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use triomphe::Arc as TrioArc;
+use uuid::Uuid;
+
+pub(crate) type PredicateFun<K, V> = Arc<dyn Fn(&K, &V) -> bool + Send + Sync + 'static>;
+
+const PREDICATE_MAP_NUM_SEGMENTS: usize = 16;
+
+#[async_trait]
+pub(crate) trait GetOrRemoveEntry<K, V> {
+    fn get_value_entry(&self, key: &Arc<K>, hash: u64) -> Option<TrioArc<ValueEntry<K, V>>>;
+
+    async fn remove_key_value_if<F>(
+        &self,
+        key: &Arc<K>,
+        hash: u64,
+        condition: F,
+    ) -> Option<TrioArc<ValueEntry<K, V>>>
+    where
+        K: Send + Sync + 'static,
+        V: Clone + Send + Sync + 'static,
+        F: for<'a, 'b> FnMut(&'a Arc<K>, &'b TrioArc<ValueEntry<K, V>>) -> bool + Send;
+}
+
+pub(crate) struct KeyDateLite<K> {
+    key: Arc<K>,
+    hash: u64,
+    timestamp: Instant,
+}
+
+impl<K> Clone for KeyDateLite<K> {
+    fn clone(&self) -> Self {
+        Self {
+            key: Arc::clone(&self.key),
+            hash: self.hash,
+            timestamp: self.timestamp,
+        }
+    }
+}
+
+impl<K> KeyDateLite<K> {
+    pub(crate) fn new(key: &Arc<K>, hash: u64, timestamp: Instant) -> Self {
+        Self {
+            key: Arc::clone(key),
+            hash,
+            timestamp,
+        }
+    }
+}
+
+pub(crate) struct Invalidator<K, V, S> {
+    predicates: crate::cht::SegmentedHashMap<PredicateId, Predicate<K, V>, S>,
+    is_empty: AtomicBool,
+    scan_context: Arc<ScanContext<K, V>>,
+}
+
+//
+// Crate public methods.
+//
+impl<K, V, S> Invalidator<K, V, S> {
+    pub(crate) fn new(hasher: S) -> Self
+    where
+        S: BuildHasher,
+    {
+        const CAPACITY: usize = 0;
+        let predicates = crate::cht::SegmentedHashMap::with_num_segments_capacity_and_hasher(
+            PREDICATE_MAP_NUM_SEGMENTS,
+            CAPACITY,
+            hasher,
+        );
+        Self {
+            predicates,
+            is_empty: AtomicBool::new(true),
+            scan_context: Arc::new(ScanContext::default()),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.is_empty.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn remove_predicates_registered_before(&self, ts: Instant)
+    where
+        K: Hash + Eq + Send + Sync + 'static,
+        V: Clone + Send + Sync + 'static,
+        S: BuildHasher,
+    {
+        let pred_map = &self.predicates;
+
+        let removing_ids = pred_map
+            .iter()
+            .filter(|(_, pred)| pred.registered_at <= ts)
+            .map(|(id, _)| id)
+            .collect::<Vec<_>>();
+
+        for id in removing_ids {
+            let hash = pred_map.hash(&id);
+            pred_map.remove(hash, |k| k == &id);
+        }
+
+        if pred_map.is_empty() {
+            self.is_empty.store(true, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn register_predicate(
+        &self,
+        predicate: PredicateFun<K, V>,
+        registered_at: Instant,
+    ) -> Result<PredicateId, PredicateError>
+    where
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        const MAX_RETRY: usize = 1_000;
+        let mut tries = 0;
+        let preds = &self.predicates;
+
+        while tries < MAX_RETRY {
+            let id = Uuid::new_v4().as_hyphenated().to_string();
+
+            let hash = preds.hash(&id);
+            if preds.contains_key(hash, |k| k == &id) {
+                tries += 1;
+
+                continue; // Retry
+            }
+            let pred = Predicate::new(&id, predicate, registered_at);
+            preds.insert_entry_and(id.clone(), hash, pred, |_, _| ());
+            self.is_empty.store(false, Ordering::Release);
+
+            return Ok(id);
+        }
+
+        // Since we are using 128-bit UUID for the ID and we do retries for MAX_RETRY
+        // times, this panic should extremely unlikely occur (unless there is a bug in
+        // UUID generation).
+        panic!("Cannot assign a new PredicateId to a predicate");
+    }
+
+    // This method will be called by the get method of Cache.
+    #[inline]
+    pub(crate) fn apply_predicates(&self, key: &Arc<K>, entry: &TrioArc<ValueEntry<K, V>>) -> bool
+    where
+        K: Hash + Eq + Send + Sync + 'static,
+        V: Clone + Send + Sync + 'static,
+        S: BuildHasher,
+    {
+        if self.is_empty() {
+            false
+        } else if let Some(ts) = entry.last_modified() {
+            Self::do_apply_predicates(
+                self.predicates.iter().map(|(_, v)| v),
+                key,
+                &entry.value,
+                ts,
+            )
+        } else {
+            false
+        }
+    }
+
+    pub(crate) async fn scan_and_invalidate<C>(
+        &self,
+        cache: &C,
+        candidates: Vec<KeyDateLite<K>>,
+        is_truncated: bool,
+    ) -> (Vec<KvEntry<K, V>>, bool)
+    where
+        C: GetOrRemoveEntry<K, V>,
+        K: Hash + Eq + Send + Sync + 'static,
+        V: Clone + Send + Sync + 'static,
+        S: BuildHasher,
+    {
+        let mut predicates = self.scan_context.predicates.lock().await;
+        if predicates.is_empty() {
+            *predicates = self.predicates.iter().map(|(_k, v)| v).collect();
+        }
+
+        let mut invalidated = Vec::default();
+        let mut newest_timestamp = None;
+
+        for candidate in &candidates {
+            let key = &candidate.key;
+            let hash = candidate.hash;
+            let ts = candidate.timestamp;
+            if self.apply(&predicates, cache, key, hash, ts) {
+                if let Some(entry) = Self::invalidate(cache, key, hash, ts).await {
+                    invalidated.push(KvEntry {
+                        key: Arc::clone(key),
+                        entry,
+                    })
+                }
+            }
+            newest_timestamp = Some(ts);
+        }
+
+        self.remove_finished_predicates(predicates, is_truncated, newest_timestamp)
+            .await;
+
+        (invalidated, self.predicates.is_empty())
+    }
+}
+
+//
+// Private methods.
+//
+impl<K, V, S> Invalidator<K, V, S> {
+    #[inline]
+    fn do_apply_predicates<I>(predicates: I, key: &K, value: &V, ts: Instant) -> bool
+    where
+        I: Iterator<Item = Predicate<K, V>>,
+    {
+        for predicate in predicates {
+            if predicate.is_applicable(ts) && predicate.apply(key, value) {
+                return true;
+            }
+        }
+        false
+    }
+
+    async fn remove_finished_predicates(
+        &self,
+        mut predicates: MutexGuard<'_, Vec<Predicate<K, V>>>,
+        is_truncated: bool,
+        newest_timestamp: Option<Instant>,
+    ) where
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        let predicates = &mut *predicates;
+        if is_truncated {
+            if let Some(ts) = newest_timestamp {
+                let (active, finished): (Vec<_>, Vec<_>) =
+                    predicates.drain(..).partition(|p| p.is_applicable(ts));
+
+                // Remove finished predicates from the predicate registry.
+                self.remove_predicates(&finished).await;
+                // Set the active predicates to the scan context.
+                *predicates = active;
+            } else {
+                unreachable!();
+            }
+        } else {
+            // Remove all the predicates from the predicate registry and scan context.
+            self.remove_predicates(predicates).await;
+            predicates.clear();
+        }
+    }
+
+    async fn remove_predicates(&self, predicates: &[Predicate<K, V>])
+    where
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        let pred_map = &self.predicates;
+        predicates.iter().for_each(|p| {
+            let hash = pred_map.hash(p.id());
+            pred_map.remove(hash, |k| k == p.id());
+        });
+
+        if pred_map.is_empty() {
+            self.is_empty.store(true, Ordering::Release);
+        }
+    }
+
+    fn apply<C>(
+        &self,
+        predicates: &[Predicate<K, V>],
+        cache: &C,
+        key: &Arc<K>,
+        hash: u64,
+        ts: Instant,
+    ) -> bool
+    where
+        C: GetOrRemoveEntry<K, V>,
+    {
+        if let Some(entry) = cache.get_value_entry(key, hash) {
+            if let Some(lm) = entry.last_modified() {
+                if lm == ts {
+                    return Self::do_apply_predicates(
+                        predicates.iter().cloned(),
+                        key,
+                        &entry.value,
+                        lm,
+                    );
+                }
+            }
+        }
+
+        false
+    }
+
+    async fn invalidate<C>(
+        cache: &C,
+        key: &Arc<K>,
+        hash: u64,
+        ts: Instant,
+    ) -> Option<TrioArc<ValueEntry<K, V>>>
+    where
+        C: GetOrRemoveEntry<K, V>,
+        K: Send + Sync + 'static,
+        V: Clone + Send + Sync + 'static,
+    {
+        cache
+            .remove_key_value_if(key, hash, |_, v| {
+                if let Some(lm) = v.last_modified() {
+                    lm == ts
+                } else {
+                    false
+                }
+            })
+            .await
+    }
+}
+
+//
+// for testing
+//
+#[cfg(test)]
+impl<K, V, S> Invalidator<K, V, S> {
+    pub(crate) fn predicate_count(&self) -> usize {
+        self.predicates.len()
+    }
+}
+
+struct ScanContext<K, V> {
+    predicates: Mutex<Vec<Predicate<K, V>>>,
+}
+
+impl<K, V> Default for ScanContext<K, V> {
+    fn default() -> Self {
+        Self {
+            predicates: Mutex::new(Vec::default()),
+        }
+    }
+}
+
+struct Predicate<K, V> {
+    id: PredicateId,
+    f: PredicateFun<K, V>,
+    registered_at: Instant,
+}
+
+impl<K, V> Clone for Predicate<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id.clone(),
+            f: Arc::clone(&self.f),
+            registered_at: self.registered_at,
+        }
+    }
+}
+
+impl<K, V> Predicate<K, V> {
+    fn new(id: PredicateIdStr<'_>, f: PredicateFun<K, V>, registered_at: Instant) -> Self {
+        Self {
+            id: id.to_string(),
+            f,
+            registered_at,
+        }
+    }
+
+    fn id(&self) -> PredicateIdStr<'_> {
+        &self.id
+    }
+
+    fn is_applicable(&self, last_modified: Instant) -> bool {
+        last_modified <= self.registered_at
+    }
+
+    fn apply(&self, key: &K, value: &V) -> bool {
+        (self.f)(key, value)
+    }
+}

--- a/src/future/key_lock.rs
+++ b/src/future/key_lock.rs
@@ -30,11 +30,11 @@ where
     S: BuildHasher,
 {
     fn drop(&mut self) {
-        if TrioArc::count(&self.lock) <= 1 {
+        if TrioArc::count(&self.lock) <= 2 {
             self.map.remove_if(
                 self.hash,
                 |k| k == &self.key,
-                |_k, v| TrioArc::count(v) <= 1,
+                |_k, v| TrioArc::count(v) <= 2,
             );
         }
     }
@@ -84,5 +84,12 @@ where
             None => KeyLock::new(&self.locks, key, hash, kl),
             Some(existing_kl) => KeyLock::new(&self.locks, key, hash, existing_kl),
         }
+    }
+}
+
+#[cfg(test)]
+impl<K, S> KeyLockMap<K, S> {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.locks.len() == 0
     }
 }

--- a/src/future/key_lock.rs
+++ b/src/future/key_lock.rs
@@ -1,0 +1,88 @@
+use std::{
+    hash::{BuildHasher, Hash},
+    sync::Arc,
+};
+
+use crate::cht::SegmentedHashMap;
+
+use async_lock::{Mutex, MutexGuard};
+use triomphe::Arc as TrioArc;
+
+const LOCK_MAP_NUM_SEGMENTS: usize = 64;
+
+type LockMap<K, S> = SegmentedHashMap<Arc<K>, TrioArc<Mutex<()>>, S>;
+
+// We need the `where` clause here because of the Drop impl.
+pub(crate) struct KeyLock<'a, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    map: &'a LockMap<K, S>,
+    key: Arc<K>,
+    hash: u64,
+    lock: TrioArc<Mutex<()>>,
+}
+
+impl<'a, K, S> Drop for KeyLock<'a, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn drop(&mut self) {
+        if TrioArc::count(&self.lock) <= 1 {
+            self.map.remove_if(
+                self.hash,
+                |k| k == &self.key,
+                |_k, v| TrioArc::count(v) <= 1,
+            );
+        }
+    }
+}
+
+impl<'a, K, S> KeyLock<'a, K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn new(map: &'a LockMap<K, S>, key: &Arc<K>, hash: u64, lock: TrioArc<Mutex<()>>) -> Self {
+        Self {
+            map,
+            key: Arc::clone(key),
+            hash,
+            lock,
+        }
+    }
+
+    pub(crate) async fn lock(&self) -> MutexGuard<'_, ()> {
+        self.lock.lock().await
+    }
+}
+
+pub(crate) struct KeyLockMap<K, S> {
+    locks: LockMap<K, S>,
+}
+
+impl<K, S> KeyLockMap<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    pub(crate) fn with_hasher(hasher: S) -> Self {
+        Self {
+            locks: SegmentedHashMap::with_num_segments_and_hasher(LOCK_MAP_NUM_SEGMENTS, hasher),
+        }
+    }
+
+    pub(crate) fn key_lock(&self, key: &Arc<K>) -> KeyLock<'_, K, S> {
+        let hash = self.locks.hash(key);
+        let kl = TrioArc::new(Mutex::new(()));
+        match self
+            .locks
+            .insert_if_not_present(Arc::clone(key), hash, kl.clone())
+        {
+            None => KeyLock::new(&self.locks, key, hash, kl),
+            Some(existing_kl) => KeyLock::new(&self.locks, key, hash, existing_kl),
+        }
+    }
+}

--- a/src/future/notifier.rs
+++ b/src/future/notifier.rs
@@ -1,0 +1,82 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use futures_util::FutureExt;
+
+use crate::notification::{AsyncEvictionListener, RemovalCause};
+
+pub(crate) struct RemovalNotifier<K, V> {
+    listener: AsyncEvictionListener<K, V>,
+    is_enabled: AtomicBool,
+    #[cfg(feature = "logging")]
+    cache_name: Option<String>,
+}
+
+impl<K, V> RemovalNotifier<K, V> {
+    pub(crate) fn new(listener: AsyncEvictionListener<K, V>, _cache_name: Option<String>) -> Self {
+        Self {
+            listener,
+            is_enabled: AtomicBool::new(true),
+            #[cfg(feature = "logging")]
+            cache_name: _cache_name,
+        }
+    }
+
+    pub(crate) async fn notify(&self, key: Arc<K>, value: V, cause: RemovalCause) {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        if !self.is_enabled.load(Ordering::Acquire) {
+            return;
+        }
+
+        // This macro unwraps the result of the catch_unwind call if it is Ok. And
+        // disable the notifier and do early return if the listener panicked.
+        macro_rules! try_or_disable {
+            ($match_expr:expr) => {
+                match $match_expr {
+                    Ok(v) => v,
+                    Err(_payload) => {
+                        self.is_enabled.store(false, Ordering::Release);
+                        #[cfg(feature = "logging")]
+                        log_panic(&*_payload, self.cache_name.as_deref());
+                        return;
+                    }
+                }
+            };
+        }
+
+        let listener_clo = || (self.listener)(key, value, cause);
+
+        // Safety: It is safe to assert unwind safety here because we will not
+        // call the listener again if it has been panicked.
+        let fut = try_or_disable!(catch_unwind(AssertUnwindSafe(listener_clo)));
+        try_or_disable!(AssertUnwindSafe(fut).catch_unwind().await);
+    }
+}
+
+#[cfg(feature = "logging")]
+fn log_panic(payload: &(dyn std::any::Any + Send + 'static), cache_name: Option<&str>) {
+    // Try to downcast the payload into &str or String.
+    //
+    // NOTE: Clippy will complain if we use `if let Some(_)` here.
+    // https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
+    let message: Option<std::borrow::Cow<'_, str>> =
+        (payload.downcast_ref::<&str>().map(|s| (*s).into()))
+            .or_else(|| payload.downcast_ref::<String>().map(Into::into));
+
+    let cn = cache_name
+        .map(|name| format!("[{}] ", name))
+        .unwrap_or_default();
+
+    if let Some(m) = message {
+        log::error!(
+            "{}Disabled the eviction listener because it panicked at '{}'",
+            cn,
+            m
+        );
+    } else {
+        log::error!("{}Disabled the eviction listener because it panicked", cn);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,8 @@
 //! - The numbers of read/write recordings reach to the configured amounts.
 //! - Or, the certain time past from the last draining.
 //!
-//! **TODO** We do not use the worker threads anymore.
+//! **TODO (v0.12.0 release)**: Update the following section as we do not use the
+//! worker threads anymore.
 //!
 //! In a `Cache`, this draining and batch application is handled by a single worker
 //! thread. So under heavy concurrent operations from clients, draining may not be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,23 +22,25 @@
 //!
 //! - Thread-safe, highly concurrent in-memory cache implementations:
 //!     - Synchronous caches that can be shared across OS threads.
-//!     - An asynchronous (futures aware) cache that can be accessed inside and
-//!       outside of asynchronous contexts.
+//!     - An asynchronous (futures aware) cache.
 //! - A cache can be bounded by one of the followings:
 //!     - The maximum number of entries.
 //!     - The total weighted size of entries. (Size aware eviction)
-//! - Maintains good hit rate by using entry replacement algorithms inspired by
-//!   [Caffeine][caffeine-git]:
+//! - Maintains near optimal hit ratio by using an entry replacement algorithms
+//!   inspired by Caffeine:
 //!     - Admission to a cache is controlled by the Least Frequently Used (LFU)
 //!       policy.
 //!     - Eviction from a cache is controlled by the Least Recently Used (LRU)
 //!       policy.
+//!     - [More details and some benchmark results are available here][tiny-lfu].
 //! - Supports expiration policies:
 //!     - Time to live.
 //!     - Time to idle.
 //!     - Per-entry variable expiration.
 //! - Supports eviction listener, a callback function that will be called when an
 //!   entry is removed from the cache.
+//!
+//! [tiny-lfu]: https://github.com/moka-rs/moka/wiki#admission-and-eviction-policies
 //!
 //! # Examples
 //!
@@ -59,7 +61,7 @@
 //!
 //! - Non concurrent cache for single threaded applications:
 //!     - `moka::unsync::Cache` → [`mini_moka::unsync::Cache`][unsync-cache-struct]
-//! - Experimental, thread-safe, synchronous cache:
+//! - A simple, thread-safe, synchronous cache:
 //!     - `moka::dash::Cache` → [`mini_moka::sync::Cache`][dash-cache-struct]
 //!
 //! [mini-moka-crate]: https://crates.io/crates/mini-moka
@@ -98,6 +100,8 @@
 //!
 //! - The numbers of read/write recordings reach to the configured amounts.
 //! - Or, the certain time past from the last draining.
+//!
+//! **TODO** We do not use the worker threads anymore.
 //!
 //! In a `Cache`, this draining and batch application is handled by a single worker
 //! thread. So under heavy concurrent operations from clients, draining may not be
@@ -155,8 +159,7 @@
 //!
 //! - The time-to-live policy uses a write-order queue.
 //! - The time-to-idle policy uses an access-order queue.
-//! - The variable expiration will use a [hierarchical timer wheel][timer-wheel]
-//!   (*1).
+//! - The variable expiration uses a [hierarchical timer wheel][timer-wheel] (*1).
 //!
 //! *1: If you get 404 page not found when you click on the link to the hierarchical
 //! timer wheel paper, try to change the URL from `https:` to `http:`.

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -2,13 +2,19 @@
 
 pub(crate) mod notifier;
 
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
+
+pub type ListenerFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
 pub(crate) type EvictionListener<K, V> =
     Arc<dyn Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static>;
 
 pub(crate) type EvictionListenerRef<'a, K, V> =
     &'a Arc<dyn Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static>;
+
+#[cfg(feature = "future")]
+pub(crate) type AsyncEvictionListener<K, V> =
+    Arc<dyn Fn(Arc<K>, V, RemovalCause) -> ListenerFuture + Send + Sync + 'static>;
 
 // NOTE: Currently, dropping the cache will drop all entries without sending
 // notifications. Calling `invalidate_all` method of the cache will trigger

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,14 +1,17 @@
 //! Common data types for notifications.
 
+#[cfg(feature = "sync")]
 pub(crate) mod notifier;
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
 pub type ListenerFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
+#[cfg(feature = "sync")]
 pub(crate) type EvictionListener<K, V> =
     Arc<dyn Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static>;
 
+#[cfg(feature = "sync")]
 pub(crate) type EvictionListenerRef<'a, K, V> =
     &'a Arc<dyn Fn(Arc<K>, V, RemovalCause) + Send + Sync + 'static>;
 
@@ -26,11 +29,13 @@ pub(crate) type AsyncEvictionListener<K, V> =
 /// Currently only setting the [`DeliveryMode`][delivery-mode] is supported.
 ///
 /// [delivery-mode]: ./enum.DeliveryMode.html
+#[cfg(feature = "sync")]
 #[derive(Clone, Debug, Default)]
 pub struct Configuration {
     mode: DeliveryMode,
 }
 
+#[cfg(feature = "sync")]
 impl Configuration {
     pub fn builder() -> ConfigurationBuilder {
         ConfigurationBuilder::default()
@@ -47,11 +52,13 @@ impl Configuration {
 ///
 /// [conf]: ./struct.Configuration.html
 /// [delivery-mode]: ./enum.DeliveryMode.html
+#[cfg(feature = "sync")]
 #[derive(Default)]
 pub struct ConfigurationBuilder {
     mode: DeliveryMode,
 }
 
+#[cfg(feature = "sync")]
 impl ConfigurationBuilder {
     pub fn build(self) -> Configuration {
         Configuration { mode: self.mode }
@@ -68,6 +75,7 @@ impl ConfigurationBuilder {
 /// For more details, see [the document][delivery-mode-doc] of `sync::Cache`.
 ///
 /// [delivery-mode-doc]: ../sync/struct.Cache.html#delivery-modes-for-eviction-listener
+#[cfg(feature = "sync")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DeliveryMode {
     /// With this mode, a notification should be delivered to the listener
@@ -93,6 +101,7 @@ pub enum DeliveryMode {
     Queued,
 }
 
+#[cfg(feature = "sync")]
 impl Default for DeliveryMode {
     fn default() -> Self {
         Self::Immediate

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -5,6 +5,12 @@ pub(crate) mod notifier;
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
+/// A future returned by an eviction listener.
+///
+/// You can use the [`boxed` method][boxed-method] of `FutureExt` trait to convert a
+/// regular `Future` object into `ListenerFuture`.
+///
+/// [boxed-method]: ../future/trait.FutureExt.html#method.boxed
 pub type ListenerFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
 #[cfg(feature = "sync")]
@@ -17,7 +23,7 @@ pub(crate) type EvictionListenerRef<'a, K, V> =
 
 #[cfg(feature = "future")]
 pub(crate) type AsyncEvictionListener<K, V> =
-    Arc<dyn Fn(Arc<K>, V, RemovalCause) -> ListenerFuture + Send + Sync + 'static>;
+    Box<dyn Fn(Arc<K>, V, RemovalCause) -> ListenerFuture + Send + Sync + 'static>;
 
 // NOTE: Currently, dropping the cache will drop all entries without sending
 // notifications. Calling `invalidate_all` method of the cache will trigger

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -212,7 +212,7 @@ impl<K, V> Clone for ExpirationPolicy<K, V> {
 }
 
 impl<K, V> ExpirationPolicy<K, V> {
-    #[cfg(test)]
+    #[cfg(all(test, feature = "sync"))]
     pub(crate) fn new(
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -212,7 +212,7 @@ impl<K, V> Clone for ExpirationPolicy<K, V> {
 }
 
 impl<K, V> ExpirationPolicy<K, V> {
-    #[cfg(all(test, feature = "sync"))]
+    #[cfg(test)]
     pub(crate) fn new(
         time_to_live: Option<Duration>,
         time_to_idle: Option<Duration>,

--- a/src/sync_base.rs
+++ b/src/sync_base.rs
@@ -1,6 +1,12 @@
-pub(crate) mod base_cache;
-mod invalidator;
 pub(crate) mod iter;
+
+#[cfg(feature = "sync")]
+pub(crate) mod base_cache;
+
+#[cfg(feature = "sync")]
+mod invalidator;
+
+#[cfg(feature = "sync")]
 mod key_lock;
 
 /// The type of the unique ID to identify a predicate used by
@@ -9,6 +15,8 @@ mod key_lock;
 /// A `PredicateId` is a `String` of UUID (version 4).
 ///
 /// [invalidate-if]: ./struct.Cache.html#method.invalidate_entries_if
+#[cfg(feature = "sync")]
 pub type PredicateId = String;
 
+#[cfg(feature = "sync")]
 pub(crate) type PredicateIdStr<'a> = &'a str;

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -2100,8 +2100,7 @@ where
                 }
                 Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
             } else if let Some(entry) = self.cache.get(hash, |k| k == key) {
-                // TODO: CHECKME: Should we check `entry.is_dirty()` instead?
-                if entry.last_modified().is_none() {
+                if entry.is_dirty() {
                     deqs.move_to_back_ao(&entry);
                     deqs.move_to_back_wo(&entry);
                 } else {

--- a/src/sync_base/iter.rs
+++ b/src/sync_base/iter.rs
@@ -16,6 +16,9 @@ pub(crate) trait ScanningGet<K, V> {
     fn keys(&self, cht_segment: usize) -> Option<Vec<Arc<K>>>;
 }
 
+/// Iterator visiting all key-value pairs in a cache in arbitrary order.
+///
+/// Call [`Cache::iter`](./struct.Cache.html#method.iter) method to obtain an `Iter`.
 pub struct Iter<'i, K, V> {
     keys: Option<Vec<Arc<K>>>,
     cache_segments: Box<[&'i dyn ScanningGet<K, V>]>,

--- a/tests/entry_api_actix_rt2.rs
+++ b/tests/entry_api_actix_rt2.rs
@@ -73,7 +73,7 @@ fn test_get_with() -> Result<(), Box<dyn std::error::Error>> {
                 };
 
                 assert_eq!(value.len(), TEN_MIB);
-                assert!(my_cache.get(key.as_str()).is_some());
+                assert!(my_cache.get(key.as_str()).await.is_some());
 
                 println!("Task {} got the value. (len: {})", task_id, value.len());
             })

--- a/tests/entry_api_async_std.rs
+++ b/tests/entry_api_async_std.rs
@@ -70,7 +70,7 @@ async fn test_get_with() {
                 };
 
                 assert_eq!(value.len(), TEN_MIB);
-                assert!(my_cache.get(key.as_str()).is_some());
+                assert!(my_cache.get(key.as_str()).await.is_some());
 
                 println!("Task {} got the value. (len: {})", task_id, value.len());
             })

--- a/tests/entry_api_tokio.rs
+++ b/tests/entry_api_tokio.rs
@@ -71,7 +71,7 @@ async fn test_get_with() {
                 };
 
                 assert_eq!(value.len(), TEN_MIB);
-                assert!(my_cache.get(key.as_str()).is_some());
+                assert!(my_cache.get(key.as_str()).await.is_some());
 
                 println!("Task {} got the value. (len: {})", task_id, value.len());
             })
@@ -137,7 +137,7 @@ async fn test_optionally_get_with() {
                 };
 
                 assert!(value.is_some());
-                assert!(my_cache.get(key.as_str()).is_some());
+                assert!(my_cache.get(key.as_str()).await.is_some());
 
                 println!(
                     "Task {} got the value. (len: {})",
@@ -208,7 +208,7 @@ async fn test_try_get_with() {
                 };
 
                 assert!(value.is_ok());
-                assert!(my_cache.get(key.as_str()).is_some());
+                assert!(my_cache.get(key.as_str()).await.is_some());
 
                 println!(
                     "Task {} got the value. (len: {})",

--- a/tests/runtime_actix_rt2.rs
+++ b/tests/runtime_actix_rt2.rs
@@ -1,11 +1,15 @@
 #![cfg(all(test, feature = "future"))]
 
-use actix_rt::Runtime;
-use moka::future::Cache;
+use std::sync::Arc;
 
-#[test]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const NUM_TASKS: usize = 16;
+use actix_rt::System;
+use moka::future::Cache;
+use tokio::sync::Barrier;
+
+#[actix_rt::test]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const NUM_TASKS: usize = 12;
+    const NUM_THREADS: usize = 4;
     const NUM_KEYS_PER_TASK: usize = 64;
 
     fn value(n: usize) -> String {
@@ -15,59 +19,83 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a cache that can store up to 10,000 entries.
     let cache = Cache::new(10_000);
 
-    // Create Actix Runtime
-    let rt = Runtime::new()?;
+    let barrier = Arc::new(Barrier::new(NUM_THREADS + NUM_TASKS));
 
     // Spawn async tasks and write to and read from the cache.
+    // NOTE: Actix Runtime is single threaded.
     let tasks: Vec<_> = (0..NUM_TASKS)
         .map(|i| {
-            // To share the same cache across the async tasks, clone it.
-            // This is a cheap operation.
+            // To share the same cache across the async tasks and OS threads, clone
+            // it. This is a cheap operation.
             let my_cache = cache.clone();
+            let my_barrier = Arc::clone(&barrier);
             let start = i * NUM_KEYS_PER_TASK;
             let end = (i + 1) * NUM_KEYS_PER_TASK;
 
-            // NOTE: Actix Runtime is single threaded.
-            rt.spawn(async move {
+            actix_rt::spawn(async move {
+                // Wait for the all async tasks and threads to be spawned.
+                my_barrier.wait().await;
+
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
-                    if key % 8 == 0 {
-                        // TODO: Use async runtime's `block_on`.
-                        // my_cache.blocking().insert(key, value(key));
-                        my_cache.insert(key, value(key)).await;
-                    } else {
-                        // insert() is an async method, so await it
-                        my_cache.insert(key, value(key)).await;
-                    }
-                    // get() returns Option<String>, a clone of the stored value.
+                    my_cache.insert(key, value(key)).await;
                     assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
-                    if key % 8 == 0 {
-                        // TODO: Use async runtime's `block_on`.
-                        // my_cache.blocking().invalidate(&key);
-                        my_cache.invalidate(&key).await;
-                    } else {
-                        // invalidate() is an async method, so await it
-                        my_cache.invalidate(&key).await;
-                    }
+                    my_cache.invalidate(&key).await;
                 }
             })
         })
         .collect();
 
-    rt.block_on(futures_util::future::join_all(tasks));
+    // Spawn OS threads and write to and read from the cache.
+    let threads: Vec<_> = (0..NUM_THREADS)
+        .map(|i| i + NUM_TASKS)
+        .map(|i| {
+            let my_cache = cache.clone();
+            let my_barrier = Arc::clone(&barrier);
+            let start = i * NUM_KEYS_PER_TASK;
+            let end = (i + 1) * NUM_KEYS_PER_TASK;
+
+            std::thread::spawn(move || {
+                // It seems there is no way to get a SystemRunner from the current
+                // System (`System::current()`). So, create a new System.
+                let runner = System::new(); // Returns a SystemRunner.
+
+                // Wait for the all async tasks and threads to be spawned.
+                runner.block_on(my_barrier.wait());
+
+                // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
+                for key in start..end {
+                    runner.block_on(my_cache.insert(key, value(key)));
+                    assert_eq!(runner.block_on(my_cache.get(&key)), Some(value(key)));
+                }
+
+                // Invalidate every 4 element of the inserted entries.
+                for key in (start..end).step_by(4) {
+                    runner.block_on(my_cache.invalidate(&key));
+                }
+            })
+        })
+        .collect();
+
+    futures_util::future::join_all(tasks).await;
+    for t in threads {
+        t.join().unwrap();
+    }
 
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
         if key % 4 == 0 {
-            assert_eq!(rt.block_on(cache.get(&key)), None);
+            assert_eq!(cache.get(&key).await, None);
         } else {
-            assert_eq!(rt.block_on(cache.get(&key)), Some(value(key)));
+            assert_eq!(cache.get(&key).await, Some(value(key)));
         }
     }
+
+    System::current().stop();
 
     Ok(())
 }

--- a/tests/runtime_actix_rt2.rs
+++ b/tests/runtime_actix_rt2.rs
@@ -32,19 +32,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
                     if key % 8 == 0 {
-                        my_cache.blocking().insert(key, value(key));
+                        // TODO: Use async runtime's `block_on`.
+                        // my_cache.blocking().insert(key, value(key));
+                        my_cache.insert(key, value(key)).await;
                     } else {
                         // insert() is an async method, so await it
                         my_cache.insert(key, value(key)).await;
                     }
                     // get() returns Option<String>, a clone of the stored value.
-                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                    assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
                     if key % 8 == 0 {
-                        my_cache.blocking().invalidate(&key);
+                        // TODO: Use async runtime's `block_on`.
+                        // my_cache.blocking().invalidate(&key);
+                        my_cache.invalidate(&key).await;
                     } else {
                         // invalidate() is an async method, so await it
                         my_cache.invalidate(&key).await;
@@ -59,9 +63,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
         if key % 4 == 0 {
-            assert_eq!(cache.get(&key), None);
+            assert_eq!(rt.block_on(cache.get(&key)), None);
         } else {
-            assert_eq!(cache.get(&key), Some(value(key)));
+            assert_eq!(rt.block_on(cache.get(&key)), Some(value(key)));
         }
     }
 

--- a/tests/runtime_async_std.rs
+++ b/tests/runtime_async_std.rs
@@ -27,19 +27,23 @@ async fn main() {
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
                     if key % 8 == 0 {
-                        my_cache.blocking().insert(key, value(key));
+                        // TODO: Use async runtime's `block_on`.
+                        // my_cache.blocking().insert(key, value(key));
+                        my_cache.insert(key, value(key)).await;
                     } else {
                         // insert() is an async method, so await it
                         my_cache.insert(key, value(key)).await;
                     }
                     // get() returns Option<String>, a clone of the stored value.
-                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                    assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
                     if key % 8 == 0 {
-                        my_cache.blocking().invalidate(&key);
+                        // TODO: Use async runtime's `block_on`.
+                        // my_cache.blocking().invalidate(&key);
+                        my_cache.invalidate(&key).await;
                     } else {
                         // invalidate() is an async method, so await it
                         my_cache.invalidate(&key).await;
@@ -55,9 +59,9 @@ async fn main() {
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
         if key % 4 == 0 {
-            assert_eq!(cache.get(&key), None);
+            assert_eq!(cache.get(&key).await, None);
         } else {
-            assert_eq!(cache.get(&key), Some(value(key)));
+            assert_eq!(cache.get(&key).await, Some(value(key)));
         }
     }
 }

--- a/tests/runtime_async_std.rs
+++ b/tests/runtime_async_std.rs
@@ -1,10 +1,16 @@
 #![cfg(all(test, feature = "future"))]
 
+use std::sync::Arc;
+
+// Use async_lock's Barrier instead of async_std's Barrier as the latter requires
+// `unstable` feature (v1.12.0).
+use async_lock::Barrier;
 use moka::future::Cache;
 
 #[async_std::test]
 async fn main() {
-    const NUM_TASKS: usize = 16;
+    const NUM_TASKS: usize = 12;
+    const NUM_THREADS: usize = 4;
     const NUM_KEYS_PER_TASK: usize = 64;
 
     fn value(n: usize) -> String {
@@ -14,40 +20,60 @@ async fn main() {
     // Create a cache that can store up to 10,000 entries.
     let cache = Cache::new(10_000);
 
+    let barrier = Arc::new(Barrier::new(NUM_THREADS + NUM_TASKS));
+
     // Spawn async tasks and write to and read from the cache.
     let tasks: Vec<_> = (0..NUM_TASKS)
         .map(|i| {
-            // To share the same cache across the async tasks, clone it.
-            // This is a cheap operation.
+            // To share the same cache across the async tasks and OS threads, clone
+            // it. This is a cheap operation.
             let my_cache = cache.clone();
+            let my_barrier = Arc::clone(&barrier);
             let start = i * NUM_KEYS_PER_TASK;
             let end = (i + 1) * NUM_KEYS_PER_TASK;
 
             async_std::task::spawn(async move {
+                // Wait for the all async tasks and threads to be spawned.
+                my_barrier.wait().await;
+
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
-                    if key % 8 == 0 {
-                        // TODO: Use async runtime's `block_on`.
-                        // my_cache.blocking().insert(key, value(key));
-                        my_cache.insert(key, value(key)).await;
-                    } else {
-                        // insert() is an async method, so await it
-                        my_cache.insert(key, value(key)).await;
-                    }
-                    // get() returns Option<String>, a clone of the stored value.
+                    my_cache.insert(key, value(key)).await;
                     assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
-                    if key % 8 == 0 {
-                        // TODO: Use async runtime's `block_on`.
-                        // my_cache.blocking().invalidate(&key);
-                        my_cache.invalidate(&key).await;
-                    } else {
-                        // invalidate() is an async method, so await it
-                        my_cache.invalidate(&key).await;
-                    }
+                    my_cache.invalidate(&key).await;
+                }
+            })
+        })
+        .collect();
+
+    // Spawn threads and write to and read from the cache.
+    let threads: Vec<_> = (0..NUM_THREADS)
+        .map(|i| i + NUM_TASKS)
+        .map(|i| {
+            let my_cache = cache.clone();
+            let my_barrier = Arc::clone(&barrier);
+            let start = i * NUM_KEYS_PER_TASK;
+            let end = (i + 1) * NUM_KEYS_PER_TASK;
+
+            std::thread::spawn(move || {
+                use async_std::task::block_on;
+
+                // Wait for the all async tasks and threads to be spawned.
+                block_on(my_barrier.wait());
+
+                // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
+                for key in start..end {
+                    block_on(my_cache.insert(key, value(key)));
+                    assert_eq!(block_on(my_cache.get(&key)), Some(value(key)));
+                }
+
+                // Invalidate every 4 element of the inserted entries.
+                for key in (start..end).step_by(4) {
+                    block_on(my_cache.invalidate(&key));
                 }
             })
         })
@@ -55,6 +81,9 @@ async fn main() {
 
     // Wait for all tasks to complete.
     futures_util::future::join_all(tasks).await;
+    for t in threads {
+        t.join().unwrap();
+    }
 
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {

--- a/tests/runtime_tokio.rs
+++ b/tests/runtime_tokio.rs
@@ -27,19 +27,23 @@ async fn main() {
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
                     if key % 8 == 0 {
-                        my_cache.blocking().insert(key, value(key));
+                        // TODO: Use async runtime's `block_on`.
+                        // my_cache.blocking().insert(key, value(key));
+                        my_cache.insert(key, value(key)).await;
                     } else {
                         // insert() is an async method, so await it
                         my_cache.insert(key, value(key)).await;
                     }
                     // get() returns Option<String>, a clone of the stored value.
-                    assert_eq!(my_cache.get(&key), Some(value(key)));
+                    assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
                     if key % 8 == 0 {
-                        my_cache.blocking().invalidate(&key);
+                        // TODO: Use async runtime's `block_on`.
+                        // my_cache.blocking().invalidate(&key);
+                        my_cache.invalidate(&key).await;
                     } else {
                         // invalidate() is an async method, so await it
                         my_cache.invalidate(&key).await;
@@ -55,9 +59,9 @@ async fn main() {
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {
         if key % 4 == 0 {
-            assert_eq!(cache.get(&key), None);
+            assert_eq!(cache.get(&key).await, None);
         } else {
-            assert_eq!(cache.get(&key), Some(value(key)));
+            assert_eq!(cache.get(&key).await, Some(value(key)));
         }
     }
 }

--- a/tests/runtime_tokio.rs
+++ b/tests/runtime_tokio.rs
@@ -1,10 +1,14 @@
 #![cfg(all(test, feature = "future"))]
 
+use std::sync::Arc;
+
 use moka::future::Cache;
+use tokio::sync::Barrier;
 
 #[tokio::test]
 async fn main() {
-    const NUM_TASKS: usize = 16;
+    const NUM_TASKS: usize = 12;
+    const NUM_THREADS: usize = 4;
     const NUM_KEYS_PER_TASK: usize = 64;
 
     fn value(n: usize) -> String {
@@ -14,47 +18,69 @@ async fn main() {
     // Create a cache that can store up to 10,000 entries.
     let cache = Cache::new(10_000);
 
+    let barrier = Arc::new(Barrier::new(NUM_THREADS + NUM_TASKS));
+
     // Spawn async tasks and write to and read from the cache.
     let tasks: Vec<_> = (0..NUM_TASKS)
         .map(|i| {
-            // To share the same cache across the async tasks, clone it.
-            // This is a cheap operation.
+            // To share the same cache across the async tasks and OS threads, clone
+            // it. This is a cheap operation.
             let my_cache = cache.clone();
+            let my_barrier = Arc::clone(&barrier);
             let start = i * NUM_KEYS_PER_TASK;
             let end = (i + 1) * NUM_KEYS_PER_TASK;
 
             tokio::spawn(async move {
+                // Wait for the all async tasks and threads to be spawned.
+                my_barrier.wait().await;
+
                 // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
                 for key in start..end {
-                    if key % 8 == 0 {
-                        // TODO: Use async runtime's `block_on`.
-                        // my_cache.blocking().insert(key, value(key));
-                        my_cache.insert(key, value(key)).await;
-                    } else {
-                        // insert() is an async method, so await it
-                        my_cache.insert(key, value(key)).await;
-                    }
-                    // get() returns Option<String>, a clone of the stored value.
+                    my_cache.insert(key, value(key)).await;
                     assert_eq!(my_cache.get(&key).await, Some(value(key)));
                 }
 
                 // Invalidate every 4 element of the inserted entries.
                 for key in (start..end).step_by(4) {
-                    if key % 8 == 0 {
-                        // TODO: Use async runtime's `block_on`.
-                        // my_cache.blocking().invalidate(&key);
-                        my_cache.invalidate(&key).await;
-                    } else {
-                        // invalidate() is an async method, so await it
-                        my_cache.invalidate(&key).await;
-                    }
+                    my_cache.invalidate(&key).await;
                 }
             })
         })
         .collect();
 
-    // Wait for all tasks to complete.
+    // Spawn OS threads and write to and read from the cache.
+    let threads: Vec<_> = (0..NUM_THREADS)
+        .map(|i| i + NUM_TASKS)
+        .map(|i| {
+            let my_cache = cache.clone();
+            let my_barrier = Arc::clone(&barrier);
+            let start = i * NUM_KEYS_PER_TASK;
+            let end = (i + 1) * NUM_KEYS_PER_TASK;
+            let rt = tokio::runtime::Handle::current();
+
+            std::thread::spawn(move || {
+                // Wait for the all async tasks and threads to be spawned.
+                rt.block_on(my_barrier.wait());
+
+                // Insert 64 entries. (NUM_KEYS_PER_TASK = 64)
+                for key in start..end {
+                    rt.block_on(my_cache.insert(key, value(key)));
+                    assert_eq!(rt.block_on(my_cache.get(&key)), Some(value(key)));
+                }
+
+                // Invalidate every 4 element of the inserted entries.
+                for key in (start..end).step_by(4) {
+                    rt.block_on(my_cache.invalidate(&key));
+                }
+            })
+        })
+        .collect();
+
+    // Wait for all tasks and threads to complete.
     futures_util::future::join_all(tasks).await;
+    for t in threads {
+        t.join().unwrap();
+    }
 
     // Verify the result.
     for key in 0..(NUM_TASKS * NUM_KEYS_PER_TASK) {


### PR DESCRIPTION
This PR changes the followings on `future::Cache`:

- Remove the thread pool from `future::Cache`. The background threads will be no longer spawned.
- Change the `notification::DeliveryMode` for eviction listener from `Queued` to `Immediate`.
    - #228

For more details, see the [migration guide at commit #16b4f899](https://github.com/moka-rs/moka/blob/16b4f899a27a1e8d89504c339e255aa32cab7dfa/MIGRATION-GUIDE.md).