### PR TITLE
Fix the CI for MSRV 1.60 for v0.9.x

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -5,3 +5,4 @@ set -eux
 # Pin some dependencies to specific versions for the MSRV.
 cargo update -p dashmap --precise 5.4.0
 cargo update -p tempfile --precise 3.6.0
+cargo update -p tokio --precise 1.29.1


### PR DESCRIPTION
When testing the MSRV 1.60, downgrade `tokio` to v1.29.1, otherwise it will not compile.