### PR TITLE
Fix a bug in sync caches where memory usage kept increasing when the eviction listener is set (v0.11.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   increasing when the eviction listener was set with the `Immediate` delivery mode.
   ([#295][gh-pull-0295])
 
+
 ## Version 0.11.2
 
 Bumped the minimum supported Rust version (MSRV) to 1.65 (Nov 3, 2022).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.11.3
+
+### Fixed
+
+- Fixed a bug in `sync::Cache` and `sync::SegmentedCache` where memory usage kept
+  increasing when the eviction listener was set with the `Immediate` delivery mode.
+  ([#295][gh-pull-0295])
+
 ## Version 0.11.2
 
 Bumped the minimum supported Rust version (MSRV) to 1.65 (Nov 3, 2022).
@@ -676,6 +684,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0295]: https://github.com/moka-rs/moka/pull/295/
 [gh-pull-0277]: https://github.com/moka-rs/moka/pull/277/
 [gh-pull-0275]: https://github.com/moka-rs/moka/pull/275/
 [gh-pull-0272]: https://github.com/moka-rs/moka/pull/272/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ algorithm to determine which entries to evict when the capacity is exceeded.
 [release-badge]: https://img.shields.io/crates/v/moka.svg
 [docs-badge]: https://docs.rs/moka/badge.svg
 [deps-rs-badge]: https://deps.rs/repo/github/moka-rs/moka/status.svg
-[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=master
+[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=main
 [license-badge]: https://img.shields.io/crates/l/moka.svg
 [fossa-badge]: https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield
 
@@ -29,7 +29,7 @@ algorithm to determine which entries to evict when the capacity is exceeded.
 [crate]: https://crates.io/crates/moka
 [docs]: https://docs.rs/moka
 [deps-rs]: https://deps.rs/repo/github/moka-rs/moka
-[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=master
+[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=main
 [fossa]: https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
@@ -112,7 +112,7 @@ routers. Here are some highlights:
 
 ## Change Log
 
-- [CHANGELOG.md](https://github.com/moka-rs/moka/blob/master/CHANGELOG.md)
+- [CHANGELOG.md](https://github.com/moka-rs/moka/blob/main/CHANGELOG.md)
 
 The `unsync::Cache` and `dash::Cache` have been moved to a separate crate called
 [Mini Moka][mini-moka-crate]:

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -2009,6 +2009,10 @@ where
     fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.base.key_locks_map_is_empty()
+    }
 }
 
 pub struct BlockingOp<'a, K, V, S>(&'a Cache<K, V, S>);
@@ -2164,6 +2168,7 @@ mod tests {
         assert!(!cache.contains_key(&"d"));
 
         verify_notification_vec(&cache, actual, &expected);
+        assert!(cache.key_locks_map_is_empty());
     }
 
     #[test]
@@ -2353,6 +2358,7 @@ mod tests {
         assert_eq!(cache.weighted_size(), 25);
 
         verify_notification_vec(&cache, actual, &expected);
+        assert!(cache.key_locks_map_is_empty());
     }
 
     #[tokio::test]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2190,6 +2190,7 @@ mod tests {
             assert!(!cache.contains_key(&"d"));
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -2320,6 +2321,7 @@ mod tests {
             assert_eq_with_mode!(cache.weighted_size(), 25, delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2054,6 +2054,10 @@ where
     pub(crate) fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.base.key_locks_map_is_empty()
+    }
 }
 
 // To see the debug prints, run test as `cargo test -- --nocapture`
@@ -4339,6 +4343,8 @@ mod tests {
             assert_eq!(a[0], (Arc::new("alice"), "a3", RemovalCause::Expired));
             a.clear();
         }
+
+        assert!(cache.key_locks_map_is_empty());
     }
 
     // This test ensures the key-level lock for the immediate notification
@@ -4469,6 +4475,8 @@ mod tests {
         for (i, (actual, expected)) in actual.iter().zip(&expected).enumerate() {
             assert_eq!(actual, expected, "expected[{}]", i);
         }
+
+        assert!(cache.key_locks_map_is_empty());
     }
 
     // NOTE: To enable the panic logging, run the following command:

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -687,6 +687,13 @@ where
 
         exp_clock
     }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.inner
+            .segments
+            .iter()
+            .all(|seg| seg.key_locks_map_is_empty())
+    }
 }
 
 // For unit tests.
@@ -916,6 +923,7 @@ mod tests {
             assert!(!cache.contains_key(&"d"));
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -1065,6 +1073,7 @@ mod tests {
             assert_eq_with_mode!(cache.weighted_size(), 25, delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -2424,7 +2424,8 @@ where
         self.key_locks
             .as_ref()
             .map(|m| m.is_empty())
-            .unwrap_or_default()
+            // If key_locks is None, consider it is empty.
+            .unwrap_or(true)
     }
 }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -2421,7 +2421,10 @@ where
     }
 
     fn key_locks_map_is_empty(&self) -> bool {
-        self.key_locks.as_ref().map(|m| m.is_empty()).unwrap_or_default()
+        self.key_locks
+            .as_ref()
+            .map(|m| m.is_empty())
+            .unwrap_or_default()
     }
 }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -785,6 +785,10 @@ where
     pub(crate) fn set_expiration_clock(&self, clock: Option<Clock>) {
         self.inner.set_expiration_clock(clock);
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.inner.key_locks_map_is_empty()
+    }
 }
 
 struct EvictionState<'a, K, V> {
@@ -2414,6 +2418,10 @@ where
                 .store(false, Ordering::SeqCst);
             *exp_clock = None;
         }
+    }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.key_locks.as_ref().map(|m| m.is_empty()).unwrap_or_default()
     }
 }
 

--- a/src/sync_base/key_lock.rs
+++ b/src/sync_base/key_lock.rs
@@ -30,11 +30,11 @@ where
     S: BuildHasher,
 {
     fn drop(&mut self) {
-        if TrioArc::count(&self.lock) <= 1 {
+        if TrioArc::count(&self.lock) <= 2 {
             self.map.remove_if(
                 self.hash,
                 |k| k == &self.key,
-                |_k, v| TrioArc::count(v) <= 1,
+                |_k, v| TrioArc::count(v) <= 2,
             );
         }
     }
@@ -84,5 +84,12 @@ where
             None => KeyLock::new(&self.locks, key, hash, kl),
             Some(existing_kl) => KeyLock::new(&self.locks, key, hash, existing_kl),
         }
+    }
+}
+
+#[cfg(test)]
+impl<K, S> KeyLockMap<K, S> {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.locks.len() == 0
     }
 }


### PR DESCRIPTION
This PR fixes a bug in `sync::Cache` and `sync::SegmentedCache`, which causes eviction listener's key-level locks not to be removed after sending notifications. This happened only when the `Immediate` notification delivery mode is used for the eviction listener. (It is the default mode)  Another mode, `Queued` mode, is unaffected as it does not use the key locks.

These key locks are stored in an internal `moka::cht::SegmentedHashMap` with `Arc<K>` as their keys. So this bug caused the `SegmentedHashMap` to hold all keys `K` that has been inserted to the cache. It will continuously increasing memory usage until the cache is dropped.

Tested the fix by adding a check to unit test if the `SegmentedHashMap` is empty after sending all notifications.