### PR TITLE
Prevent timing issues causing inconsistencies between concurrent hash table and policy data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.2
+
+### Fixed
+
+- Prevent timing issues that cause inconsistencies between the cache's internal data
+  structures ([#348][gh-pull-0348]):
+    - e.g. If you insert the same key twice quickly, once when the cache is full and
+      a second time when there is room in the cache, the key may not remain in the
+      cache after the second insertion. However, the `entry_count` method may return
+      a non zero number after calling the `invalidate_all` method.
+
+
 ## Version 0.12.1
 
 ### Fixed
@@ -738,6 +750,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0348]: https://github.com/moka-rs/moka/pull/348/
 [gh-pull-0331]: https://github.com/moka-rs/moka/pull/331/
 [gh-pull-0316]: https://github.com/moka-rs/moka/pull/316/
 [gh-pull-0309]: https://github.com/moka-rs/moka/pull/309/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@
 
 ### Fixed
 
-- Prevent timing issues that cause inconsistencies between the cache's internal data
-  structures ([#348][gh-pull-0348]):
+- Prevent timing issues in writes that cause inconsistencies between the cache's
+  internal data structures ([#348][gh-pull-0348]):
     - One way to trigger the issue is that insert the same key twice quickly, once
       when the cache is full and a second time when there is a room in the cache.
       - When it occurs, the cache will not return the value inserted in the second
         call (which is wrong), and the `entry_count` method will keep returning a non
         zero value after calling the `invalidate_all` method (which is also wrong).
     - These issues were already present in `v0.11.x` and older versions, but less
-      likely to occur because these versions had background threads to periodically
-      process pending tasks.
+      likely to occur because these versions had smaller time windows for the issues
+      to occur by having a background threads to periodically process pending tasks.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,24 @@
 
 - Prevent timing issues that cause inconsistencies between the cache's internal data
   structures ([#348][gh-pull-0348]):
-    - e.g. If you insert the same key twice quickly, once when the cache is full and
-      a second time when there is room in the cache, the key may not remain in the
-      cache after the second insertion. However, the `entry_count` method may return
-      a non zero number after calling the `invalidate_all` method.
-    - With this fix, the key should remain in the cache after the second insertion,
-      and the `entry_count` method should return zero after calling the
+    - Steps to reproduce: Insert the same key twice quickly, once when the cache is
+      full and a second time when there is room in the cache. And then call the
+      `invalidate_all` and `entry_count` methods.
+    - The expected behavior is: (1) the key should exist after the second insertion,
+      and (2) the `entry_count` method should return zero shortly after calling the
       `invalidate_all` method.
-    - These issues were already present in `v0.11.x` and older versions, but were
-      less likely to occur.
+    - The actual behavior was: (1) the key may not exist after the second insertion,
+      and (2) the `entry_count` method may keep returning a non zero number.
+    - These issues were already present in `v0.11.x` and older versions, but less
+      likely to occur because these versions had background threads to periodically
+      process pending tasks.
+
+### Changed
+
+- Updated the Rust edition from 2018 to 2021. ([#339][gh-pull-0339], by
+  [@nyurik][gh-nyurik])
+- Changed to use inline format arguments throughout the code, including examples.
+  ([#340][gh-pull-0340], by [@nyurik][gh-nyurik])
 
 
 ## Version 0.12.1
@@ -728,6 +737,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-LMJW]: https://github.com/LMJW
 [gh-Milo123459]: https://github.com/Milo123459
 [gh-messense]: https://github.com/messense
+[gh-nyurik]: https://github.com/nyurik
 [gh-paolobarbolini]: https://github.com/paolobarbolini
 [gh-peter-scholtens]: https://github.com/peter-scholtens
 [gh-saethlin]: https://github.com/saethlin
@@ -756,6 +766,8 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
 [gh-pull-0348]: https://github.com/moka-rs/moka/pull/348/
+[gh-pull-0340]: https://github.com/moka-rs/moka/pull/340/
+[gh-pull-0339]: https://github.com/moka-rs/moka/pull/339/
 [gh-pull-0331]: https://github.com/moka-rs/moka/pull/331/
 [gh-pull-0316]: https://github.com/moka-rs/moka/pull/316/
 [gh-pull-0309]: https://github.com/moka-rs/moka/pull/309/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,11 @@
 
 - Prevent timing issues that cause inconsistencies between the cache's internal data
   structures ([#348][gh-pull-0348]):
-    - Steps to reproduce: Insert the same key twice quickly, once when the cache is
-      full and a second time when there is room in the cache. And then call the
-      `invalidate_all` and `entry_count` methods.
-    - The expected behavior is: (1) the key should exist after the second insertion,
-      and (2) the `entry_count` method should return zero shortly after calling the
-      `invalidate_all` method.
-    - The actual behavior was: (1) the key may not exist after the second insertion,
-      and (2) the `entry_count` method may keep returning a non zero number.
+    - One way to trigger the issue is that insert the same key twice quickly, once
+      when the cache is full and a second time when there is a room in the cache.
+      - When it occurs, the cache will not return the value inserted in the second
+        call (which is wrong), and the `entry_count` method will keep returning a non
+        zero value after calling the `invalidate_all` method (which is also wrong).
     - These issues were already present in `v0.11.x` and older versions, but less
       likely to occur because these versions had background threads to periodically
       process pending tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
       a second time when there is room in the cache, the key may not remain in the
       cache after the second insertion. However, the `entry_count` method may return
       a non zero number after calling the `invalidate_all` method.
+    - With this fix, the key should remain in the cache after the second insertion,
+      and the `entry_count` method should return zero after calling the
+      `invalidate_all` method.
+    - These issues were already present in `v0.11.x` and older versions, but were
+      less likely to occur.
 
 
 ## Version 0.12.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Migrating to v0.12 from a prior version
 
-v0.12.0 has major breaking changes on the API and internal behavior. This section
+v0.12.0 had major breaking changes on the API and internal behavior. This section
 describes the code changes required to migrate to v0.12.0.
 
 ### Highlights v0.12

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fmoka-rs%2Fmoka?ref=badge_shield)
 
 > **note**
-> `v0.12.0` has major breaking changes on the API and internal behavior. Please read
+> `v0.12.0` had major breaking changes on the API and internal behavior. Please read
 > the [MIGRATION-GUIDE.md][migration-guide-v012] for the details.
 
 * * *
@@ -118,7 +118,7 @@ routers. Here are some highlights:
 ## Recent Changes
 
 > **Note**
-> `v0.12.0` has major breaking changes on the API and internal behavior. Please read
+> `v0.12.0` had major breaking changes on the API and internal behavior. Please read
 > the [MIGRATION-GUIDE.md][migration-guide-v012] for the details.
 
 - [MIGRATION-GUIDE.md][migration-guide-v012]

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,7 +35,6 @@ impl From<usize> for CacheRegion {
     }
 }
 
-#[cfg(feature = "future")]
 impl CacheRegion {
     pub(crate) fn name(self) -> &'static str {
         match self {

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -90,6 +90,10 @@ impl<K> KeyHashDate<K> {
         self.entry_info.last_modified()
     }
 
+    pub(crate) fn last_accessed(&self) -> Option<Instant> {
+        self.entry_info.last_accessed()
+    }
+
     pub(crate) fn is_dirty(&self) -> bool {
         self.entry_info.is_dirty()
     }
@@ -209,10 +213,6 @@ impl<K, V> ValueEntry<K, V> {
 
     pub(crate) fn set_admitted(&self, value: bool) {
         self.info.set_admitted(value);
-    }
-
-    pub(crate) fn is_dirty(&self) -> bool {
-        self.info.is_dirty()
     }
 
     #[inline]

--- a/src/common/concurrent/deques.rs
+++ b/src/common/concurrent/deques.rs
@@ -34,7 +34,6 @@ impl<K> Default for Deques<K> {
 }
 
 impl<K> Deques<K> {
-    #[cfg(feature = "future")]
     pub(crate) fn select_mut(
         &mut self,
         selector: CacheRegion,

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -191,12 +191,12 @@ mod test {
         };
 
         let expected_sizes = match (arch, is_quanta_enabled) {
-            (Linux64, true) => vec![("1.51", 48)],
-            (Linux32, true) => vec![("1.51", 48)],
-            (MacOS64, true) => vec![("1.62", 48)],
-            (Linux64, false) => vec![("1.66", 96), ("1.60", 120)],
-            (Linux32, false) => vec![("1.66", 96), ("1.62", 120), ("1.60", 72)],
-            (MacOS64, false) => vec![("1.62", 96)],
+            (Linux64, true) => vec![("1.51", 56)],
+            (Linux32, true) => vec![("1.51", 56)],
+            (MacOS64, true) => vec![("1.62", 56)],
+            (Linux64, false) => vec![("1.66", 104), ("1.60", 128)],
+            (Linux32, false) => vec![("1.66", 104), ("1.62", 128), ("1.60", 80)],
+            (MacOS64, false) => vec![("1.62", 104)],
         };
 
         let mut expected = None;

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering};
+use std::sync::atomic::{self, AtomicBool, AtomicU16, AtomicU32, Ordering};
 
 use super::{AccessTime, KeyHash};
 use crate::common::{concurrent::atomic_time::AtomicInstant, time::Instant};
@@ -61,7 +61,10 @@ impl<K> EntryInfo<K> {
     /// not yet in the cache policies such as access-order queue.
     #[inline]
     pub(crate) fn is_dirty(&self) -> bool {
-        self.entry_gen.load(Ordering::Acquire) != self.policy_gen.load(Ordering::Acquire)
+        let result =
+            self.entry_gen.load(Ordering::Relaxed) != self.policy_gen.load(Ordering::Relaxed);
+        atomic::fence(Ordering::Acquire);
+        result
     }
 
     #[inline]

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -169,7 +169,9 @@ mod test {
         #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
         enum TargetArch {
             Linux64,
-            Linux32,
+            Linux32X86,
+            Linux32Arm,
+            Linux32Mips,
             MacOS64,
         }
 
@@ -184,9 +186,17 @@ mod test {
             if cfg!(target_pointer_width = "64") {
                 Linux64
             } else if cfg!(target_pointer_width = "32") {
-                Linux32
+                if cfg!(target_arch = "x86") {
+                    Linux32X86
+                } else if cfg!(target_arch = "arm") {
+                    Linux32Arm
+                } else if cfg!(target_arch = "x86") {
+                    Linux32Mips
+                } else {
+                    unimplemented!();
+                }
             } else {
-                panic!("Unsupported pointer width for Linux");
+                unimplemented!();
             }
         } else if cfg!(target_os = "macos") {
             MacOS64
@@ -195,11 +205,13 @@ mod test {
         };
 
         let expected_sizes = match (arch, is_quanta_enabled) {
-            (Linux64, true) => vec![("1.51", 56)],
-            (Linux32, true) => vec![("1.51", 56)],
+            (Linux64 | Linux32Arm, true) => vec![("1.51", 56)],
+            (Linux32X86, true) => vec![("1.51", 48)],
+            (Linux32Mips, true) => unimplemented!(),
             (MacOS64, true) => vec![("1.62", 56)],
             (Linux64, false) => vec![("1.66", 104), ("1.60", 128)],
-            (Linux32, false) => vec![("1.66", 96), ("1.62", 120), ("1.60", 72)],
+            (Linux32X86, false) => unimplemented!(),
+            (Linux32Arm | Linux32Mips, false) => vec![("1.66", 104), ("1.62", 128), ("1.60", 80)],
             (MacOS64, false) => vec![("1.62", 104)],
         };
 

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -14,7 +14,8 @@ pub(crate) struct EntryInfo<K> {
     /// in the concurrent hash table.
     entry_gen: AtomicU16,
     /// `policy_gen` (policy generation) is incremented every time entry's `WriteOpe`
-    /// is applied to the cache policies including the LRU deque and LFU estimator.
+    /// is applied to the cache policies including the access-order queue (the LRU
+    /// deque).
     policy_gen: AtomicU16,
     last_accessed: AtomicInstant,
     last_modified: AtomicInstant,
@@ -77,6 +78,7 @@ impl<K> EntryInfo<K> {
     pub(crate) fn incr_entry_gen(&self) -> u16 {
         // NOTE: This operation wraps around on overflow.
         let prev = self.entry_gen.fetch_add(1, Ordering::AcqRel);
+        // Need to add `1` to the previous value to get the current value.
         prev.wrapping_add(1)
     }
 

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -190,7 +190,7 @@ mod test {
                     Linux32X86
                 } else if cfg!(target_arch = "arm") {
                     Linux32Arm
-                } else if cfg!(target_arch = "x86") {
+                } else if cfg!(target_arch = "mips") {
                     Linux32Mips
                 } else {
                     unimplemented!();

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -13,7 +13,7 @@ pub(crate) struct EntryInfo<K> {
     /// `entry_gen` (entry generation) is incremented every time the entry is updated
     /// in the concurrent hash table.
     entry_gen: AtomicU16,
-    /// `policy_gen` (policy generation) is incremented every time entry's `WriteOpe`
+    /// `policy_gen` (policy generation) is incremented every time entry's `WriteOp`
     /// is applied to the cache policies including the access-order queue (the LRU
     /// deque).
     policy_gen: AtomicU16,
@@ -32,7 +32,8 @@ impl<K> EntryInfo<K> {
         Self {
             key_hash,
             is_admitted: AtomicBool::default(),
-            entry_gen: AtomicU16::new(0),
+            // `entry_gen` starts at 1 and `policy_gen` start at 0.
+            entry_gen: AtomicU16::new(1),
             policy_gen: AtomicU16::new(0),
             last_accessed: AtomicInstant::new(timestamp),
             last_modified: AtomicInstant::new(timestamp),

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -55,6 +55,10 @@ impl<K> EntryInfo<K> {
         self.is_admitted.store(value, Ordering::Release);
     }
 
+    /// Returns `true` if the `ValueEntry` having this `EntryInfo` is dirty.
+    ///
+    /// Dirty means that the entry has been updated in the concurrent hash table but
+    /// not yet in the cache policies such as access-order queue.
     #[inline]
     pub(crate) fn is_dirty(&self) -> bool {
         self.entry_gen.load(Ordering::Acquire) != self.policy_gen.load(Ordering::Acquire)

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -511,12 +511,7 @@ where
             // on_insert
             || {
                 let entry = self.new_value_entry(&key, hash, value.clone(), ts, weight);
-                let ins_op = WriteOp::Upsert {
-                    key_hash: KeyHash::new(Arc::clone(&key), hash),
-                    value_entry: TrioArc::clone(&entry),
-                    old_weight: 0,
-                    new_weight: weight,
-                };
+                let ins_op = WriteOp::new_upsert(&key, hash, &entry, 0, 0, weight);
                 let cnt = op_cnt1.fetch_add(1, Ordering::Relaxed);
                 op1 = Some((cnt, ins_op));
                 entry
@@ -529,13 +524,8 @@ where
                 // that the OldEntryInfo can preserve the old EntryInfo's
                 // last_accessed and last_modified timestamps.
                 let old_info = OldEntryInfo::new(old_entry);
-                let entry = self.new_value_entry_from(value.clone(), ts, weight, old_entry);
-                let upd_op = WriteOp::Upsert {
-                    key_hash: KeyHash::new(Arc::clone(&key), hash),
-                    value_entry: TrioArc::clone(&entry),
-                    old_weight,
-                    new_weight: weight,
-                };
+                let (entry, gen) = self.new_value_entry_from(value.clone(), ts, weight, old_entry);
+                let upd_op = WriteOp::new_upsert(&key, hash, &entry, gen, old_weight, weight);
                 let cnt = op_cnt2.fetch_add(1, Ordering::Relaxed);
                 op2 = Some((cnt, old_info, upd_op));
                 entry
@@ -781,15 +771,15 @@ impl<K, V, S> BaseCache<K, V, S> {
         timestamp: Instant,
         policy_weight: u32,
         other: &ValueEntry<K, V>,
-    ) -> TrioArc<ValueEntry<K, V>> {
+    ) -> (TrioArc<ValueEntry<K, V>>, u16) {
         let info = TrioArc::clone(other.entry_info());
         // To prevent this updated ValueEntry from being evicted by an expiration policy,
-        // set the dirty flag to true. It will be reset to false when the write is applied.
-        info.set_dirty(true);
+        // increment the entry generation.
+        let gen = info.incr_entry_gen();
         info.set_last_accessed(timestamp);
         info.set_last_modified(timestamp);
         info.set_policy_weight(policy_weight);
-        TrioArc::new(ValueEntry::new_from(value, info, other))
+        (TrioArc::new(ValueEntry::new_from(value, info, other)), gen)
     }
 
     fn expire_after_create(
@@ -1623,12 +1613,14 @@ where
                 Ok(Upsert {
                     key_hash: kh,
                     value_entry: entry,
+                    entry_gen: gen,
                     old_weight,
                     new_weight,
                 }) => {
                     self.handle_upsert(
                         kh,
                         entry,
+                        gen,
                         old_weight,
                         new_weight,
                         deqs,
@@ -1651,6 +1643,7 @@ where
         &self,
         kh: KeyHash<K>,
         entry: TrioArc<ValueEntry<K, V>>,
+        gen: u16,
         old_weight: u32,
         new_weight: u32,
         deqs: &mut Deques<K>,
@@ -1660,8 +1653,6 @@ where
     ) where
         V: Clone,
     {
-        entry.set_dirty(false);
-
         {
             let counters = &mut eviction_state.counters;
 
@@ -1672,6 +1663,7 @@ where
                 self.update_timer_wheel(&entry, timer_wheel);
                 deqs.move_to_back_ao(&entry);
                 deqs.move_to_back_wo(&entry);
+                entry.entry_info().set_policy_gen(gen);
                 return;
             }
 
@@ -1679,6 +1671,7 @@ where
                 // There are enough room in the cache (or the cache is unbounded).
                 // Add the candidate to the deques.
                 self.handle_admit(&entry, new_weight, deqs, timer_wheel, counters);
+                entry.entry_info().set_policy_gen(gen);
                 return;
             }
         }
@@ -1695,7 +1688,11 @@ where
                     None
                 };
 
-                let removed = self.cache.remove(kh.hash, |k| k == &kh.key);
+                let removed = self.cache.remove_if(
+                    kh.hash,
+                    |k| k == &kh.key,
+                    |_, entry| entry.entry_info().entry_gen() == gen,
+                );
                 if let Some(entry) = removed {
                     if eviction_state.is_notifier_enabled() {
                         let key = Arc::clone(&kh.key);
@@ -1704,6 +1701,7 @@ where
                             .await;
                     }
                 }
+                entry.entry_info().set_policy_gen(gen);
                 return;
             }
         }
@@ -1733,6 +1731,7 @@ where
                     };
 
                     if let Some((vic_key, vic_entry)) =
+                        // TODO: Check if the entry generation matches.
                         self.cache.remove_entry(vic_hash, |k| k == &vic_key)
                     {
                         if eviction_state.is_notifier_enabled() {
@@ -1775,16 +1774,26 @@ where
                     None
                 };
 
-                // Remove the candidate from the cache (hash map).
+                // Remove the candidate from the cache (hash map) if the entry
+                // generation matches.
                 let key = Arc::clone(&kh.key);
-                self.cache.remove(kh.hash, |k| k == &key);
-                if eviction_state.is_notifier_enabled() {
-                    eviction_state
-                        .add_removed_entry(key, &entry, RemovalCause::Size)
-                        .await;
+                let removed = self.cache.remove_if(
+                    kh.hash,
+                    |k| k == &key,
+                    |_, entry| entry.entry_info().entry_gen() == gen,
+                );
+
+                if let Some(entry) = removed {
+                    if eviction_state.is_notifier_enabled() && entry.entry_info().entry_gen() == gen
+                    {
+                        eviction_state
+                            .add_removed_entry(key, &entry, RemovalCause::Size)
+                            .await;
+                    }
                 }
             }
         }
+        entry.entry_info().set_policy_gen(gen);
     }
 
     /// Performs size-aware admission explained in the paper:
@@ -1837,6 +1846,7 @@ where
                 if let Some(vic_entry) = cache.get(hash, |k| k == key) {
                     victims.add_policy_weight(vic_entry.policy_weight());
                     victims.add_frequency(freq, hash);
+                    // TODO: Record the entry generation too.
                     victim_keys.push(KeyHash::new(Arc::clone(key), hash));
                     retries = 0;
                 } else {

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -964,9 +964,17 @@ impl EntrySizeAndFrequency {
     }
 }
 
+// NOTE: Clippy detected `Admitted` variant contains at least 208 bytes of data and
+// `Rejected` variant contains no data at all. It suggests to box the `SmallVec`.
+//
+// We ignore this suggestion because (1) the `SmallVec` is used for avoiding heap
+// allocation as it will be used in a performance hot spot, and (2) this enum has a
+// very short lifetime and there will only one instance at a time.
+#[allow(clippy::large_enum_variant)]
 enum AdmissionResult<K> {
     Admitted {
-        victim_keys: SmallVec<[KeyHash<K>; 8]>,
+        /// A vec of pairs of KeyHash and entry generation.
+        victim_keys: SmallVec<[(KeyHash<K>, u16); 8]>,
     },
     Rejected,
 }
@@ -1718,9 +1726,9 @@ where
         match admission_result {
             AdmissionResult::Admitted { victim_keys } => {
                 // Try to remove the victims from the hash map.
-                for victim in victim_keys {
-                    let vic_key = victim.key;
-                    let vic_hash = victim.hash;
+                for (vic_kh, vic_gen) in victim_keys {
+                    let vic_key = vic_kh.key;
+                    let vic_hash = vic_kh.hash;
 
                     // Lock the key for removal if blocking removal notification is enabled.
                     let kl = self.maybe_key_lock(&vic_key);
@@ -1730,10 +1738,12 @@ where
                         None
                     };
 
-                    if let Some((vic_key, vic_entry)) =
-                        // TODO: Check if the entry generation matches.
-                        self.cache.remove_entry(vic_hash, |k| k == &vic_key)
-                    {
+                    if let Some((vic_key, vic_entry)) = self.cache.remove_entry_if_and(
+                        vic_hash,
+                        |k| k == &vic_key,
+                        |_, entry| entry.entry_info().entry_gen() == vic_gen,
+                        |k, v| (k.clone(), v.clone()),
+                    ) {
                         if eviction_state.is_notifier_enabled() {
                             eviction_state
                                 .add_removed_entry(vic_key, &vic_entry, RemovalCause::Size)
@@ -1842,12 +1852,12 @@ where
                 let vic_elem = &unsafe { victim.as_ref() }.element;
                 let key = vic_elem.key();
                 let hash = vic_elem.hash();
+                let gen = vic_elem.entry_info().entry_gen();
 
                 if let Some(vic_entry) = cache.get(hash, |k| k == key) {
                     victims.add_policy_weight(vic_entry.policy_weight());
                     victims.add_frequency(freq, hash);
-                    // TODO: Record the entry generation too.
-                    victim_keys.push(KeyHash::new(Arc::clone(key), hash));
+                    victim_keys.push((KeyHash::new(Arc::clone(key), hash), gen));
                     retries = 0;
                 } else {
                     // Could not get the victim from the cache (hash map). Skip this node

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -510,8 +510,8 @@ where
             hash,
             // on_insert
             || {
-                let entry = self.new_value_entry(&key, hash, value.clone(), ts, weight);
-                let ins_op = WriteOp::new_upsert(&key, hash, &entry, 0, 0, weight);
+                let (entry, gen) = self.new_value_entry(&key, hash, value.clone(), ts, weight);
+                let ins_op = WriteOp::new_upsert(&key, hash, &entry, gen, 0, weight);
                 let cnt = op_cnt1.fetch_add(1, Ordering::Relaxed);
                 op1 = Some((cnt, ins_op));
                 entry
@@ -758,10 +758,11 @@ impl<K, V, S> BaseCache<K, V, S> {
         value: V,
         timestamp: Instant,
         policy_weight: u32,
-    ) -> TrioArc<ValueEntry<K, V>> {
+    ) -> (TrioArc<ValueEntry<K, V>>, u16) {
         let key_hash = KeyHash::new(Arc::clone(key), hash);
         let info = TrioArc::new(EntryInfo::new(key_hash, timestamp, policy_weight));
-        TrioArc::new(ValueEntry::new(value, info))
+        let gen: u16 = info.entry_gen();
+        (TrioArc::new(ValueEntry::new(value, info)), gen)
     }
 
     #[inline]
@@ -964,17 +965,18 @@ impl EntrySizeAndFrequency {
     }
 }
 
-// NOTE: Clippy detected `Admitted` variant contains at least 208 bytes of data and
-// `Rejected` variant contains no data at all. It suggests to box the `SmallVec`.
+// NOTE: Clippy found that the `Admitted` variant contains at least a few hundred
+// bytes of data and the `Rejected` variant contains no data at all. It suggested to
+// box the `SmallVec`.
 //
-// We ignore this suggestion because (1) the `SmallVec` is used for avoiding heap
+// We ignore the suggestion because (1) the `SmallVec` is used to avoid heap
 // allocation as it will be used in a performance hot spot, and (2) this enum has a
 // very short lifetime and there will only one instance at a time.
 #[allow(clippy::large_enum_variant)]
 enum AdmissionResult<K> {
     Admitted {
-        /// A vec of pairs of KeyHash and entry generation.
-        victim_keys: SmallVec<[(KeyHash<K>, u16); 8]>,
+        /// A vec of pairs of `KeyHash` and `last_accessed`.
+        victim_keys: SmallVec<[(KeyHash<K>, Option<Instant>); 8]>,
     },
     Rejected,
 }
@@ -1708,7 +1710,10 @@ where
                 let removed = self.cache.remove_if(
                     kh.hash,
                     |k| k == &kh.key,
-                    |_, entry| entry.entry_info().entry_gen() == gen,
+                    |_, current_entry| {
+                        TrioArc::ptr_eq(entry.entry_info(), current_entry.entry_info())
+                            && current_entry.entry_info().entry_gen() == gen
+                    },
                 );
                 if let Some(entry) = removed {
                     if eviction_state.is_notifier_enabled() {
@@ -1735,7 +1740,7 @@ where
         match admission_result {
             AdmissionResult::Admitted { victim_keys } => {
                 // Try to remove the victims from the hash map.
-                for (vic_kh, vic_gen) in victim_keys {
+                for (vic_kh, vic_la) in victim_keys {
                     let vic_key = vic_kh.key;
                     let vic_hash = vic_kh.hash;
 
@@ -1750,7 +1755,7 @@ where
                     if let Some((vic_key, vic_entry)) = self.cache.remove_entry_if_and(
                         vic_hash,
                         |k| k == &vic_key,
-                        |_, entry| entry.entry_info().entry_gen() == vic_gen,
+                        |_, entry| entry.entry_info().last_accessed() == vic_la,
                         |k, v| (k.clone(), v.clone()),
                     ) {
                         if eviction_state.is_notifier_enabled() {
@@ -1801,7 +1806,10 @@ where
                 let removed = self.cache.remove_if(
                     kh.hash,
                     |k| k == &key,
-                    |_, entry| entry.entry_info().entry_gen() == gen,
+                    |_, current_entry| {
+                        TrioArc::ptr_eq(entry.entry_info(), current_entry.entry_info())
+                            && current_entry.entry_info().entry_gen() == gen
+                    },
                 );
 
                 if let Some(entry) = removed {
@@ -1872,12 +1880,12 @@ where
 
             let key = vic_elem.key();
             let hash = vic_elem.hash();
-            let gen = vic_elem.entry_info().entry_gen();
+            let last_accessed = vic_elem.entry_info().last_accessed();
 
             if let Some(vic_entry) = cache.get(hash, |k| k == key) {
                 victims.add_policy_weight(vic_entry.policy_weight());
                 victims.add_frequency(freq, hash);
-                victim_keys.push((KeyHash::new(Arc::clone(key), hash), gen));
+                victim_keys.push((KeyHash::new(Arc::clone(key), hash), last_accessed));
                 retries = 0;
             } else {
                 // Could not get the victim from the cache (hash map). Skip this node

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1874,7 +1874,13 @@ where
                     None
                 };
 
-                let op = WriteOp::Remove(kv.clone());
+                let info = kv.entry.entry_info();
+                let entry_gen = info.incr_entry_gen();
+
+                let op: WriteOp<K, V> = WriteOp::Remove {
+                    kv_entry: kv.clone(),
+                    entry_gen,
+                };
 
                 // Async Cancellation Safety: To ensure the below future should be
                 // executed even if our caller async task is cancelled, we create a

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -3080,9 +3080,9 @@ mod tests {
         // The following `insert` will do the followings:
         // 1. Replaces current "c" (c1) in the concurrent hash table (cht).
         // 2. Runs the pending tasks implicitly.
-        //    (1) c1 will be evicted by size constraint.
-        //    (2) "a" will be admitted.
-        //    (3) "b" will be admitted.
+        //    (1) "a" will be admitted.
+        //    (2) "b" will be admitted.
+        //    (3) c1 will be evicted by size constraint.
         //    (4) "a" will be evicted due to expiration.
         //    (5) "b" will be evicted due to expiration.
         // 3. Send its `WriteOp` log to the channel.

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -3095,7 +3095,7 @@ mod tests {
 
         // The following `run_pending_tasks` will do the followings:
         // 1. Admits "c" (c2) to the cache. (Create a node in the LRU deque)
-        // 2. Because of c-remove, removes c2's deque node from the cache.
+        // 2. Because of c-remove, removes c2's node from the LRU deque.
         cache.run_pending_tasks().await;
         assert_eq!(cache.entry_count(), 0);
     }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -3071,8 +3071,6 @@ mod tests {
             .build();
         let (clock, mock) = Clock::mock();
         cache.set_expiration_clock(Some(clock)).await;
-        // Make the cache exterior immutable.
-        let cache = cache;
 
         cache.insert("a", "alice").await;
         cache.insert("b", "bob").await;

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2751,7 +2751,7 @@ mod tests {
 
         // The following `run_pending_tasks` will do the followings:
         // 1. Admits "c" (c2) to the cache. (Create a node in the LRU deque)
-        // 2. Because of c-remove, removes c2's deque node from the cache.
+        // 2. Because of c-remove, removes c2's node from the LRU deque.
         cache.run_pending_tasks();
         assert_eq!(cache.entry_count(), 0);
     }

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1563,6 +1563,9 @@ where
             Some(kv) => {
                 let now = self.base.current_time_from_expiration_clock();
 
+                let info = kv.entry.entry_info();
+                let entry_gen = info.incr_entry_gen();
+
                 if self.base.is_removal_notifier_enabled() {
                     self.base.notify_invalidate(&kv.key, &kv.entry);
                 }
@@ -1579,7 +1582,10 @@ where
                     None
                 };
 
-                let op = WriteOp::Remove(kv);
+                let op = WriteOp::Remove {
+                    kv_entry: kv,
+                    entry_gen,
+                };
                 let hk = self.base.housekeeper.as_ref();
                 Self::schedule_write_op(
                     self.base.inner.as_ref(),

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2736,9 +2736,9 @@ mod tests {
         // The following `insert` will do the followings:
         // 1. Replaces current "c" (c1) in the concurrent hash table (cht).
         // 2. Runs the pending tasks implicitly.
-        //    (1) c1 will be evicted by size constraint.
-        //    (2) "a" will be admitted.
-        //    (3) "b" will be admitted.
+        //    (1) "a" will be admitted.
+        //    (2) "b" will be admitted.
+        //    (3) c1 will be evicted by size constraint.
         //    (4) "a" will be evicted due to expiration.
         //    (5) "b" will be evicted due to expiration.
         // 3. Send its `WriteOp` log to the channel.

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2727,8 +2727,6 @@ mod tests {
             .build();
         let (clock, mock) = Clock::mock();
         cache.set_expiration_clock(Some(clock));
-        // Make the cache exterior immutable.
-        let cache = cache;
 
         cache.insert("a", "alice");
         cache.insert("b", "bob");

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -2718,6 +2718,46 @@ mod tests {
         expiry_counters.verify();
     }
 
+    // https://github.com/moka-rs/moka/issues/345
+    #[test]
+    fn test_race_between_updating_entry_and_processing_its_write_op() {
+        let cache = Cache::builder()
+            .max_capacity(2)
+            .time_to_idle(Duration::from_secs(1))
+            .build();
+        let (clock, mock) = Clock::mock();
+        cache.set_expiration_clock(Some(clock));
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cathy"); // c1
+        mock.increment(Duration::from_secs(2));
+
+        // The following `insert` will do the followings:
+        // 1. Replaces current "c" (c1) in the concurrent hash table (cht).
+        // 2. Runs the pending tasks implicitly.
+        //    (1) c1 will be evicted by size constraint.
+        //    (2) "a" will be admitted.
+        //    (3) "b" will be admitted.
+        //    (4) "a" will be evicted due to expiration.
+        //    (5) "b" will be evicted due to expiration.
+        // 3. Send its `WriteOp` log to the channel.
+        cache.insert("c", "cindy"); // c2
+
+        // Remove "c" (c2) from the cht.
+        assert_eq!(cache.remove(&"c"), Some("cindy")); // c-remove
+
+        mock.increment(Duration::from_secs(2));
+
+        // The following `run_pending_tasks` will do the followings:
+        // 1. Admits "c" (c2) to the cache. (Create a node in the LRU deque)
+        // 2. Because of c-remove, removes c2's deque node from the cache.
+        cache.run_pending_tasks();
+        assert_eq!(cache.entry_count(), 0);
+    }
+
     #[test]
     fn test_iter() {
         const NUM_KEYS: usize = 50;

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1541,14 +1541,12 @@ where
                     let kl = self.maybe_key_lock(&vic_key);
                     let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-                    if let Some((vic_key, vic_entry)) =
-                        self.cache.remove_entry_if_and(
-                            vic_hash,
-                            |k| k == &vic_key,
-                            |_, entry| entry.entry_info().entry_gen() == vic_gen,
-                            |k, v| (k.clone(), v.clone()),
-                        )
-                    {
+                    if let Some((vic_key, vic_entry)) = self.cache.remove_entry_if_and(
+                        vic_hash,
+                        |k| k == &vic_key,
+                        |_, entry| entry.entry_info().entry_gen() == vic_gen,
+                        |k, v| (k.clone(), v.clone()),
+                    ) {
                         if eviction_state.is_notifier_enabled() {
                             eviction_state.add_removed_entry(
                                 vic_key,

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1456,8 +1456,17 @@ where
                     &freq,
                     eviction_state,
                 ),
-                Ok(Remove(KvEntry { key: _key, entry })) => {
-                    Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
+                Ok(Remove {
+                    kv_entry: KvEntry { key: _key, entry },
+                    entry_gen: gen,
+                }) => {
+                    Self::handle_remove(
+                        deqs,
+                        timer_wheel,
+                        entry,
+                        Some(gen),
+                        &mut eviction_state.counters,
+                    );
                 }
                 Err(_) => break,
             };
@@ -1559,6 +1568,7 @@ where
                             deqs,
                             timer_wheel,
                             vic_entry,
+                            None,
                             &mut eviction_state.counters,
                         );
                     } else {
@@ -1763,17 +1773,19 @@ where
         deqs: &mut Deques<K>,
         timer_wheel: &mut TimerWheel<K>,
         entry: TrioArc<ValueEntry<K, V>>,
+        gen: Option<u16>,
         counters: &mut EvictionCounters,
     ) {
         if let Some(timer_node) = entry.take_timer_node() {
             timer_wheel.deschedule(timer_node);
         }
-        Self::handle_remove_without_timer_wheel(deqs, entry, counters);
+        Self::handle_remove_without_timer_wheel(deqs, entry, gen, counters);
     }
 
     fn handle_remove_without_timer_wheel(
         deqs: &mut Deques<K>,
         entry: TrioArc<ValueEntry<K, V>>,
+        gen: Option<u16>,
         counters: &mut EvictionCounters,
     ) {
         if entry.is_admitted() {
@@ -1784,6 +1796,9 @@ where
             Deques::unlink_wo(&mut deqs.write_order, &entry);
         } else {
             entry.unset_q_nodes();
+        }
+        if let Some(g) = gen {
+            entry.entry_info().set_policy_gen(g);
         }
     }
 
@@ -1868,6 +1883,7 @@ where
                     Self::handle_remove_without_timer_wheel(
                         deqs,
                         entry,
+                        None,
                         &mut eviction_state.counters,
                     );
                 } else {
@@ -1995,7 +2011,9 @@ where
             // The key exists and the entry may have been read or updated by other
             // thread.
             Deques::move_to_back_ao_in_deque(deq_name, deq, &entry);
-            Deques::move_to_back_wo_in_deque(write_order_deq, &entry);
+            if entry.is_dirty() {
+                Deques::move_to_back_wo_in_deque(write_order_deq, &entry);
+            }
         } else {
             // Skip this entry as the key may have been invalidated by other thread.
             // Since the invalidated ValueEntry (which should be still in the write
@@ -2079,7 +2097,7 @@ where
                 if eviction_state.is_notifier_enabled() {
                     eviction_state.add_removed_entry(key, &entry, cause);
                 }
-                Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
+                Self::handle_remove(deqs, timer_wheel, entry, None, &mut eviction_state.counters);
             } else {
                 self.skip_updated_entry_wo(&key, hash, deqs);
             }
@@ -2138,7 +2156,7 @@ where
             invalidator.scan_and_invalidate(self, candidates, is_truncated);
 
         for KvEntry { key: _key, entry } in invalidated {
-            Self::handle_remove(deqs, timer_wheel, entry, &mut eviction_state.counters);
+            Self::handle_remove(deqs, timer_wheel, entry, None, &mut eviction_state.counters);
         }
         if is_done {
             deqs.write_order.reset_cursor();

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1542,7 +1542,6 @@ where
                     let _klg = &kl.as_ref().map(|kl| kl.lock());
 
                     if let Some((vic_key, vic_entry)) =
-                        // TODO: Check if the entry generation matches.
                         self.cache.remove_entry_if_and(
                             vic_hash,
                             |k| k == &vic_key,

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -1590,6 +1590,7 @@ where
                     timer_wheel,
                     &mut eviction_state.counters,
                 );
+                entry.entry_info().set_policy_gen(gen);
             }
             AdmissionResult::Rejected => {
                 // Lock the key for removal if blocking removal notification is enabled.
@@ -1606,13 +1607,13 @@ where
                 );
 
                 if let Some(entry) = removed {
+                    entry.entry_info().set_policy_gen(gen);
                     if eviction_state.is_notifier_enabled() {
                         eviction_state.add_removed_entry(key, &entry, RemovalCause::Size);
                     }
                 }
             }
         };
-        entry.entry_info().set_policy_gen(gen);
     }
 
     /// Performs size-aware admission explained in the paper:
@@ -1651,36 +1652,39 @@ where
         let mut next_victim = deq.peek_front_ptr();
 
         // Aggregate potential victims.
-        while victims.policy_weight < candidate.policy_weight {
-            if candidate.freq < victims.freq {
-                break;
-            }
-            if let Some(victim) = next_victim.take() {
-                next_victim = DeqNode::next_node_ptr(victim);
-
-                let vic_elem = &unsafe { victim.as_ref() }.element;
-                let key = vic_elem.key();
-                let hash = vic_elem.hash();
-                let gen = vic_elem.entry_info().entry_gen();
-
-                if let Some(vic_entry) = cache.get(hash, |k| k == key) {
-                    victims.add_policy_weight(vic_entry.policy_weight());
-                    victims.add_frequency(freq, hash);
-                    victim_keys.push((KeyHash::new(Arc::clone(key), hash), gen));
-                    retries = 0;
-                } else {
-                    // Could not get the victim from the cache (hash map). Skip this node
-                    // as its ValueEntry might have been invalidated.
-                    unsafe { deq.move_to_back(victim) };
-                    retries += 1;
-                }
-            } else {
+        while victims.policy_weight < candidate.policy_weight
+            && victims.freq <= candidate.freq
+            && retries <= MAX_CONSECUTIVE_RETRIES
+        {
+            let Some(victim) = next_victim.take() else {
                 // No more potential victims.
                 break;
+            };
+            next_victim = DeqNode::next_node_ptr(victim);
+
+            let vic_elem = &unsafe { victim.as_ref() }.element;
+            if vic_elem.is_dirty() {
+                // Skip this node as its ValueEntry have been updated or invalidated.
+                unsafe { deq.move_to_back(victim) };
+                retries += 1;
+                continue;
             }
 
-            if retries > MAX_CONSECUTIVE_RETRIES {
-                break;
+            let key = vic_elem.key();
+            let hash = vic_elem.hash();
+            let gen = vic_elem.entry_info().entry_gen();
+
+            if let Some(vic_entry) = cache.get(hash, |k| k == key) {
+                victims.add_policy_weight(vic_entry.policy_weight());
+                victims.add_frequency(freq, hash);
+                victim_keys.push((KeyHash::new(Arc::clone(key), hash), gen));
+                retries = 0;
+            } else {
+                // Could not get the victim from the cache (hash map). Skip this node
+                // as its ValueEntry might have been invalidated (after we checked
+                // `is_dirty` above`).
+                unsafe { deq.move_to_back(victim) };
+                retries += 1;
             }
         }
 


### PR DESCRIPTION
## Descriptions

Fixes #345.

This pull request (PR) prevents timing issues in writes that cause inconsistencies between the cache's internal data structures such as the concurrent hash table and access-order queue.

## Example

The following new test case reproduces this issue in `v0.12.0` and `v0.12.1`:

- [`test_race_between_updating_entry_and_processing_its_write_op`](https://github.com/moka-rs/moka/pull/348/files#diff-338f772312880199137f8bbb508f15dd7f83457565cc983b85043cddd71b2f24)

1. Create a `Cache` with `max_capacity = 2` and `time_to_idle = 1 second`.
2. Insert key `a`.
3. Insert key `b`.
4. Insert key `c`.
    - → When pending tasks are processed (at step 6), `c` will be evicted as the cache is full.
5. Pause for 2 seconds.
    - → When pending tasks are processed (at step 6), `a` and `b` should expire.
6. Insert key `c` again.
    - → The pending tasks up to step 4 should be processed implicitly because more than 0.3 seconds have passed after creating the `Cache`.
7. Remove key `c`.
8. Pause for 2 seconds.
9. Call `run_pending_tasks`.
    - → The pending tasks from step 6 and 7 should be processed.
10. Get the `entry_count`.

### Expected

- At step 7, the value inserted at step 6 should be returned.
- At step 10, `0` should be returned.

## Actual

- At step 7, no value was returned.
- At step 10, `1` was be returned.

## Cause

When processing pending tasks, `Cache` did not check if more than one pending tasks exist for the same key.

In the above example, key `c` had two pending tasks at step 6; first one from step 4 (when cache is full) and second one from step 6 (when cache has enough room).

At step 6, pending tasks up to step 4 should be processed:

1. Write operation log for inserting key `a` is processed:
    - Key `a` is admitted and added to the access-order queue (the LRU deque).
2. Write operation log for inserting key `b` is processed:
    - Key `b` is admitted and added to the LRU.
3. Write operation log for inserting key `c` (at step 4) is processed:
    - It is evicted because the `Cache` is full, and removed from the concurrent hash table (CHT).
    - This removes the key-value of `c` (second insertion at step 6) from the CHT (**wrong**).
5. Key `a` is considered expired:
    - It is removed from both the CHT and LRU.
6. Key `b` is considered expired:
    - It is removed from both the CHT and LRU.

Then, at step 9, pending tasks from step 6 and 7 should be processed:

1. Write operation log for inserting key `c`  (at step 6) is processed:
    - Key `"c"` is admitted and added to the LRU.
    - (But there is no key-value for `c` in the CHT)
2. There is no write operation log for removing key `c` (at step 7).
    - This is because key-value for `c` did not exist at step 7.
3. Key `c` is considered expired:
    - Key `c` is supposed to be removed from both the CHT and LRU, but it will not be, because it does not exist in the CHT.

This issue was already present in `v0.11.x` and older versions, but were less likely to occur because the window for the timings was much smaller than `v0.12.0` and `v0.12.1` because these older versions used background threads to periodically process pending tasks.

## Fixes

When processing write operation logs in pending tasks, check if more than one logs exist for the same key:

- To achieve it, add two `u16` counters to each key in the CHT to track the following generations (versions):
    - `entry_gen`: Will be incremented on every insertion, update and removal of the key.
        - The write operation log carries the `entry_gen` after the increment.
    - `policy_gen`: Will be updated on every time the write operation log is processed for the key.
- When processing a write operation log, check if the `entry_gen` in the log equals to the current `entry_gen` of the key.
    - If yes, and the key is not admitted, remove the key from the CHT.
    - If no, and the key is not admitted, do nothing for the key. (This solves the problem in the above example)

After processing write operation logs, `Cache` will process other pending tasks such as evicting expired entries. This PR also incudes various small improvements in these steps by checking if each key still has pending write operation logs. This is done by calling `is_dirty` method, which returns `true` when `entry_gen != policy_gen`.

### Checklist

Add check if `entry_gen` in the write operation log equals to the current `entry_gen` of the key:

- `future::base_cache::Internal` struct
    - [x] `handle_upsert` method
- `sync::base_cache::Internal` struct 
    - [x] `handle_upsert` method

Add `is_dirty` checks to the following internal methods:

- `future::base_cache::Internal` struct
    - [x] `evict_expired_entries_using_timers` method
    - [x] `remove_expired_ao` method
    - [x] `remove_expired_wo` method
    - [x] `invalidate_entries` method
    - [x] `evict_lru_entries` method
- `sync::base_cache::Internal` struct 
    - [x] `handle_upsert` method
    - [x] `evict_expired_entries_using_timers` method
    - [x] `remove_expired_ao` method
    - [x] `remove_expired_wo` method
    - [x] `invalidate_entries` method
    - [x] `evict_lru_entries` method
