### PR TITLE
Get the last modified time for upsert after acquiring key level lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Please read the [MIGRATION-GUIDE.md][migration-guide-v012] for more details.
   caches ([#316][gh-pull-0316]).
 - Improved async cancellation safety of `future::Cache`. ([#309][gh-pull-0309])
 
+### Fixed
+
+- Fixed a bug that an internal `do_insert_with_hash` method gets the current
+  `Instant` too early when eviction listener is enabled. ([#322][gh-issue-0322])
+
 
 ## Version 0.11.3
 
@@ -696,6 +701,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
 
+[gh-issue-0322]: https://github.com/moka-rs/moka/issues/322/
 [gh-issue-0255]: https://github.com/moka-rs/moka/issues/255/
 [gh-issue-0252]: https://github.com/moka-rs/moka/issues/252/
 [gh-issue-0243]: https://github.com/moka-rs/moka/issues/243/

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -479,7 +479,6 @@ where
     ) -> (WriteOp<K, V>, Instant) {
         self.retry_interrupted_ops().await;
 
-        let ts = self.current_time_from_expiration_clock();
         let weight = self.inner.weigh(&key, &value);
         let op_cnt1 = Arc::new(AtomicU8::new(0));
         let op_cnt2 = Arc::clone(&op_cnt1);
@@ -493,6 +492,8 @@ where
         } else {
             None
         };
+
+        let ts = self.current_time_from_expiration_clock();
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -480,7 +480,6 @@ where
         hash: u64,
         value: V,
     ) -> (WriteOp<K, V>, Instant) {
-        let ts = self.current_time_from_expiration_clock();
         let weight = self.inner.weigh(&key, &value);
         let op_cnt1 = Rc::new(AtomicU8::new(0));
         let op_cnt2 = Rc::clone(&op_cnt1);
@@ -490,6 +489,8 @@ where
         // Lock the key for update if blocking removal notification is enabled.
         let kl = self.maybe_key_lock(&key);
         let _klg = &kl.as_ref().map(|kl| kl.lock());
+
+        let ts = self.current_time_from_expiration_clock();
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation


### PR DESCRIPTION
- Fixes #322
- Update the `Expiry` documentation for clarity.

This is for the `main` branch (v0.12.0). I will back-port this to the branch for v0.11.0.