### PR TITLE
Do not copy internal pointers on updating an entry (v0.10.x)

### DIFF
--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -179,12 +179,12 @@ mod test {
         };
 
         let expected_sizes = match (arch, is_quanta_enabled) {
-            (Linux64, true) => vec![("1.51", 24)],
-            (Linux32, true) => vec![("1.51", 24)],
-            (MacOS64, true) => vec![("1.62", 24)],
-            (Linux64, false) => vec![("1.66", 56), ("1.51", 72)],
-            (Linux32, false) => vec![("1.66", 56), ("1.62", 72), ("1.51", 40)],
-            (MacOS64, false) => vec![("1.62", 56)],
+            (Linux64, true) => vec![("1.60", 48)],
+            (Linux32, true) => vec![("1.60", 40)],
+            (MacOS64, true) => vec![("1.62", 48)],
+            (Linux64, false) => vec![("1.66", 80), ("1.60", 96)],
+            (Linux32, false) => vec![("1.66", 72)],
+            (MacOS64, false) => vec![("1.62", 80)],
         };
 
         let mut expected = None;

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -494,9 +494,10 @@ where
             // on_modify
             |_k, old_entry| {
                 // NOTES on `new_value_entry_from` method:
-                // 1. The internal EntryInfo will be shared between the old and new ValueEntries.
-                // 2. This method will set the last_accessed and last_modified to the max value to
-                //    prevent this new ValueEntry from being evicted by an expiration policy.
+                // 1. The internal EntryInfo will be shared between the old and new
+                //    ValueEntries.
+                // 2. This method will set the dirty flag to prevent this new
+                //    ValueEntry from being evicted by an expiration policy.
                 // 3. This method will update the policy_weight with the new weight.
                 let old_weight = old_entry.policy_weight();
                 let old_timestamps = (old_entry.last_accessed(), old_entry.last_modified());
@@ -520,7 +521,6 @@ where
         match (op1, op2) {
             (Some((_cnt, ins_op)), None) => (ins_op, ts),
             (None, Some((_cnt, old_entry, (old_last_accessed, old_last_modified), upd_op))) => {
-                old_entry.unset_q_nodes();
                 if self.is_removal_notifier_enabled() {
                     self.inner
                         .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified);
@@ -535,7 +535,6 @@ where
                 if cnt1 > cnt2 {
                     (ins_op, ts)
                 } else {
-                    old_entry.unset_q_nodes();
                     if self.is_removal_notifier_enabled() {
                         self.inner.notify_upsert(
                             key,
@@ -578,7 +577,7 @@ where
         info.set_last_accessed(timestamp);
         info.set_last_modified(timestamp);
         info.set_policy_weight(policy_weight);
-        TrioArc::new(ValueEntry::new_from(value, info, other))
+        TrioArc::new(ValueEntry::new(value, info))
     }
 
     #[inline]
@@ -1763,7 +1762,7 @@ where
                 }
                 Self::handle_remove(deqs, entry, &mut eviction_state.counters);
             } else if let Some(entry) = self.cache.get(hash, |k| k == key) {
-                if entry.last_modified().is_none() {
+                if entry.is_dirty() {
                     deqs.move_to_back_ao(&entry);
                     deqs.move_to_back_wo(&entry);
                 } else {


### PR DESCRIPTION
Move internal pointers to deque nodes from `ValueEntry` to `EntryInfo`, so that the pointers are no longer copied on updating an entry.