### PR TITLE
Update to 2021 edition, bless tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "moka"
 version = "0.12.1"
-edition = "2018"
+edition = "2021"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"
 description = "A fast and concurrent cache library inspired by Java Caffeine"

--- a/src/common/timer_wheel.rs
+++ b/src/common/timer_wheel.rs
@@ -373,9 +373,6 @@ impl<K> TimerWheel<K> {
     //   which is ~584 years in nanoseconds.
     //
     fn time_nanos(&self, time: Instant) -> u64 {
-        // `TryInto` will be in the prelude starting in Rust 2021 Edition.
-        use std::convert::TryInto;
-
         let nanos_u128 = time
             .checked_duration_since(self.origin)
             // If `time` is earlier than `self.origin`, use zero. This would never

--- a/tests/compile_tests/default/clone/sync_cache_clone.stderr
+++ b/tests/compile_tests/default/clone/sync_cache_clone.stderr
@@ -1,33 +1,41 @@
 error[E0277]: the trait bound `MyValue: Clone` is not satisfied
-   --> tests/compile_tests/default/clone/sync_cache_clone.rs:18:41
-    |
-18  |     let _cache: Cache<MyKey, MyValue> = Cache::new(CAP);
-    |                                         ^^^^^^^^^^ the trait `Clone` is not implemented for `MyValue`
-    |
+  --> tests/compile_tests/default/clone/sync_cache_clone.rs:18:41
+   |
+18 |     let _cache: Cache<MyKey, MyValue> = Cache::new(CAP);
+   |                                         ^^^^^^^^^^ the trait `Clone` is not implemented for `MyValue`
+   |
 note: required by a bound in `moka::sync::Cache::<K, V>::new`
-   --> src/sync/cache.rs
-    |
-    |     V: Clone + Send + Sync + 'static,
-    |        ^^^^^ required by this bound in `moka::sync::Cache::<K, V>::new`
+  --> src/sync/cache.rs
+   |
+   |     V: Clone + Send + Sync + 'static,
+   |        ^^^^^ required by this bound in `Cache::<K, V>::new`
+...
+   |     pub fn new(max_capacity: u64) -> Self {
+   |            --- required by a bound in this associated function
 help: consider annotating `MyValue` with `#[derive(Clone)]`
-    |
-41  | #[derive(Clone)]
+   |
+41  + #[derive(Clone)]
+42  | pub struct MyValue(i32);
     |
 
 error[E0277]: the trait bound `MyBuildHasher1: Clone` is not satisfied
-   --> tests/compile_tests/default/clone/sync_cache_clone.rs:28:84
-    |
-28  |     let _cache: Cache<MyKey, Arc<MyValue>, _> = Cache::builder().build_with_hasher(MyBuildHasher1);
-    |                                                                  ----------------- ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `MyBuildHasher1`
-    |                                                                  |
-    |                                                                  required by a bound introduced by this call
-    |
+  --> tests/compile_tests/default/clone/sync_cache_clone.rs:28:84
+   |
+28 |     let _cache: Cache<MyKey, Arc<MyValue>, _> = Cache::builder().build_with_hasher(MyBuildHasher1);
+   |                                                                  ----------------- ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `MyBuildHasher1`
+   |                                                                  |
+   |                                                                  required by a bound introduced by this call
+   |
 note: required by a bound in `moka::sync::CacheBuilder::<K, V, moka::sync::Cache<K, V>>::build_with_hasher`
-   --> src/sync/builder.rs
-    |
-    |         S: BuildHasher + Clone + Send + Sync + 'static,
-    |                          ^^^^^ required by this bound in `moka::sync::CacheBuilder::<K, V, moka::sync::Cache<K, V>>::build_with_hasher`
+  --> src/sync/builder.rs
+   |
+   |     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
+   |            ----------------- required by a bound in this associated function
+   |     where
+   |         S: BuildHasher + Clone + Send + Sync + 'static,
+   |                          ^^^^^ required by this bound in `CacheBuilder::<K, V, Cache<K, V>>::build_with_hasher`
 help: consider annotating `MyBuildHasher1` with `#[derive(Clone)]`
-    |
-44  | #[derive(Clone)]
+   |
+44  + #[derive(Clone)]
+45  | pub struct MyBuildHasher1;
     |

--- a/tests/compile_tests/default/clone/sync_seg_cache_clone.stderr
+++ b/tests/compile_tests/default/clone/sync_seg_cache_clone.stderr
@@ -9,25 +9,33 @@ note: required by a bound in `SegmentedCache::<K, V>::new`
    |
    |     V: Clone + Send + Sync + 'static,
    |        ^^^^^ required by this bound in `SegmentedCache::<K, V>::new`
+...
+   |     pub fn new(max_capacity: u64, num_segments: usize) -> Self {
+   |            --- required by a bound in this associated function
 help: consider annotating `MyValue` with `#[derive(Clone)]`
    |
-44 | #[derive(Clone)]
+44 + #[derive(Clone)]
+45 | pub struct MyValue(i32);
    |
 
 error[E0277]: the trait bound `MyBuildHasher1: Clone` is not satisfied
-   --> tests/compile_tests/default/clone/sync_seg_cache_clone.rs:30:56
-    |
-30  |         SegmentedCache::builder(SEG).build_with_hasher(MyBuildHasher1);
-    |                                      ----------------- ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `MyBuildHasher1`
-    |                                      |
-    |                                      required by a bound introduced by this call
-    |
+  --> tests/compile_tests/default/clone/sync_seg_cache_clone.rs:30:56
+   |
+30 |         SegmentedCache::builder(SEG).build_with_hasher(MyBuildHasher1);
+   |                                      ----------------- ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `MyBuildHasher1`
+   |                                      |
+   |                                      required by a bound introduced by this call
+   |
 note: required by a bound in `moka::sync::CacheBuilder::<K, V, SegmentedCache<K, V>>::build_with_hasher`
-   --> src/sync/builder.rs
-    |
-    |         S: BuildHasher + Clone + Send + Sync + 'static,
-    |                          ^^^^^ required by this bound in `moka::sync::CacheBuilder::<K, V, SegmentedCache<K, V>>::build_with_hasher`
+  --> src/sync/builder.rs
+   |
+   |     pub fn build_with_hasher<S>(self, hasher: S) -> SegmentedCache<K, V, S>
+   |            ----------------- required by a bound in this associated function
+   |     where
+   |         S: BuildHasher + Clone + Send + Sync + 'static,
+   |                          ^^^^^ required by this bound in `CacheBuilder::<K, V, SegmentedCache<K, V>>::build_with_hasher`
 help: consider annotating `MyBuildHasher1` with `#[derive(Clone)]`
-    |
-47  | #[derive(Clone)]
+   |
+47  + #[derive(Clone)]
+48  | pub struct MyBuildHasher1;
     |

--- a/tests/compile_tests/future/clone/future_cache_clone.stderr
+++ b/tests/compile_tests/future/clone/future_cache_clone.stderr
@@ -1,33 +1,41 @@
 error[E0277]: the trait bound `MyValue: Clone` is not satisfied
-   --> tests/compile_tests/future/clone/future_cache_clone.rs:19:41
-    |
-19  |     let _cache: Cache<MyKey, MyValue> = Cache::new(CAP);
-    |                                         ^^^^^^^^^^ the trait `Clone` is not implemented for `MyValue`
-    |
+  --> tests/compile_tests/future/clone/future_cache_clone.rs:19:41
+   |
+19 |     let _cache: Cache<MyKey, MyValue> = Cache::new(CAP);
+   |                                         ^^^^^^^^^^ the trait `Clone` is not implemented for `MyValue`
+   |
 note: required by a bound in `moka::future::Cache::<K, V>::new`
-   --> src/future/cache.rs
-    |
-    |     V: Clone + Send + Sync + 'static,
-    |        ^^^^^ required by this bound in `moka::future::Cache::<K, V>::new`
+  --> src/future/cache.rs
+   |
+   |     V: Clone + Send + Sync + 'static,
+   |        ^^^^^ required by this bound in `Cache::<K, V>::new`
+...
+   |     pub fn new(max_capacity: u64) -> Self {
+   |            --- required by a bound in this associated function
 help: consider annotating `MyValue` with `#[derive(Clone)]`
-    |
-42  | #[derive(Clone)]
+   |
+42  + #[derive(Clone)]
+43  | pub struct MyValue(i32);
     |
 
 error[E0277]: the trait bound `MyBuildHasher1: Clone` is not satisfied
-   --> tests/compile_tests/future/clone/future_cache_clone.rs:29:84
-    |
-29  |     let _cache: Cache<MyKey, Arc<MyValue>, _> = Cache::builder().build_with_hasher(MyBuildHasher1);
-    |                                                                  ----------------- ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `MyBuildHasher1`
-    |                                                                  |
-    |                                                                  required by a bound introduced by this call
-    |
+  --> tests/compile_tests/future/clone/future_cache_clone.rs:29:84
+   |
+29 |     let _cache: Cache<MyKey, Arc<MyValue>, _> = Cache::builder().build_with_hasher(MyBuildHasher1);
+   |                                                                  ----------------- ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `MyBuildHasher1`
+   |                                                                  |
+   |                                                                  required by a bound introduced by this call
+   |
 note: required by a bound in `moka::future::CacheBuilder::<K, V, moka::future::Cache<K, V>>::build_with_hasher`
-   --> src/future/builder.rs
-    |
-    |         S: BuildHasher + Clone + Send + Sync + 'static,
-    |                          ^^^^^ required by this bound in `moka::future::CacheBuilder::<K, V, moka::future::Cache<K, V>>::build_with_hasher`
+  --> src/future/builder.rs
+   |
+   |     pub fn build_with_hasher<S>(self, hasher: S) -> Cache<K, V, S>
+   |            ----------------- required by a bound in this associated function
+   |     where
+   |         S: BuildHasher + Clone + Send + Sync + 'static,
+   |                          ^^^^^ required by this bound in `CacheBuilder::<K, V, Cache<K, V>>::build_with_hasher`
 help: consider annotating `MyBuildHasher1` with `#[derive(Clone)]`
-    |
-45  | #[derive(Clone)]
+   |
+45  + #[derive(Clone)]
+46  | pub struct MyBuildHasher1;
     |


### PR DESCRIPTION
* Move to edition 2021, and remove redundant `use` in test
* run tests with `TRYBUILD=overwrite`