### PR TITLE
Reduce the TTL from 3 secs to 2.5 secs in the cascading drop example

### DIFF
--- a/examples/cascading_drop_async.rs
+++ b/examples/cascading_drop_async.rs
@@ -38,8 +38,7 @@ pub struct Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        let user_id;
-        user_id = self.ptr.as_ref().unwrap().lock().unwrap().user_id;
+        let user_id = self.ptr.as_ref().unwrap().lock().unwrap().user_id;
         println!("Dropping session holding a reference to user {}", user_id);
         self.ptr = None; // Must drop Arc before verify Btree!!!
         let _ = self.sender.send(user_id);


### PR DESCRIPTION
As we discussed in https://github.com/moka-rs/moka/pull/350#issuecomment-1870995237, we will reduce the TTL value in the example from 3 secs to 2.5 secs.

Also this fixes a Clippy warning from a recent beta Clippy `0.1.75 (1a06ac5b5d7 2023-12-01)`.

* * *
CC: @peter-scholtens