### PR TITLE
Improve async cancellation safety of `future::Cache` (v0.12.0-beta.X)

### DIFF
--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -335,6 +335,15 @@ where
         }
     }
 
+    pub(crate) fn get_key_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<Arc<K>>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner
+            .get_key_value_and(key, hash, |k, _entry| Arc::clone(k))
+    }
+
     #[inline]
     pub(crate) fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<KvEntry<K, V>>
     where
@@ -538,6 +547,8 @@ where
                 }
 
                 if self.is_removal_notifier_enabled() {
+                    // TODO: Make this one resumable. (Pass `kl`, `_klg`, `upd_op`
+                    // and `ts`)
                     self.inner
                         .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified)
                         .await;
@@ -578,6 +589,8 @@ where
                     }
 
                     if self.is_removal_notifier_enabled() {
+                        // TODO: Make this one resumable. (Pass `kl`, `_klg`, `upd_op`
+                        // and `ts`)
                         self.inner
                             .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified)
                             .await;

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -109,7 +109,6 @@ impl<K, V, S> BaseCache<K, V, S> {
     }
 
     #[inline]
-    #[cfg(feature = "sync")]
     pub(crate) fn is_blocking_removal_notification(&self) -> bool {
         self.inner.is_blocking_removal_notification()
     }
@@ -378,7 +377,6 @@ where
         }
     }
 
-    #[cfg(feature = "sync")]
     pub(crate) fn get_key_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<Arc<K>>
     where
         K: Borrow<Q>,
@@ -997,7 +995,6 @@ impl<K, V, S> Inner<K, V, S> {
     }
 
     #[inline]
-    #[cfg(feature = "sync")]
     fn is_blocking_removal_notification(&self) -> bool {
         self.removal_notifier
             .as_ref()


### PR DESCRIPTION
https://github.com/moka-rs/moka/pull/294#issuecomment-1687337263

> I was reviewing the codes and found that cache write operations (such as `insert` and `get_with`) may not record a write operation log if the caller (enclosing future) has been cancelled. This will leave a newly inserted cached entry not managed by the cache policies (LFU filter, LRU queue, etc.). When this happens, the entry will never be evicted by the policy, while it can be read by `get`, replaced by other `insert`, or removed by `invalidate`.
>
> This issue already existed in very early version of moka. But v0.12.0 will increase the chance of this issue to happen as it now supports for calling user supplied async eviction listener.
>
> A common solution for this would be write-ahead-log, which to record the write op log ahead of the actual insert/update operation. However, we will not be able to do this because it is impossible to know the exact operation we are going to perform (_insert_ or _update_ to the internal concurrent hash table (cht)). Our lock-free cht allows multiple threads to try to insert and remove the same key at the same time, without taking locks. We will know our insert attempt turned out to be an insert or update only _after_ we succeeded.