### PR TITLE
Fix the CI for the MSRV 1.65.0. (Moka v0.12.x)

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -3,4 +3,4 @@
 set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
-# cargo update -p <crate> --precise <version>
+cargo update -p cargo-platform --precise 0.1.5


### PR DESCRIPTION
Pin the version of `cargo-platform` to v0.1.5.