### PR TITLE
rustfmt and clippy (v0.12.x)

### DIFF
--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -83,7 +83,9 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
         mut eq: impl FnMut(&K) -> bool,
     ) -> Result<Shared<'g, Bucket<K, V>>, RelocatedError> {
         for bucket in self.probe(guard, hash) {
-            let Ok((_, _, this_bucket_ptr)) = bucket else { return Err(RelocatedError); };
+            let Ok((_, _, this_bucket_ptr)) = bucket else {
+                return Err(RelocatedError);
+            };
 
             let this_bucket_ref = if let Some(r) = unsafe { this_bucket_ptr.as_ref() } {
                 r
@@ -121,7 +123,9 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
     {
         let mut probe = self.probe(guard, hash);
         while let Some(bucket) = probe.next() {
-            let Ok((_, this_bucket, this_bucket_ptr)) = bucket else { return Err(condition); };
+            let Ok((_, this_bucket, this_bucket_ptr)) = bucket else {
+                return Err(condition);
+            };
 
             let this_bucket_ref = if let Some(r) = unsafe { this_bucket_ptr.as_ref() } {
                 r
@@ -233,7 +237,9 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
     {
         let mut probe = self.probe(guard, hash);
         while let Some(bucket) = probe.next() {
-            let Ok((_, this_bucket, this_bucket_ptr)) = bucket else { return Err((state, modifier)); };
+            let Ok((_, this_bucket, this_bucket_ptr)) = bucket else {
+                return Err((state, modifier));
+            };
 
             let (new_bucket, maybe_insert_value) =
                 if let Some(this_bucket_ref) = unsafe { this_bucket_ptr.as_ref() } {
@@ -294,7 +300,9 @@ impl<'g, K: 'g + Eq, V: 'g> BucketArray<K, V> {
 
         let mut probe = self.probe(guard, hash);
         while let Some(bucket) = probe.next() {
-            let Ok((i, this_bucket, this_bucket_ptr)) = bucket else { return None; };
+            let Ok((i, this_bucket, this_bucket_ptr)) = bucket else {
+                return None;
+            };
 
             if let Some(Bucket { key: this_key, .. }) = unsafe { this_bucket_ptr.as_ref() } {
                 if this_bucket_ptr == bucket_ptr {

--- a/src/notification/notifier.rs
+++ b/src/notification/notifier.rs
@@ -158,13 +158,9 @@ impl<K, V> ThreadPoolRemovalNotifier<K, V> {
             is_running: Default::default(),
             is_shutting_down: Default::default(),
         };
-
-        #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
-        let state = Arc::new(state);
-
         Self {
             snd,
-            state,
+            state: Arc::new(state),
             thread_pool,
         }
     }

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -112,7 +112,6 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
-            #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }


### PR DESCRIPTION
- Apply rustfmt for `if let ... else`.
- Remove allow `clippy::arc_with_non_send_sync` as the false positives are fixed in Clippy.