### PR TITLE
Micro-optimize ValueInitializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.1
+
+### Fixed
+
+- Fixed memory leak in `future::Cache` when `get_with()`, `entry().or_insert_with()`,
+  and friend methods are used ([#329][gh-issue-0329]).
+    - This bug was introduced in `v0.12.0`. Versions earlier than `v0.12.0` do not
+      have this bug.
+
+
 ## Version 0.12.0
 
 > **Note**
@@ -702,6 +712,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
 
+[gh-issue-0329]: https://github.com/moka-rs/moka/issues/329/
 [gh-issue-0322]: https://github.com/moka-rs/moka/issues/322/
 [gh-issue-0255]: https://github.com/moka-rs/moka/issues/255/
 [gh-issue-0252]: https://github.com/moka-rs/moka/issues/252/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2018"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -498,7 +498,7 @@ where
 
         // TODO: Instead using Arc<AtomicU8> to check if the actual operation was
         // insert or update, check the return value of insert_with_or_modify. If it
-        // is_some, the value was inserted, otherwise the value was updated.
+        // is_some, the value was updated, otherwise the value was inserted.
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -495,7 +495,7 @@ where
 
         // TODO: Instead using Arc<AtomicU8> to check if the actual operation was
         // insert or update, check the return value of insert_with_or_modify. If it
-        // is_some, the value was inserted, otherwise the value was updated.
+        // is_some, the value was updated, otherwise the value was inserted.
 
         // Since the cache (cht::SegmentedHashMap) employs optimistic locking
         // strategy, insert_with_or_modify() may get an insert/modify operation


### PR DESCRIPTION
This has the following changes/optimizations:
- Avoids a needless incref/decref on `waiters`.
- Avoids unconditionally cloning the waiter key by moving it to the `WaiterGuard`.
- Use an `Option` in the `WaiterGuard` instead of a manual bool.
- Move the own `waiter` allocation out of the loop.
- Un-indent the loop by using an let-else.
- This also clarifies that no looping happens when our waiter was inserted.

Based on top of #330, I will rebase once that lands.