### PR TITLE
Better async waiting for when the write op channel is full

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"
@@ -35,25 +35,25 @@ logging = ["log"]
 # https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 atomic64 = []
 
-# This is an **experimental** feature to make `unsync` and `sync` caches to compile
-# for `wasm32-unknown-unknown` target. Note that we have not tested if these caches
-# work correctly in wasm32 environment.
+# This is an **experimental** feature to make `sync` caches to compile for
+# `wasm32-unknown-unknown` target. Note that we have not tested if these caches work
+# correctly in wasm32 environment.
 js = ["uuid/js"]
 
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns
 # counters of internal object construction and destruction. It will have some
-# performance impacts and is intended for debugging purpose.
+# performance impacts and is intended for debugging.
 unstable-debug-counters = ["future"]
 
 [dependencies]
-crossbeam-channel = { version = "0.5.5" }
-crossbeam-epoch = { version = "0.9.9" }
-crossbeam-utils = { version = "0.8" }
-once_cell = { version = "1.7" }
-parking_lot = { version = "0.12" }
-smallvec = { version = "1.8" }
-tagptr = { version = "0.2" }
-thiserror = { version = "1.0" }
+crossbeam-channel = "0.5.5"
+crossbeam-epoch = "0.9.9"
+crossbeam-utils = "0.8"
+once_cell = "1.7"
+parking_lot = "0.12"
+smallvec = "1.8"
+tagptr = "0.2"
+thiserror = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
 # Opt-out serde and stable_deref_trait features

--- a/src/future.rs
+++ b/src/future.rs
@@ -3,10 +3,8 @@
 //!
 //! To use this module, enable a crate feature called "future".
 
-use async_lock::Mutex;
 use crossbeam_channel::Sender;
 use futures_util::future::{BoxFuture, Shared};
-use once_cell::sync::Lazy;
 use std::{future::Future, hash::Hash, sync::Arc};
 
 use crate::common::{concurrent::WriteOp, time::Instant};
@@ -146,15 +144,4 @@ impl<'a, K, V> Drop for CancelGuard<'a, K, V> {
             .send(interrupted_op)
             .expect("Failed to send a pending op");
     }
-}
-
-/// May yield to other async tasks.
-pub(crate) async fn may_yield() {
-    static LOCK: Lazy<Mutex<()>> = Lazy::new(Default::default);
-
-    // Acquire the lock then immediately release it. This `await` may yield to other
-    // tasks.
-    //
-    // NOTE: This behavior was tested with Tokio and async-std.
-    let _ = LOCK.lock().await;
 }

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -657,13 +657,12 @@ where
                 Err(e @ TrySendError::Disconnected(_)) => return Err(e),
             }
 
-            // We have got a `TrySendError::Full` above. Wait for a moment and try
-            // again.
+            // We have got a `TrySendError::Full` above. Wait a moment and try again.
 
             if spin_loop_attempts < 4 {
                 spin_loop_attempts += 1;
                 // Wastes some CPU time with a hint to indicate to the CPU that we
-                // are spinning. Adjust the SPIN_COUNT because the `pause`
+                // are spinning. Adjust the SPIN_COUNT because the `PAUSE`
                 // instruction of recent x86_64 CPUs may have longer latency than the
                 // alternatives in other CPU architectures.
                 const SPIN_COUNT: usize = if cfg!(target_arch = "x86_64") { 8 } else { 32 };
@@ -671,8 +670,8 @@ where
                     std::hint::spin_loop();
                 }
             } else {
-                // Wait for a shared (reader) lock to become available. The exclusive
-                // (writer) lock will be already held by another async task that is
+                // Wait for a shared reader lock to become available. The exclusive
+                // writer lock will be already held by another async task that is
                 // currently calling `do_run_pending_tasks` method via
                 // `apply_reads_writes_if_needed` method above.
                 //


### PR DESCRIPTION
This PR replaces the async `may_yield` function introduced at `v0.12.0-beta.1` with a more efficient implementation. It uses an `async_lock::RwLock` between a user async task, that is currently running internal `do_run_pending_tasks`, and other user async tasks.

This will be more CPU efficient than `may_yield` because it makes some of the user async tasks to wait for reader locks, rather than keeping spinning, so that the async runtime scheduler can run other async tasks if there are any.

This PR also bumps the version to `v0.12.0-beta.3`.