### PR TITLE
Fix the CI with minimal crate versions. (moka v0.12.x)

### DIFF
--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -3,4 +3,4 @@
 set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain.
-cargo update -p proc-macro2 --precise 1.0.60
+cargo update -p proc-macro2 --precise 1.0.63

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -19,6 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         rust:
           - stable


### PR DESCRIPTION
- Change the following dev dependencies:
    - Change proc-macro2 from v1.0.60 to v1.0.63.
- Disable fail-fast feature on CI and CIQuantaDisabled workflows