### PR TITLE
Fix a bug in sync caches where memory usage kept increasing when the eviction listener is set (v0.10.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ algorithm to determine which entries to evict when the capacity is exceeded.
 [release-badge]: https://img.shields.io/crates/v/moka.svg
 [docs-badge]: https://docs.rs/moka/badge.svg
 [deps-rs-badge]: https://deps.rs/repo/github/moka-rs/moka/status.svg
-[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=master
+[coveralls-badge]: https://coveralls.io/repos/github/moka-rs/moka/badge.svg?branch=main
 [license-badge]: https://img.shields.io/crates/l/moka.svg
 [fossa-badge]: https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield
 
@@ -29,7 +29,7 @@ algorithm to determine which entries to evict when the capacity is exceeded.
 [crate]: https://crates.io/crates/moka
 [docs]: https://docs.rs/moka
 [deps-rs]: https://deps.rs/repo/github/moka-rs/moka
-[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=master
+[coveralls]: https://coveralls.io/github/moka-rs/moka?branch=main
 [fossa]: https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
@@ -111,9 +111,9 @@ routers. Here are some highlights:
 ## Change Log
 
 - For v0.10.x releases:
-  [CHANGELOG.md (`maint-010` branch)](https://github.com/moka-rs/moka/blob/maint-010/CHANGELOG.md)
+  [CHANGELOG.md (`v0.10.x` branch)](https://github.com/moka-rs/moka/blob/v0.10.x/CHANGELOG.md)
 - For the latest release:
-  [CHANGELOG.md (`master` branch)](https://github.com/moka-rs/moka/blob/master/CHANGELOG.md)
+  [CHANGELOG.md (`main` branch)](https://github.com/moka-rs/moka/blob/main/CHANGELOG.md)
 
 The `unsync::Cache` and `dash::Cache` have been moved to a separate crate called
 [Mini Moka][mini-moka-crate]:

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1821,6 +1821,10 @@ where
     fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.base.key_locks_map_is_empty()
+    }
 }
 
 pub struct BlockingOp<'a, K, V, S>(&'a Cache<K, V, S>);
@@ -1962,6 +1966,7 @@ mod tests {
         assert!(!cache.contains_key(&"b"));
 
         verify_notification_vec(&cache, actual, &expected);
+        assert!(cache.key_locks_map_is_empty());
     }
 
     #[test]
@@ -2151,6 +2156,7 @@ mod tests {
         assert_eq!(cache.weighted_size(), 25);
 
         verify_notification_vec(&cache, actual, &expected);
+        assert!(cache.key_locks_map_is_empty());
     }
 
     #[tokio::test]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1898,6 +1898,10 @@ where
     pub(crate) fn set_expiration_clock(&self, clock: Option<crate::common::time::Clock>) {
         self.base.set_expiration_clock(clock);
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.base.key_locks_map_is_empty()
+    }
 }
 
 // To see the debug prints, run test as `cargo test -- --nocapture`
@@ -2017,6 +2021,7 @@ mod tests {
             assert_with_mode!(!cache.contains_key(&"b"), delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -2147,6 +2152,7 @@ mod tests {
             assert_eq_with_mode!(cache.weighted_size(), 25, delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -3837,6 +3843,8 @@ mod tests {
             assert_eq!(a[0], (Arc::new("alice"), "a3", RemovalCause::Expired));
             a.clear();
         }
+
+        assert!(cache.key_locks_map_is_empty());
     }
 
     // This test ensures the key-level lock for the immediate notification
@@ -3967,6 +3975,8 @@ mod tests {
         for (i, (actual, expected)) in actual.iter().zip(&expected).enumerate() {
             assert_eq!(actual, expected, "expected[{}]", i);
         }
+
+        assert!(cache.key_locks_map_is_empty());
     }
 
     // NOTE: To enable the panic logging, run the following command:

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -667,6 +667,13 @@ where
 
         exp_clock
     }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.inner
+            .segments
+            .iter()
+            .all(|seg| seg.key_locks_map_is_empty())
+    }
 }
 
 // For unit tests.
@@ -891,6 +898,7 @@ mod tests {
             assert_with_mode!(!cache.contains_key(&"b"), delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 
@@ -1040,6 +1048,7 @@ mod tests {
             assert_eq_with_mode!(cache.weighted_size(), 25, delivery_mode);
 
             verify_notification_vec(&cache, actual, &expected, delivery_mode);
+            assert_with_mode!(cache.key_locks_map_is_empty(), delivery_mode);
         }
     }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -629,6 +629,10 @@ where
     pub(crate) fn set_expiration_clock(&self, clock: Option<Clock>) {
         self.inner.set_expiration_clock(clock);
     }
+
+    pub(crate) fn key_locks_map_is_empty(&self) -> bool {
+        self.inner.key_locks_map_is_empty()
+    }
 }
 
 struct EvictionState<'a, K, V> {
@@ -2025,6 +2029,14 @@ where
             self.has_expiration_clock.store(false, Ordering::SeqCst);
             *exp_clock = None;
         }
+    }
+
+    fn key_locks_map_is_empty(&self) -> bool {
+        self.key_locks
+            .as_ref()
+            .map(|m| m.is_empty())
+            // If key_locks is None, consider it is empty.
+            .unwrap_or(true)
     }
 }
 

--- a/src/sync_base/key_lock.rs
+++ b/src/sync_base/key_lock.rs
@@ -30,11 +30,11 @@ where
     S: BuildHasher,
 {
     fn drop(&mut self) {
-        if TrioArc::count(&self.lock) <= 1 {
+        if TrioArc::count(&self.lock) <= 2 {
             self.map.remove_if(
                 self.hash,
                 |k| k == &self.key,
-                |_k, v| TrioArc::count(v) <= 1,
+                |_k, v| TrioArc::count(v) <= 2,
             );
         }
     }
@@ -84,5 +84,12 @@ where
             None => KeyLock::new(&self.locks, key, hash, kl),
             Some(existing_kl) => KeyLock::new(&self.locks, key, hash, existing_kl),
         }
+    }
+}
+
+#[cfg(test)]
+impl<K, S> KeyLockMap<K, S> {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.locks.len() == 0
     }
 }


### PR DESCRIPTION
This PR fixes a bug in `sync::Cache` and `sync::SegmentedCache`, which causes eviction listener's key-level locks not to be removed after sending notifications. This happened only when the `Immediate` notification delivery mode is used for the eviction listener. (It is the default mode)  Another mode, `Queued` mode, is unaffected as it does not use the key locks.

These key locks are stored in an internal `moka::cht::SegmentedHashMap` with `Arc<K>` as their keys. So this bug caused the `SegmentedHashMap` to hold all keys `K` that has been inserted to the cache. It will continuously increasing memory usage until the cache is dropped.

Tested the fix by adding a check to unit test if the `SegmentedHashMap` is empty after sending all notifications.