### PR TITLE
Fix memory leak in `get_with` and friend methods of `future::Cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.1
+
+### Fixed
+
+- Fixed memory leak in `future::Cache` when `get_with()`, `entry().or_insert_with()`,
+  and friend methods are used ([#329][gh-issue-0329]).
+    - This bug was introduced in `v0.12.0`. Versions earlier than `v0.12.0` do not
+      have this bug.
+
+
 ## Version 0.12.0
 
 > **Note**
@@ -702,6 +712,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
 
+[gh-issue-0329]: https://github.com/moka-rs/moka/issues/329/
 [gh-issue-0322]: https://github.com/moka-rs/moka/issues/322/
 [gh-issue-0255]: https://github.com/moka-rs/moka/issues/255/
 [gh-issue-0252]: https://github.com/moka-rs/moka/issues/252/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
-- Fixed memory leak in `future::Cache` when `get_with()`, `entry().or_insert_with()`,
-  and friend methods are used ([#329][gh-issue-0329]).
-    - This bug was introduced in `v0.12.0`. Versions earlier than `v0.12.0` do not
+- Fixed memory leak in `future::Cache` that occurred when `get_with()`,
+  `entry().or_insert_with()`, and similar methods were used ([#329][gh-issue-0329]).
+    - This bug was introduced in `v0.12.0`. Versions prior to `v0.12.0` do not
       have this bug.
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -498,7 +498,7 @@ where
 
         // TODO: Instead using Arc<AtomicU8> to check if the actual operation was
         // insert or update, check the return value of insert_with_or_modify. If it
-        // is_some, the value was inserted, otherwise the value was updated.
+        // is_some, the value was updated, otherwise the value was inserted.
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -495,7 +495,7 @@ where
 
         // TODO: Instead using Arc<AtomicU8> to check if the actual operation was
         // insert or update, check the return value of insert_with_or_modify. If it
-        // is_some, the value was inserted, otherwise the value was updated.
+        // is_some, the value was updated, otherwise the value was inserted.
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation


### PR DESCRIPTION
This PR fixes #329, a bug introduced to v0.12.0 causing memory leak in `get_with()`, `entry().or_insert_with()` and friend methods in `future::Cache`.

It also bumps the crate version to v0.12.1.

## Details of the bug

The bug was introduced by PR #294 for v0.12.0 ([src/future/value_initializer.rs diff L316-L330](https://github.com/moka-rs/moka/pull/294/files#diff-3df6f2ad1c01aeaaff49319246d71a65d7fd5ac8ae5bcd0c32a912ba38228f65L316-L330)). So this PR basically reverts the change.

Here are some backgrounds. An instance of `future::Cache` has a few internal concurrent hash tables (cht), and the following tables are related to this bug:

1. The main cht called `cache` map, which stores cached entries.
2. A cht called `waiter` map, which stores per-key reader-writer locks used by `get_with` and friends methods.

The key of `cache` map is `Arc<K>`, and the key of `waiter` map is `(Arc<K>, TypeId)`. These internal maps take a hash function at creation, and both `cache` map and `waiter` map are given the same hash function.

Also, these maps take `hash` value for the key when inserting, getting, or removing an entry (a key-value pair). The `hash` value is supposed to be calculated from the key by the hash function. However, the bug made `get_with` etc. to use a hash value for `cache` map for accessing `waiter` map. Since their keys are different, the hash value are also different.

Using a _wrong_ hash value still works as long as `waiter` map is using the same memory region where the entry was inserted to. However, once the memory region gets half full with live entries and deleted keys, `waiter` map will allocate a new memory region and move live entries to it, using the _correct_ hash values for the keys. Once this happens, `get_with` etc. (who use wrong hash) cannot find entries in `waiter` map anymore, leaving them in the map forever. (memory leak)
