### PR TITLE
Fix a bug in sync caches where memory usage kept increasing when the eviction listener is set (v0.9.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.9.9
+
+### Fixed
+
+- Fixed a bug in `sync::Cache` and `sync::SegmentedCache` where memory usage kept
+  increasing when the eviction listener was set with the `Immediate` delivery mode.
+  ([#296][gh-pull-0296])
+
+
 ## Version 0.9.8
 
 Bumped the minimum supported Rust version (MSRV) to 1.60 (Apr 7, 2022).
@@ -580,6 +589,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (2021-03-25).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0296]: https://github.com/moka-rs/moka/pull/296/
 [gh-pull-0283]: https://github.com/moka-rs/moka/pull/283/
 [gh-pull-0282]: https://github.com/moka-rs/moka/pull/282/
 [gh-pull-0259]: https://github.com/moka-rs/moka/pull/259/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2018"
 # Rust 1.60 was released on Apr 7, 2022.
 rust-version = "1.60"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ algorithm to determine which entries to evict when the capacity is exceeded.
 [release-badge]: https://img.shields.io/crates/v/moka.svg
 [docs-badge]: https://docs.rs/moka/badge.svg
 [deps-rs-badge]: https://deps.rs/repo/github/moka-rs/moka/status.svg
-[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=master
+[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=main
 [license-badge]: https://img.shields.io/crates/l/moka.svg
 [fossa-badge]: https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield
 
@@ -30,7 +30,7 @@ algorithm to determine which entries to evict when the capacity is exceeded.
 [crate]: https://crates.io/crates/moka
 [docs]: https://docs.rs/moka
 [deps-rs]: https://deps.rs/repo/github/moka-rs/moka
-[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=master
+[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=main
 [fossa]: https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
@@ -87,9 +87,9 @@ routers. Here are some highlights:
 ## Change Log
 
 - For v0.9.x releases:
-  [CHANGELOG.md (`maint-09` branch)](https://github.com/moka-rs/moka/blob/maint-09/CHANGELOG.md)
+  [CHANGELOG.md (`v0.9.x` branch)](https://github.com/moka-rs/moka/blob/v0.9.x/CHANGELOG.md)
 - For the latest release:
-  [CHANGELOG.md (`master` branch)](https://github.com/moka-rs/moka/blob/master/CHANGELOG.md)
+  [CHANGELOG.md (`main` branch)](https://github.com/moka-rs/moka/blob/main/CHANGELOG.md)
 
 
 ## Table of Contents

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1694,6 +1694,10 @@ where
     fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.base.key_locks_map_is_empty()
+    }
 }
 
 pub struct BlockingOp<'a, K, V, S>(&'a Cache<K, V, S>);
@@ -1817,6 +1821,7 @@ mod tests {
         assert!(!cache.contains_key(&"b"));
 
         verify_notification_vec(&cache, actual, &expected);
+        assert!(cache.key_locks_map_is_empty());
     }
 
     #[test]
@@ -1986,6 +1991,7 @@ mod tests {
         assert_eq!(cache.weighted_size(), 25);
 
         verify_notification_vec(&cache, actual, &expected);
+        assert!(cache.key_locks_map_is_empty());
     }
 
     #[tokio::test]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1789,6 +1789,10 @@ where
     pub(crate) fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.base.key_locks_map_is_empty()
+    }
 }
 
 // To see the debug prints, run test as `cargo test -- --nocapture`
@@ -1890,6 +1894,7 @@ mod tests {
             assert_with_mode!(!cache.contains_key(&"b"), delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -2020,6 +2025,7 @@ mod tests {
             assert_eq_with_mode!(cache.weighted_size(), 25, delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -3691,6 +3697,8 @@ mod tests {
             assert_eq!(a[0], (Arc::new("alice"), "a3", RemovalCause::Expired));
             a.clear();
         }
+
+        assert!(cache.key_locks_map_is_empty());
     }
 
     // This test ensures the key-level lock for the immediate notification
@@ -3821,6 +3829,8 @@ mod tests {
         for (i, (actual, expected)) in actual.iter().zip(&expected).enumerate() {
             assert_eq!(actual, expected, "expected[{}]", i);
         }
+
+        assert!(cache.key_locks_map_is_empty());
     }
 
     // NOTE: To enable the panic logging, run the following command:

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -657,6 +657,13 @@ where
 
         exp_clock
     }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.inner
+            .segments
+            .iter()
+            .all(|seg| seg.key_locks_map_is_empty())
+    }
 }
 
 // For unit tests.
@@ -862,6 +869,7 @@ mod tests {
             assert_with_mode!(!cache.contains_key(&"b"), delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -1011,6 +1019,7 @@ mod tests {
             assert_eq_with_mode!(cache.weighted_size(), 25, delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -610,6 +610,10 @@ where
     pub(crate) fn set_expiration_clock(&self, clock: Option<Clock>) {
         self.inner.set_expiration_clock(clock);
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.inner.key_locks_map_is_empty()
+    }
 }
 
 struct EvictionState<'a, K, V> {
@@ -1995,6 +1999,14 @@ where
             self.has_expiration_clock.store(false, Ordering::SeqCst);
             *exp_clock = None;
         }
+    }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.key_locks
+            .as_ref()
+            .map(|m| m.is_empty())
+            // If key_locks is None, consider it is empty.
+            .unwrap_or(true)
     }
 }
 

--- a/src/sync_base/key_lock.rs
+++ b/src/sync_base/key_lock.rs
@@ -30,11 +30,11 @@ where
     S: BuildHasher,
 {
     fn drop(&mut self) {
-        if TrioArc::count(&self.lock) <= 1 {
+        if TrioArc::count(&self.lock) <= 2 {
             self.map.remove_if(
                 self.hash,
                 |k| k == &self.key,
-                |_k, v| TrioArc::count(v) <= 1,
+                |_k, v| TrioArc::count(v) <= 2,
             );
         }
     }
@@ -84,5 +84,12 @@ where
             None => KeyLock::new(&self.locks, key, hash, kl),
             Some(existing_kl) => KeyLock::new(&self.locks, key, hash, existing_kl),
         }
+    }
+}
+
+#[cfg(test)]
+impl<K, S> KeyLockMap<K, S> {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.locks.len() == 0
     }
 }


### PR DESCRIPTION
This PR fixes a bug in `sync::Cache` and `sync::SegmentedCache`, which causes eviction listener's key-level locks not to be removed after sending notifications. This happened only when the `Immediate` notification delivery mode is used for the eviction listener. (It is the default mode)  Another mode, `Queued` mode, is unaffected as it does not use the key locks.

These key locks are stored in an internal `moka::cht::SegmentedHashMap` with `Arc<K>` as their keys. So this bug caused the `SegmentedHashMap` to hold all keys `K` that has been inserted to the cache. It will continuously increasing memory usage until the cache is dropped.

Tested the fix by adding a check to unit test if the `SegmentedHashMap` is empty after sending all notifications.