### PR TITLE
Improve async cancellation safety of `future::Cache` (v0.12.0-beta.X)

### DIFF
--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -242,7 +242,6 @@ free some memory), you do not need to call `run_pending_tasks` method.
    - To enable it, see [Enabling the thread pool](#enabling-the-thread-pool) for more
      details.
 
-
 #### Enabling the thread pool
 
 To enable the thread pool, do the followings:

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -146,7 +146,7 @@ let cache = Cache::builder()
 
 `async_eviction_listener` takes a closure that returns a `Future`. If you need to
 `.await` something in the eviction listener, use this method. The actual return type
-of the closure is `future::ListenerFuture`, which is a type alias of
+of the closure is `notification::ListenerFuture`, which is a type alias of
 `Pin<Box<dyn Future<Output = ()> + Send>>`. You can use the `boxed` method of
 `future::FutureExt` trait to convert a regular `Future` into this type.
 

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -318,3 +318,19 @@ pub(crate) enum WriteOp<K, V> {
     },
     Remove(KvEntry<K, V>),
 }
+
+pub(crate) struct OldEntryInfo<K, V> {
+    pub(crate) entry: TrioArc<ValueEntry<K, V>>,
+    pub(crate) last_accessed: Option<Instant>,
+    pub(crate) last_modified: Option<Instant>,
+}
+
+impl<K, V> OldEntryInfo<K, V> {
+    pub(crate) fn new(entry: &TrioArc<ValueEntry<K, V>>) -> Self {
+        Self {
+            entry: TrioArc::clone(entry),
+            last_accessed: entry.last_accessed(),
+            last_modified: entry.last_modified(),
+        }
+    }
+}

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -297,6 +297,7 @@ impl<K, V> AccessTime for TrioArc<ValueEntry<K, V>> {
     }
 }
 
+#[cfg(feature = "sync")]
 pub(crate) enum ReadOp<K, V> {
     Hit {
         value_entry: TrioArc<ValueEntry<K, V>>,
@@ -307,6 +308,7 @@ pub(crate) enum ReadOp<K, V> {
     Miss(u64),
 }
 
+#[cfg(feature = "sync")]
 pub(crate) enum WriteOp<K, V> {
     Upsert {
         key_hash: KeyHash<K>,

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -306,7 +306,6 @@ impl<K, V> AccessTime for TrioArc<ValueEntry<K, V>> {
     }
 }
 
-#[cfg(feature = "sync")]
 pub(crate) enum ReadOp<K, V> {
     Hit {
         value_entry: TrioArc<ValueEntry<K, V>>,

--- a/src/future.rs
+++ b/src/future.rs
@@ -4,9 +4,16 @@
 //! To use this module, enable a crate feature called "future".
 
 use async_lock::Mutex;
-use futures_util::future::BoxFuture;
+use crossbeam_channel::Sender;
+use futures_util::future::{BoxFuture, Shared};
 use once_cell::sync::Lazy;
 use std::{future::Future, hash::Hash, sync::Arc};
+use triomphe::Arc as TrioArc;
+
+use crate::common::{
+    concurrent::{KeyHash, KvEntry, ValueEntry},
+    time::Instant,
+};
 
 mod base_cache;
 mod builder;
@@ -71,6 +78,54 @@ where
     }
 }
 
+pub(crate) enum PendingOp<K, V> {
+    // 'static means that the future can capture only owned value and/or static
+    // references. No non-static references are allowed.
+    CallEvictionListener {
+        future: Shared<BoxFuture<'static, ()>>,
+        op: WriteOp<K, V>,
+    },
+    #[allow(unused)]
+    SendWriteOp(WriteOp<K, V>),
+}
+
+struct PendingOpGuard<'a, K, V> {
+    pending_op_ch: &'a Sender<PendingOp<K, V>>,
+    future: Option<Shared<BoxFuture<'static, ()>>>,
+    op: Option<WriteOp<K, V>>,
+}
+
+impl<'a, K, V> PendingOpGuard<'a, K, V> {
+    fn new(pending_op_ch: &'a Sender<PendingOp<K, V>>) -> Self {
+        Self {
+            pending_op_ch,
+            future: Default::default(),
+            op: Default::default(),
+        }
+    }
+
+    fn set(&mut self, future: Shared<BoxFuture<'static, ()>>, op: WriteOp<K, V>) {
+        self.future = Some(future);
+        self.op = Some(op);
+    }
+
+    fn clear(&mut self) -> Option<WriteOp<K, V>> {
+        self.future = None;
+        self.op.take()
+    }
+}
+
+impl<'a, K, V> Drop for PendingOpGuard<'a, K, V> {
+    fn drop(&mut self) {
+        if let (Some(future), Some(op)) = (self.future.take(), self.op.take()) {
+            let pending_op = PendingOp::CallEvictionListener { future, op };
+            self.pending_op_ch
+                .send(pending_op)
+                .expect("Failed to send a pending op");
+        }
+    }
+}
+
 /// May yield to other async tasks.
 pub(crate) async fn may_yield() {
     static LOCK: Lazy<Mutex<()>> = Lazy::new(Default::default);
@@ -80,4 +135,24 @@ pub(crate) async fn may_yield() {
     //
     // NOTE: This behavior was tested with Tokio and async-std.
     let _ = LOCK.lock().await;
+}
+
+pub(crate) enum ReadOp<K, V> {
+    Hit {
+        value_entry: TrioArc<ValueEntry<K, V>>,
+        timestamp: Instant,
+        is_expiry_modified: bool,
+    },
+    // u64 is the hash of the key.
+    Miss(u64),
+}
+
+pub(crate) enum WriteOp<K, V> {
+    Upsert {
+        key_hash: KeyHash<K>,
+        value_entry: TrioArc<ValueEntry<K, V>>,
+        old_weight: u32,
+        new_weight: u32,
+    },
+    Remove(TrioArc<KvEntry<K, V>>),
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -8,12 +8,8 @@ use crossbeam_channel::Sender;
 use futures_util::future::{BoxFuture, Shared};
 use once_cell::sync::Lazy;
 use std::{future::Future, hash::Hash, sync::Arc};
-use triomphe::Arc as TrioArc;
 
-use crate::common::{
-    concurrent::{ValueEntry, WriteOp},
-    time::Instant,
-};
+use crate::common::{concurrent::WriteOp, time::Instant};
 
 mod base_cache;
 mod builder;
@@ -160,14 +156,4 @@ pub(crate) async fn may_yield() {
     //
     // NOTE: This behavior was tested with Tokio and async-std.
     let _ = LOCK.lock().await;
-}
-
-pub(crate) enum ReadOp<K, V> {
-    Hit {
-        value_entry: TrioArc<ValueEntry<K, V>>,
-        timestamp: Instant,
-        is_expiry_modified: bool,
-    },
-    // u64 is the hash of the key.
-    Miss(u64),
 }

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -3,7 +3,7 @@ use super::{
     invalidator::{GetOrRemoveEntry, Invalidator, KeyDateLite, PredicateFun},
     key_lock::{KeyLock, KeyLockMap},
     notifier::RemovalNotifier,
-    PendingOp, PredicateId, ReadOp, WriteOp,
+    PendingOp, PredicateId,
 };
 
 use crate::{
@@ -16,7 +16,8 @@ use crate::{
             },
             deques::Deques,
             entry_info::EntryInfo,
-            AccessTime, KeyHash, KeyHashDate, KvEntry, OldEntryInfo, ValueEntry, Weigher,
+            AccessTime, KeyHash, KeyHashDate, KvEntry, OldEntryInfo, ReadOp, ValueEntry, Weigher,
+            WriteOp,
         },
         deque::{DeqNode, Deque},
         frequency_sketch::FrequencySketch,

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -547,8 +547,9 @@ where
                 }
 
                 if self.is_removal_notifier_enabled() {
-                    // TODO: Make this one resumable. (Pass `kl`, `_klg`, `upd_op`
-                    // and `ts`)
+                    // TODO: Async cancellation safety: Make this resumable.
+                    // (NOTE: Move `kl`, `_klg`, `upd_op` and `ts` into the
+                    // Future)
                     self.inner
                         .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified)
                         .await;
@@ -589,8 +590,9 @@ where
                     }
 
                     if self.is_removal_notifier_enabled() {
-                        // TODO: Make this one resumable. (Pass `kl`, `_klg`, `upd_op`
-                        // and `ts`)
+                        // TODO: Async cancellation safety: Make this resumable.
+                        // (NOTE: Move `kl`, `_klg`, `upd_op` and `ts` into the
+                        // Future)
                         self.inner
                             .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified)
                             .await;

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -16,7 +16,7 @@ use crate::{
             },
             deques::Deques,
             entry_info::EntryInfo,
-            AccessTime, KeyHash, KeyHashDate, KvEntry, ValueEntry, Weigher,
+            AccessTime, KeyHash, KeyHashDate, KvEntry, OldEntryInfo, ValueEntry, Weigher,
         },
         deque::{DeqNode, Deque},
         frequency_sketch::FrequencySketch,
@@ -469,8 +469,6 @@ where
         hash: u64,
         value: V,
     ) -> (TrioArc<WriteOp<K, V>>, Instant) {
-        use futures_util::FutureExt;
-
         self.process_pending_ops().await;
 
         let ts = self.current_time_from_expiration_clock();
@@ -489,7 +487,7 @@ where
             None
         };
 
-        let mut drop_guard = PendingOpGuard::new(pending_op_ch, ts);
+        let drop_guard = PendingOpGuard::new(pending_op_ch, ts);
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation
@@ -505,140 +503,108 @@ where
             // on_insert
             || {
                 let entry = self.new_value_entry(&key, hash, value.clone(), ts, weight);
+                let ins_op = WriteOp::Upsert {
+                    key_hash: KeyHash::new(Arc::clone(&key), hash),
+                    value_entry: TrioArc::clone(&entry),
+                    old_weight: 0,
+                    new_weight: weight,
+                };
                 let cnt = op_cnt1.fetch_add(1, Ordering::Relaxed);
-                op1 = Some((
-                    cnt,
-                    WriteOp::Upsert {
-                        key_hash: KeyHash::new(Arc::clone(&key), hash),
-                        value_entry: TrioArc::clone(&entry),
-                        old_weight: 0,
-                        new_weight: weight,
-                    },
-                ));
+                op1 = Some((cnt, ins_op));
                 entry
             },
             // on_modify
             |_k, old_entry| {
-                // NOTES on `new_value_entry_from` method:
-                // 1. The internal EntryInfo will be shared between the old and new
-                //    ValueEntries.
-                // 2. This method will set the is_dirty to prevent this new
-                //    ValueEntry from being evicted by an expiration policy.
-                // 3. This method will update the policy_weight with the new weight.
                 let old_weight = old_entry.policy_weight();
-                let old_timestamps = (old_entry.last_accessed(), old_entry.last_modified());
+
+                // Create this OldEntryInfo _before_ creating a new ValueEntry, so
+                // that the OldEntryInfo can preserve the old EntryInfo's
+                // last_accessed and last_modified timestamps.
+                let old_info = OldEntryInfo::new(old_entry);
                 let entry = self.new_value_entry_from(value.clone(), ts, weight, old_entry);
+                let upd_op = WriteOp::Upsert {
+                    key_hash: KeyHash::new(Arc::clone(&key), hash),
+                    value_entry: TrioArc::clone(&entry),
+                    old_weight,
+                    new_weight: weight,
+                };
                 let cnt = op_cnt2.fetch_add(1, Ordering::Relaxed);
-                op2 = Some((
-                    cnt,
-                    TrioArc::clone(old_entry),
-                    old_timestamps,
-                    WriteOp::Upsert {
-                        key_hash: KeyHash::new(Arc::clone(&key), hash),
-                        value_entry: TrioArc::clone(&entry),
-                        old_weight,
-                        new_weight: weight,
-                    },
-                ));
+                op2 = Some((cnt, old_info, upd_op));
                 entry
             },
         );
 
         match (op1, op2) {
-            (Some((_cnt, ins_op)), None) => {
-                if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                    (&self.inner.expiration_policy.expiry(), &ins_op)
-                {
-                    Self::expire_after_create(expiry, &key, value_entry, ts, self.inner.clocks());
-                }
-                (TrioArc::new(ins_op), ts)
+            (Some((_cnt, ins_op)), None) => self.post_insert(ts, &key, ins_op),
+            (Some((cnt1, ins_op)), Some((cnt2, ..))) if cnt1 > cnt2 => {
+                self.post_insert(ts, &key, ins_op)
             }
-            (None, Some((_cnt, old_entry, (old_last_accessed, old_last_modified), upd_op))) => {
-                if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                    (&self.inner.expiration_policy.expiry(), &upd_op)
-                {
-                    Self::expire_after_read_or_update(
-                        |k, v, t, d| expiry.expire_after_update(k, v, t, d),
-                        &key,
-                        value_entry,
-                        self.inner.expiration_policy.time_to_live(),
-                        self.inner.expiration_policy.time_to_idle(),
-                        ts,
-                        self.inner.clocks(),
-                    );
-                }
-
-                let upd_op = TrioArc::new(upd_op);
-
-                if self.is_removal_notifier_enabled() {
-                    let future = self
-                        .inner
-                        .notify_upsert_future(key, &old_entry, old_last_accessed, old_last_modified)
-                        .shared();
-                    drop_guard.set_future_and_op(future.clone(), TrioArc::clone(&upd_op));
-
-                    future.await;
-                    drop_guard.clear();
-                }
-
-                crossbeam_epoch::pin().flush();
-                (upd_op, ts)
-            }
-            (
-                Some((cnt1, ins_op)),
-                Some((cnt2, old_entry, (old_last_accessed, old_last_modified), upd_op)),
-            ) => {
-                if cnt1 > cnt2 {
-                    if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                        (&self.inner.expiration_policy.expiry(), &ins_op)
-                    {
-                        Self::expire_after_create(
-                            expiry,
-                            &key,
-                            value_entry,
-                            ts,
-                            self.inner.clocks(),
-                        );
-                    }
-                    (TrioArc::new(ins_op), ts)
-                } else {
-                    if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                        (&self.inner.expiration_policy.expiry(), &upd_op)
-                    {
-                        Self::expire_after_read_or_update(
-                            |k, v, t, d| expiry.expire_after_update(k, v, t, d),
-                            &key,
-                            value_entry,
-                            self.inner.expiration_policy.time_to_live(),
-                            self.inner.expiration_policy.time_to_idle(),
-                            ts,
-                            self.inner.clocks(),
-                        );
-                    }
-
-                    let upd_op = TrioArc::new(upd_op);
-
-                    if self.is_removal_notifier_enabled() {
-                        let future = self
-                            .inner
-                            .notify_upsert_future(
-                                key,
-                                &old_entry,
-                                old_last_accessed,
-                                old_last_modified,
-                            )
-                            .shared();
-                        drop_guard.set_future_and_op(future.clone(), TrioArc::clone(&upd_op));
-
-                        future.await;
-                        drop_guard.clear();
-                    }
-                    crossbeam_epoch::pin().flush();
-                    (upd_op, ts)
-                }
+            (_, Some((_cnt, old_entry, upd_op))) => {
+                self.post_update(ts, key, old_entry, upd_op, drop_guard)
+                    .await
             }
             (None, None) => unreachable!(),
         }
+    }
+
+    fn post_insert(
+        &self,
+        ts: Instant,
+        key: &Arc<K>,
+        ins_op: WriteOp<K, V>,
+    ) -> (TrioArc<WriteOp<K, V>>, Instant) {
+        if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
+            (&self.inner.expiration_policy.expiry(), &ins_op)
+        {
+            Self::expire_after_create(expiry, key, value_entry, ts, self.inner.clocks());
+        }
+        (TrioArc::new(ins_op), ts)
+    }
+
+    async fn post_update<'a>(
+        &self,
+        ts: Instant,
+        key: Arc<K>,
+        old_info: OldEntryInfo<K, V>,
+        upd_op: WriteOp<K, V>,
+        mut drop_guard: PendingOpGuard<'a, K, V>,
+    ) -> (TrioArc<WriteOp<K, V>>, Instant) {
+        use futures_util::FutureExt;
+
+        if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
+            (&self.inner.expiration_policy.expiry(), &upd_op)
+        {
+            Self::expire_after_read_or_update(
+                |k, v, t, d| expiry.expire_after_update(k, v, t, d),
+                &key,
+                value_entry,
+                self.inner.expiration_policy.time_to_live(),
+                self.inner.expiration_policy.time_to_idle(),
+                ts,
+                self.inner.clocks(),
+            );
+        }
+
+        let upd_op = TrioArc::new(upd_op);
+
+        if self.is_removal_notifier_enabled() {
+            let future = self
+                .inner
+                .notify_upsert_future(
+                    key,
+                    &old_info.entry,
+                    old_info.last_accessed,
+                    old_info.last_modified,
+                )
+                .shared();
+            drop_guard.set_future_and_op(future.clone(), TrioArc::clone(&upd_op));
+
+            future.await;
+            drop_guard.clear();
+        }
+
+        crossbeam_epoch::pin().flush();
+        (upd_op, ts)
     }
 
     #[inline]

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -4625,14 +4625,23 @@ mod tests {
         // - get               (Already tested in a previous test)
         // - insert
         // - invalidate
+        // - remove
 
+        // insert
         prepare().await;
         cache.insert(99, 99).await;
         assert_eq!(listener_initiation_count.load(Ordering::Acquire), 1);
         assert_eq!(listener_completion_count.load(Ordering::Acquire), 1);
 
+        // invalidate
         prepare().await;
         cache.invalidate(&88).await;
+        assert_eq!(listener_initiation_count.load(Ordering::Acquire), 1);
+        assert_eq!(listener_completion_count.load(Ordering::Acquire), 1);
+
+        // remove
+        prepare().await;
+        cache.remove(&77).await;
         assert_eq!(listener_initiation_count.load(Ordering::Acquire), 1);
         assert_eq!(listener_completion_count.load(Ordering::Acquire), 1);
     }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1432,9 +1432,9 @@ where
 
                 let op = WriteOp::Remove(kv);
                 let hk = self.base.housekeeper.as_ref();
-                // TODO: If enclosing future is being dropped, save `op` and `now` so
-                // that we can resume later. (maybe we can send to an unbound mpsc
-                // channel)
+                // TODO: Async cancellation safety: If enclosing future is being
+                // dropped, save `op` and `now` so that we can resume later. (maybe
+                // we can send to an unbound mpsc channel)
                 Self::schedule_write_op(&self.base.inner, &self.base.write_op_ch, op, now, hk)
                     .await
                     .expect("Failed to remove");
@@ -1881,8 +1881,9 @@ where
 
         let (op, now) = self.base.do_insert_with_hash(key, hash, value).await;
         let hk = self.base.housekeeper.as_ref();
-        // TODO: If enclosing future is being dropped, save `op` and `now` so that
-        // we can resume later. (maybe we can send to an unbound mpsc channel)
+        // TODO: Async cancellation safety: If enclosing future is being dropped,
+        // save `op` and `now` so that we can resume later. (maybe we can send to an
+        // unbound mpsc channel)
         Self::schedule_write_op(&self.base.inner, &self.base.write_op_ch, op, now, hk)
             .await
             .expect("Failed to insert");

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -17,7 +17,8 @@ use crate::{
             deques::Deques,
             entry_info::EntryInfo,
             housekeeper::{self, Housekeeper, InnerSync, SyncPace},
-            AccessTime, KeyHash, KeyHashDate, KvEntry, ReadOp, ValueEntry, Weigher, WriteOp,
+            AccessTime, KeyHash, KeyHashDate, KvEntry, OldEntryInfo, ReadOp, ValueEntry, Weigher,
+            WriteOp,
         },
         deque::{DeqNode, Deque},
         frequency_sketch::FrequencySketch,
@@ -520,121 +521,92 @@ where
             // on_insert
             || {
                 let entry = self.new_value_entry(&key, hash, value.clone(), ts, weight);
+                let ins_op = WriteOp::Upsert {
+                    key_hash: KeyHash::new(Arc::clone(&key), hash),
+                    value_entry: TrioArc::clone(&entry),
+                    old_weight: 0,
+                    new_weight: weight,
+                };
                 let cnt = op_cnt1.fetch_add(1, Ordering::Relaxed);
-                op1 = Some((
-                    cnt,
-                    WriteOp::Upsert {
-                        key_hash: KeyHash::new(Arc::clone(&key), hash),
-                        value_entry: TrioArc::clone(&entry),
-                        old_weight: 0,
-                        new_weight: weight,
-                    },
-                ));
+                op1 = Some((cnt, ins_op));
                 entry
             },
             // on_modify
             |_k, old_entry| {
-                // NOTES on `new_value_entry_from` method:
-                // 1. The internal EntryInfo will be shared between the old and new ValueEntries.
-                // 2. This method will set the last_accessed and last_modified to the max value to
-                //    prevent this new ValueEntry from being evicted by an expiration policy.
-                // 3. This method will update the policy_weight with the new weight.
                 let old_weight = old_entry.policy_weight();
-                let old_timestamps = (old_entry.last_accessed(), old_entry.last_modified());
+
+                // Create this OldEntryInfo _before_ creating a new ValueEntry, so
+                // that the OldEntryInfo can preserve the old EntryInfo's
+                // last_accessed and last_modified timestamps.
+                let old_info = OldEntryInfo::new(old_entry);
                 let entry = self.new_value_entry_from(value.clone(), ts, weight, old_entry);
+                let upd_op = WriteOp::Upsert {
+                    key_hash: KeyHash::new(Arc::clone(&key), hash),
+                    value_entry: TrioArc::clone(&entry),
+                    old_weight,
+                    new_weight: weight,
+                };
                 let cnt = op_cnt2.fetch_add(1, Ordering::Relaxed);
-                op2 = Some((
-                    cnt,
-                    TrioArc::clone(old_entry),
-                    old_timestamps,
-                    WriteOp::Upsert {
-                        key_hash: KeyHash::new(Arc::clone(&key), hash),
-                        value_entry: TrioArc::clone(&entry),
-                        old_weight,
-                        new_weight: weight,
-                    },
-                ));
+                op2 = Some((cnt, old_info, upd_op));
                 entry
             },
         );
 
         match (op1, op2) {
-            (Some((_cnt, ins_op)), None) => {
-                if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                    (&self.inner.expiration_policy.expiry(), &ins_op)
-                {
-                    Self::expire_after_create(expiry, &key, value_entry, ts, self.inner.clocks());
-                }
-                (ins_op, ts)
+            (Some((_cnt, ins_op)), None) => self.post_insert(ts, &key, ins_op),
+            (Some((cnt1, ins_op)), Some((cnt2, ..))) if cnt1 > cnt2 => {
+                self.post_insert(ts, &key, ins_op)
             }
-            (None, Some((_cnt, old_entry, (old_last_accessed, old_last_modified), upd_op))) => {
-                if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                    (&self.inner.expiration_policy.expiry(), &upd_op)
-                {
-                    Self::expire_after_read_or_update(
-                        |k, v, t, d| expiry.expire_after_update(k, v, t, d),
-                        &key,
-                        value_entry,
-                        self.inner.expiration_policy.time_to_live(),
-                        self.inner.expiration_policy.time_to_idle(),
-                        ts,
-                        self.inner.clocks(),
-                    );
-                }
-
-                if self.is_removal_notifier_enabled() {
-                    self.inner
-                        .notify_upsert(key, &old_entry, old_last_accessed, old_last_modified);
-                }
-                crossbeam_epoch::pin().flush();
-                (upd_op, ts)
-            }
-            (
-                Some((cnt1, ins_op)),
-                Some((cnt2, old_entry, (old_last_accessed, old_last_modified), upd_op)),
-            ) => {
-                if cnt1 > cnt2 {
-                    if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                        (&self.inner.expiration_policy.expiry(), &ins_op)
-                    {
-                        Self::expire_after_create(
-                            expiry,
-                            &key,
-                            value_entry,
-                            ts,
-                            self.inner.clocks(),
-                        );
-                    }
-                    (ins_op, ts)
-                } else {
-                    if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
-                        (&self.inner.expiration_policy.expiry(), &upd_op)
-                    {
-                        Self::expire_after_read_or_update(
-                            |k, v, t, d| expiry.expire_after_update(k, v, t, d),
-                            &key,
-                            value_entry,
-                            self.inner.expiration_policy.time_to_live(),
-                            self.inner.expiration_policy.time_to_idle(),
-                            ts,
-                            self.inner.clocks(),
-                        );
-                    }
-
-                    if self.is_removal_notifier_enabled() {
-                        self.inner.notify_upsert(
-                            key,
-                            &old_entry,
-                            old_last_accessed,
-                            old_last_modified,
-                        );
-                    }
-                    crossbeam_epoch::pin().flush();
-                    (upd_op, ts)
-                }
-            }
+            (_, Some((_cnt, old_info, upd_op))) => self.post_update(ts, key, old_info, upd_op),
             (None, None) => unreachable!(),
         }
+    }
+
+    fn post_insert(
+        &self,
+        ts: Instant,
+        key: &Arc<K>,
+        ins_op: WriteOp<K, V>,
+    ) -> (WriteOp<K, V>, Instant) {
+        if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
+            (&self.inner.expiration_policy.expiry(), &ins_op)
+        {
+            Self::expire_after_create(expiry, key, value_entry, ts, self.inner.clocks());
+        }
+        (ins_op, ts)
+    }
+
+    fn post_update(
+        &self,
+        ts: Instant,
+        key: Arc<K>,
+        old_info: OldEntryInfo<K, V>,
+        upd_op: WriteOp<K, V>,
+    ) -> (WriteOp<K, V>, Instant) {
+        if let (Some(expiry), WriteOp::Upsert { value_entry, .. }) =
+            (&self.inner.expiration_policy.expiry(), &upd_op)
+        {
+            Self::expire_after_read_or_update(
+                |k, v, t, d| expiry.expire_after_update(k, v, t, d),
+                &key,
+                value_entry,
+                self.inner.expiration_policy.time_to_live(),
+                self.inner.expiration_policy.time_to_idle(),
+                ts,
+                self.inner.clocks(),
+            );
+        }
+
+        if self.is_removal_notifier_enabled() {
+            self.inner.notify_upsert(
+                key,
+                &old_info.entry,
+                old_info.last_accessed,
+                old_info.last_modified,
+            );
+        }
+        crossbeam_epoch::pin().flush();
+        (upd_op, ts)
     }
 
     #[inline]

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -553,16 +553,18 @@ where
         );
 
         match (op1, op2) {
-            (Some((_cnt, ins_op)), None) => self.post_insert(ts, &key, ins_op),
+            (Some((_cnt, ins_op)), None) => self.do_post_insert_steps(ts, &key, ins_op),
             (Some((cnt1, ins_op)), Some((cnt2, ..))) if cnt1 > cnt2 => {
-                self.post_insert(ts, &key, ins_op)
+                self.do_post_insert_steps(ts, &key, ins_op)
             }
-            (_, Some((_cnt, old_info, upd_op))) => self.post_update(ts, key, old_info, upd_op),
+            (_, Some((_cnt, old_info, upd_op))) => {
+                self.do_post_update_steps(ts, key, old_info, upd_op)
+            }
             (None, None) => unreachable!(),
         }
     }
 
-    fn post_insert(
+    fn do_post_insert_steps(
         &self,
         ts: Instant,
         key: &Arc<K>,
@@ -576,7 +578,7 @@ where
         (ins_op, ts)
     }
 
-    fn post_update(
+    fn do_post_update_steps(
         &self,
         ts: Instant,
         key: Arc<K>,


### PR DESCRIPTION
This PR improves async cancellation safety of cache write methods `insert`, `get_with`, `invalidate` and `remove`. It is for `future::Cache` in v0.12.0-beta.1.

## The Problem

https://github.com/moka-rs/moka/pull/294#issuecomment-1687337263

> I was reviewing the codes and found that cache write operations (such as `insert` and `get_with`) may not record a write operation log if the caller (enclosing future) has been cancelled. This will leave a newly inserted cached entry not managed by the cache policies (LFU filter, LRU queue, etc.). When this happens, the entry will never be evicted by the policy, while it can be read by `get`, replaced by other `insert`, or removed by `invalidate`.
> 
> This issue already existed in very early version of moka. But v0.12.0 will increase the chance of this issue to happen as it now supports for calling user supplied async eviction listener.
> 
> A common solution for this would be write-ahead-log, which to record the write op log ahead of the actual insert/update operation. However, we will not be able to do this because it is impossible to know the exact operation we are going to perform (_insert_ or _update_ to the internal concurrent hash table (cht)). Our lock-free cht allows multiple threads to try to insert and remove the same key at the same time, without taking locks. We will know our insert attempt turned out to be an insert or update only _after_ we succeeded.

You will be affected by the above if you use `async_eviction_listener` _and_ do [async cancellation](https://blog.yoshuawuyts.com/async-cancellation-1/). For example, some sever frameworks such as Axum do async cancellation for you; request handling will be cancelled when the client connection is dropped.

## The Solution

This PR addresses the above problem by saving the interrupted tasks to a mpmc channel when async cancellation happens on the following methods:

- Some of the cache write methods: `insert`, `get_with`, `invalidate` and `remove`

These interrupted tasks will be resumed/retried when one of the following methods is called:

- The cache write methods listed above.
- `get` method
- `run_pending_tasks` method

The following interrupted tasks will be saved and resumed/retried:

- If an eviction listener is configured, and an async cancellation happens while one of those cache write methods listed above is notifying the eviction listener for an entry replacement/removal, the incomplete notification `Future` should be saved.
- An async cancellation happens while one of those cache write methods listed above tries to send a write op log (`WriteOp` enum) to an internal channel but the channel is full, the `WriteOp` should be saved.

## A Limitation

`future::Cache` v0.12.0 or later does `Immediate` notification delivery mode, which guarantees to preserve the order of events on a key. However, if the eviction listener is interrupted by async cancellation and then resumed, the order may not be preserved. 

## Testing the Solution

Added the following unit tests to verify those interrupted tasks are resumed/retried:

- `cancel_future_while_calling_eviction_listener`
- `cancel_future_while_scheduling_write_op`