### PR TITLE
CI: Update Linux cross compile tests (v0.12.x)

### DIFF
--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -21,6 +21,8 @@ jobs:
   linux-cross:
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         platform:
           - target: aarch64-unknown-linux-musl

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -36,15 +36,18 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          target: ${{ matrix.platform.target }}
-          override: true
+          targets: ${{ matrix.platform.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Remove integration tests and force enable rustc_version crate
         run: |
@@ -54,25 +57,12 @@ jobs:
           sed -i 's/build = "build.rs"/build = ".ci_extras\/build_linux_cross.rs"/' Cargo.toml
           cat Cargo.toml
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Run tests (sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --release --features sync --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+        run: cross test --release -F sync --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (future feature)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --release --features future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+        run: cross test --release -F future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}


### PR DESCRIPTION
Update Linux cross compile tests (linux-cross) on the `main` branch (for v0.12.x).

- Disable fail-fast strategy for linux-cross.
- Stop using actions-rs GH actions in linux-cross:
    - Stop using `actions-rs/toolchain` and `actions-rs/cargo`.
    - Start to use `dtolnay/rust-toolchain` and `taiki-e/install-action`.
    - Upgrade `actions/checkout` from v2 to v4.

Note that the following tests are failing due to a Rust compiler/LLVM bug for MIPS targets. (See #333)

- linux-cross (mips-unknown-linux-musl)
- linux-cross (mipsel-unknown-linux-musl)
