### PR TITLE
Update the access time of a cached entry immediately after the entry is read

### DIFF
--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -303,7 +303,6 @@ impl<K, V> AccessTime for TrioArc<ValueEntry<K, V>> {
 pub(crate) enum ReadOp<K, V> {
     Hit {
         value_entry: TrioArc<ValueEntry<K, V>>,
-        timestamp: Instant,
         is_expiry_modified: bool,
     },
     // u64 is the hash of the key.

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -323,12 +323,13 @@ where
                         );
                     }
 
+                    entry.set_last_accessed(now);
+
                     let maybe_key = if need_key { Some(Arc::clone(k)) } else { None };
                     let ent = Entry::new(maybe_key, entry.value.clone(), false);
                     let maybe_op = if record_read {
                         Some(ReadOp::Hit {
                             value_entry: TrioArc::clone(entry),
-                            timestamp: now,
                             is_expiry_modified,
                         })
                     } else {
@@ -1586,12 +1587,10 @@ where
             match ch.try_recv() {
                 Ok(Hit {
                     value_entry,
-                    timestamp,
                     is_expiry_modified,
                 }) => {
                     let kh = value_entry.entry_info().key_hash();
                     freq.increment(kh.hash);
-                    value_entry.set_last_accessed(timestamp);
                     if is_expiry_modified {
                         self.update_timer_wheel(&value_entry, timer_wheel);
                     }

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -349,10 +349,11 @@ where
                 );
             }
 
+            entry.set_last_accessed(now);
+
             let v = entry.value.clone();
             let op = ReadOp::Hit {
                 value_entry: entry,
-                timestamp: now,
                 is_expiry_modified,
             };
             read_recorder(op, now);
@@ -1407,12 +1408,10 @@ where
             match ch.try_recv() {
                 Ok(Hit {
                     value_entry,
-                    timestamp,
                     is_expiry_modified,
                 }) => {
                     let kh = value_entry.entry_info().key_hash();
                     freq.increment(kh.hash);
-                    value_entry.set_last_accessed(timestamp);
                     if is_expiry_modified {
                         self.update_timer_wheel(&value_entry, timer_wheel);
                     }


### PR DESCRIPTION
Fixes #359.

~~(We will merge this into the `main` branch after #348 is merged)~~

## Problem

When a cached entry is read (by e.g. the `get` method) or write (by e.g. the `insert` method), the `last_accessed` time of the entry is updated. When `time_to_idle` of the `Cache` is set, the `last_accessed` time is used to determine whether the entry is expired or not.

Up to Moka `v0.12.1`, `last_accessed` time was _eventual consistent_ for read operations. So it will not be updated immediately after read, but will be updated sometime later when pending tasks are processed. (Note: It will be updated to the time when read was performed, not to the time when pending task is processed). This was designed so to achieve better throughput as updating `last_accessed` has a small performance overhead from a synchronous primitive such as `AtomicU64` when the default features are enabled, and `Mutex` when the `atomic64` or `quanta` feature is disabled. 

Note that `last_accessed` time is _strong consistent_ for write operations, and it is updated during the write.

Before `v0.12.0`, pending tasks were processed periodically (every ~0.3 secs) by a background thread, so the delay after read was not obvious. However we removed the background thread completely from `v0.12.0`, and the delay becomes obvious.

## Fix

Like the write operations, make `last_accessed` strong consistent for read operations.