### PR TITLE
Prepare for v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Moka Cache &mdash; Change Log
 
-## Version 0.12.0 (Currently Beta)
+## Version 0.12.0
 
-**ATTENTION**: `v0.12.0` has major breaking changes on the API and internal behavior.
+> **Note**
+> `v0.12.0` has major breaking changes on the API and internal behavior.
 
 - **`sync` caches are no longer enabled by default**: Please use a crate feature
   `sync` to enable it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.0-beta.3"
+version = "0.12.0"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![license][license-badge]](#license)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield)
 
-**ATTENTION**: `v0.12.0` (currently beta) has major breaking changes on the API and
-internal behavior. Please read the [MIGRATION-GUIDE.md][migration-guide-v012] for the
-details.
+> **note**
+> `v0.12.0` has major breaking changes on the API and internal behavior. Please read
+> the [MIGRATION-GUIDE.md][migration-guide-v012] for the details.
 
 * * *
 
@@ -117,9 +117,9 @@ routers. Here are some highlights:
 
 ## Recent Changes
 
-**ATTENTION**: `v0.12.0` (currently beta) has major breaking changes on the API and
-internal behavior. Please read the [MIGRATION-GUIDE.md][migration-guide-v012] for the
-details.
+> **Note**
+> `v0.12.0` has major breaking changes on the API and internal behavior. Please read
+> the [MIGRATION-GUIDE.md][migration-guide-v012] for the details.
 
 - [MIGRATION-GUIDE.md][migration-guide-v012]
 - [CHANGELOG.md](https://github.com/moka-rs/moka/blob/main/CHANGELOG.md)

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1761,6 +1761,7 @@ where
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
+    // TODO: Like future::Cache, move this method to BaseCache.
     #[inline]
     fn schedule_write_op(
         inner: &impl InnerSync,


### PR DESCRIPTION
- Removed `-beta.N` from the version `v0.12.0`.
- Removed an internal field `invalidator_enabled` from `sync::base_cache::Inner`.
- Added some source code comments (`TODO` comments).