### PR TITLE
CI: Update Linux cross compile tests (v0.10.x)

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -5,3 +5,9 @@ set -eux
 # Pin some dependencies to specific versions for the MSRV.
 cargo update -p tempfile --precise 3.6.0
 cargo update -p tokio --precise 1.29.1
+cargo update -p async-executor --precise 1.5.1
+cargo update -p reqwest --precise 0.11.18
+cargo update -p regex --precise 1.9.6
+cargo update -p memchr --precise 2.6.2
+cargo update -p h2 --precise 0.3.20
+cargo update -p actix-rt --precise 2.8.0

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -21,6 +21,8 @@ jobs:
   linux-cross:
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         platform:
           - target: aarch64-unknown-linux-musl

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -26,15 +26,23 @@ jobs:
       matrix:
         platform:
           - target: aarch64-unknown-linux-musl
+            rust-version: stable
           - target: i686-unknown-linux-musl
+            rust-version: stable
           - target: armv7-unknown-linux-musleabihf
+            rust-version: stable
           # Platforms without AtomicU64 support.
           - target: armv5te-unknown-linux-musleabi
             cargo-opts: "--no-default-features"  # Disable atomic64 and quanta features.
+            rust-version: stable
           - target: mips-unknown-linux-musl
             cargo-opts: "--no-default-features"  # Disable atomic64 and quanta features.
+            rust-version: "1.72.1"
+            cargo-version: "+1.72.1"
           - target: mipsel-unknown-linux-musl
             cargo-opts: "--no-default-features"  # Disable atomic64 and quanta features.
+            rust-version: "1.72.1"
+            cargo-version: "+1.72.1"
 
     steps:
       - name: Checkout Moka
@@ -43,7 +51,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.platform.rust-version }}
           targets: ${{ matrix.platform.target }}
 
       - name: Install cross
@@ -62,9 +70,13 @@ jobs:
       - run: cargo clean
 
       - name: Run tests (sync feature)
-        run: cross test --release -F sync --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+        run: |
+          cross ${{ matrix.platform.carge-version }} test --release -F sync \
+            --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (future feature)
-        run: cross test --release -F future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+        run: |
+          cross ${{ matrix.platform.cargo-version }} test --release -F future \
+            --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -36,15 +36,18 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          target: ${{ matrix.platform.target }}
-          override: true
+          targets: ${{ matrix.platform.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Remove integration tests and force enable rustc_version crate
         run: |
@@ -54,25 +57,12 @@ jobs:
           sed -i 's/build = "build.rs"/build = ".ci_extras\/build_linux_cross.rs"/' Cargo.toml
           cat Cargo.toml
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo clean
 
       - name: Run tests (sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --release --features sync --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+        run: cross test --release -F sync --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (future feature)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --release --features future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+        run: cross test --release -F future --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -117,6 +117,7 @@ mod test {
 
         use TargetArch::*;
 
+        #[allow(clippy::option_env_unwrap)]
         // e.g. "1.64"
         let ver = option_env!("RUSTC_SEMVER").expect("RUSTC_SEMVER env var not set");
         let is_quanta_enabled = cfg!(feature = "quanta");

--- a/src/notification/notifier.rs
+++ b/src/notification/notifier.rs
@@ -159,12 +159,9 @@ impl<K, V> ThreadPoolRemovalNotifier<K, V> {
             is_shutting_down: Default::default(),
         };
 
-        #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
-        let state = Arc::new(state);
-
         Self {
             snd,
-            state,
+            state: Arc::new(state),
             thread_pool,
         }
     }

--- a/src/sync_base/invalidator.rs
+++ b/src/sync_base/invalidator.rs
@@ -114,7 +114,6 @@ impl<K, V, S> Invalidator<K, V, S> {
         Self {
             predicates: RwLock::new(HashMap::new()),
             is_empty: AtomicBool::new(true),
-            #[cfg_attr(beta_clippy, allow(clippy::arc_with_non_send_sync))]
             scan_context: Arc::new(ScanContext::new(cache)),
             thread_pool,
         }


### PR DESCRIPTION
Update Linux cross compile tests (linux-cross) on the `v0.10.x` branch.

- To workaround [#333](https://github.com/moka-rs/moka/issues/333), pin the Rust version to 1.72.1 for the following tests:
    - linux-cross (mips-unknown-linux-musl)
    - linux-cross (mipsel-unknown-linux-musl)
- Disable fail-fast strategy for linux-cross.
- Add more crates to downgrade when testing the MSRV (1.60.0):
    - `async-executor` v1.5.1
    - `reqwest` v0.11.18
    - `regex` v1.9.6
    - `memchr` v2.6.2
    - `h2` v0.3.20
    - `actix-rt` v2.8.0
- Stop using actions-rs GH actions in linux-cross:
    - Stop using `actions-rs/toolchain` and `actions-rs/cargo`.
    - Start to use `dtolnay/rust-toolchain` and `taiki-e/install-action`.
    - Upgrade `actions/checkout` from v2 to v4.
- Apply rustfmt.
- Disable a Clippy lint `clippy::option_env_unwrap` in a test.
- Remove workarounds for a Clippy issue ([#301](https://github.com/moka-rs/moka/issues/301)):
    - Remove allow `clippy::arc_with_non_send_sync` as the false positives have been fixed in Clippy.