### PR TITLE
Fix the CI with minimal crate versions. (moka v0.12.x)

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the MSRV.
+# cargo update -p <crate> --precise <version>

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the nightly toolchain.
+cargo update -p proc-macro2 --precise 1.0.60

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,15 +61,11 @@ jobs:
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
-        run: |
-          cargo update -p openssl --precise 0.10.39
-          cargo update -p cc --precise 1.0.61
-          cargo update -p proc-macro2 --precise 1.0.60
+        run: ./.ci_extras/pin-crate-vers-nightly.sh
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.65.0' }}
-      #   run: |
-      #     cargo update -p <crate> --precise <version>
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.65.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Show cargo tree
         uses: actions-rs/cargo@v1

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -54,15 +54,11 @@ jobs:
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
-        run: |
-          cargo update -p openssl --precise 0.10.39
-          cargo update -p cc --precise 1.0.61
-          cargo update -p proc-macro2 --precise 1.0.60
+        run: ./.ci_extras/pin-crate-vers-nightly.sh
 
-      # - name: Pin some dependencies to specific versions (MSRV only)
-      #   if: ${{ matrix.rust == '1.65.0' }}
-      #   run: |
-      #     cargo update -p <crate> --precise <version>
+      - name: Pin some dependencies to specific versions (MSRV only)
+        if: ${{ matrix.rust == '1.65.0' }}
+        run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Run tests (debug, but no quanta feature)
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,11 @@ log = { version = "0.4", optional = true }
 actix-rt = "2.8"
 ahash = "0.8.3"
 anyhow = "1.0.19"
-async-std = { version = "1.11", features = ["attributes"] }
+async-std = { version = "1.12", features = ["attributes"] }
 env_logger = "0.10.0"
 getrandom = "0.2"
 paste = "1.0.9"
-reqwest = "0.11.11"
+reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls"] }
 skeptic = "0.13"
 tokio = { version = "1.19", features = ["fs", "macros", "rt-multi-thread", "sync", "time" ] }
 


### PR DESCRIPTION
Change the following dev dependencies:

- Raise the minimal `async-std` version from 1.1 to 1.2.
- Use `rustls` in `reqwest` instead of `native-tls` (openssl on Linux).