### PR TITLE
Add the upsert and compute methods for modifying a cached entry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -64,6 +64,7 @@
         "Uninit",
         "unsync",
         "Upsert",
+        "upserted",
         "usize"
     ],
     "files.watcherExclude": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.3
+
+### Added
+
+- Added the upsert and compute methods for modifying a cached entry
+  ([#370][gh-pull-0370]):
+    - Now the `entry` or `entry_by_ref` APIs have the following methods:
+        - `and_upsert_with` method to insert or update the entry.
+        - `and_compute_with` method to insert, update, remove or do nothing on the
+          entry.
+        - `and_try_compute_with` method, which is similar to above but returns
+          `Result`.
+
+
 ## Version 0.12.2
 
 ### Fixed
@@ -781,6 +795,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0370]: https://github.com/moka-rs/moka/pull/370/
 [gh-pull-0363]: https://github.com/moka-rs/moka/pull/363/
 [gh-pull-0350]: https://github.com/moka-rs/moka/pull/350/
 [gh-pull-0348]: https://github.com/moka-rs/moka/pull/348/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ getrandom = "0.2"
 paste = "1.0.9"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls"] }
 skeptic = "0.13"
-tokio = { version = "1.19", features = ["fs", "macros", "rt-multi-thread", "sync", "time" ] }
+tokio = { version = "1.19", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time" ] }
 
 [target.'cfg(trybuild)'.dev-dependencies]
 trybuild = "1.0"
@@ -137,3 +137,7 @@ required-features = ["sync"]
 [[example]]
 name = "size_aware_eviction_sync"
 required-features = ["sync"]
+
+[[example]]
+name = "try_append_value_async"
+required-features = ["future"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,10 @@ name = "append_value_async"
 required-features = ["future"]
 
 [[example]]
+name = "append_value_sync"
+required-features = ["sync"]
+
+[[example]]
 name = "basics_async"
 required-features = ["future"]
 
@@ -123,12 +127,20 @@ name = "bounded_counter_async"
 required-features = ["future"]
 
 [[example]]
+name = "bounded_counter_sync"
+required-features = ["sync"]
+
+[[example]]
 name = "cascading_drop_async"
 required-features = ["future"]
 
 [[example]]
 name = "counter_async"
 required-features = ["future"]
+
+[[example]]
+name = "counter_sync"
+required-features = ["sync"]
 
 [[example]]
 name = "eviction_listener_sync"
@@ -141,3 +153,7 @@ required-features = ["sync"]
 [[example]]
 name = "try_append_value_async"
 required-features = ["future"]
+
+[[example]]
+name = "try_append_value_sync"
+required-features = ["sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Examples
 
 [[example]]
+name = "append_value_async"
+required-features = ["future"]
+
+[[example]]
 name = "basics_async"
 required-features = ["future"]
 
@@ -116,6 +120,10 @@ required-features = ["sync"]
 
 [[example]]
 name = "cascading_drop_async"
+required-features = ["future"]
+
+[[example]]
+name = "counter_async"
 required-features = ["future"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ name = "basics_sync"
 required-features = ["sync"]
 
 [[example]]
+name = "bounded_counter_async"
+required-features = ["future"]
+
+[[example]]
 name = "cascading_drop_async"
 required-features = ["future"]
 

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ $ cargo +nightly -Z unstable-options --config 'build.rustdocflags="--cfg docsrs"
     doc --no-deps --features 'future, sync'
 ```
 
-## Road Map
+## Roadmap
 
 - [x] Size-aware eviction. (`v0.7.0` via [#24][gh-pull-024])
 - [x] API stabilization. (Smaller core API, shorter names for frequently used

--- a/README.md
+++ b/README.md
@@ -517,21 +517,20 @@ $ cargo +nightly -Z unstable-options --config 'build.rustdocflags="--cfg docsrs"
 ## Road Map
 
 - [x] Size-aware eviction. (`v0.7.0` via [#24][gh-pull-024])
-- [x] API stabilization. (Smaller core cache API, shorter names for frequently
-      used methods) (`v0.8.0` via [#105][gh-pull-105])
+- [x] API stabilization. (Smaller core API, shorter names for frequently used
+       methods) (`v0.8.0` via [#105][gh-pull-105])
     - e.g.
     - `get_or_insert_with(K, F)` → `get_with(K, F)`
     - `get_or_try_insert_with(K, F)` → `try_get_with(K, F)`
-    - `blocking_insert(K, V)` → `blocking().insert(K, V)`
     - `time_to_live()` → `policy().time_to_live()`
 - [x] Notifications on eviction. (`v0.9.0` via [#145][gh-pull-145])
 - [x] Variable (per-entry) expiration, using hierarchical timer wheels.
   (`v0.11.0` via [#248][gh-pull-248])
-- [ ] Cache statistics (Hit rate, etc.). ([details][cache-stats])
 - [x] Remove background threads. (`v0.12.0` via [#294][gh-pull-294] and
   [#316][gh-pull-316])
+- [x] Add upsert and compute methods. (`v0.12.3` via [#370][gh-pull-370])
+- [ ] Cache statistics (Hit rate, etc.). ([details][cache-stats])
 - [ ] Restore cache from a snapshot. ([details][restore])
-- [ ] `and_compute` method. ([details][and-compute])
 - [ ] Upgrade TinyLFU to Window-TinyLFU. ([details][tiny-lfu])
 
 [gh-pull-024]: https://github.com/moka-rs/moka/pull/24
@@ -540,8 +539,8 @@ $ cargo +nightly -Z unstable-options --config 'build.rustdocflags="--cfg docsrs"
 [gh-pull-248]: https://github.com/moka-rs/moka/pull/248
 [gh-pull-294]: https://github.com/moka-rs/moka/pull/294
 [gh-pull-316]: https://github.com/moka-rs/moka/pull/316
+[gh-pull-370]: https://github.com/moka-rs/moka/pull/370
 
-[and-compute]: https://github.com/moka-rs/moka/issues/227
 [cache-stats]: https://github.com/moka-rs/moka/issues/234
 [restore]: https://github.com/moka-rs/moka/issues/314
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,29 +13,54 @@ Each example has a suffix `_async` or `_sync`:
 ## Basics of the Cache API
 
 - [basics_async](./basics_async.rs) and [basics_sync](./basics_sync.rs)
-    - Sharing a cache between async tasks or OS threads.
+    - Shares a cache between async tasks or OS threads.
         - Do not wrap a `Cache` with `Arc<Mutex<_>>`! Just clone the `Cache` and you
           are all set.
-    - `insert`, `get` and `invalidate` methods.
+    - Uses `insert`, `get` and `invalidate` methods.
 
 - [size_aware_eviction_sync](./size_aware_eviction_sync.rs)
-    - Configuring the max capacity of the cache based on the total size of the cached
+    - Configures the max capacity of the cache based on the total size of the cached
       entries.
+
+## The `Entry` API
+
+Atomically inserts, updates and removes an entry from the cache depending on the
+existence of the entry.
+
+- [counter_async](./counter_async.rs) and [counter_sync](./counter_sync.rs)
+    - Atomically increments a cached `u64` by 1. If the entry does not exist, inserts
+      a new entry with the value 1.
+    - Uses `and_upsert_with` method.
+- [bounded_counter_async](./bounded_counter_async.rs) and
+  [bounded_counter_sync](./bounded_counter_sync.rs)
+    - Same as above except removing the entry when the value is 2.
+    - `and_compute_with` method.
+- [append_value_async](./append_value_async.rs) and
+  [append_value_sync](./append_value_sync.rs)
+    - Atomically appends an `i32` to a cached `Arc<RwLock<Vec<i32>>>`. If the entry
+      does not exist, inserts a new entry.
+    - Uses `and_upsert_with` method.
+- [try_append_value_async](./try_append_value_async.rs) and
+  [try_append_value_sync](./try_append_value_sync.rs)
+    - Atomically reads an `char` from a reader and appends it to a cached `Arc<RwLock<String>>`,
+      but reading may fail by an early EOF.
+    - Uses `and_try_compute_with` method.
 
 ## Expiration and Eviction Listener
 
 - [eviction_listener_sync](./eviction_listener_sync.rs)
-    - Setting the `time_to_live` expiration policy.
-    - Registering a listener (closure) to be notified when an entry is evicted from
-      the cache.
-    - `insert`, `invalidate` and `invalidate_all` methods.
-    - Demonstrating when the expired entries will be actually evicted from the cache,
+    - Configures the `time_to_live` expiration policy.
+    - Registers a listener (closure) to be notified when an entry is evicted from the
+      cache.
+    - Uses `insert`, `invalidate`, `invalidate_all` and `run_pending_tasks` methods.
+    - Demonstrates when the expired entries will be actually evicted from the cache,
       and why the `run_pending_tasks` method could be important in some cases.
 
 - [cascading_drop_async](./cascading_drop_async.rs)
-    - Controlling the lifetime of the objects in a separate `BTreeMap` collection
-      from the cache using an eviction listener.
-    - `BTreeMap`, `Arc` and mpsc channel (multi-producer, single consumer channel).
+    - Controls the lifetime of the objects in a separate `BTreeMap` collection from
+      the cache using an eviction listener.
+    - Beside the cache APIs, uses `BTreeMap`, `Arc` and mpsc channel (multi-producer,
+      single consumer channel).
 
 ## Check out the API Documentation too!
 

--- a/examples/append_value_async.rs
+++ b/examples/append_value_async.rs
@@ -27,18 +27,20 @@ async fn main() {
     let key = "key".to_string();
 
     let entry = append_to_cached_vec(&cache, &key, 1).await;
+    // It was not an update.
+    assert!(!entry.is_old_value_replaced());
     assert!(entry.is_fresh());
-    assert!(!entry.is_updated());
     assert_eq!(*entry.into_value().read().await, &[1]);
 
     let entry = append_to_cached_vec(&cache, &key, 2).await;
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    // It was an update.
+    assert!(entry.is_old_value_replaced());
     assert_eq!(*entry.into_value().read().await, &[1, 2]);
 
     let entry = append_to_cached_vec(&cache, &key, 3).await;
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(*entry.into_value().read().await, &[1, 2, 3]);
 }
 

--- a/examples/append_value_async.rs
+++ b/examples/append_value_async.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use moka::{future::Cache, Entry};
+use tokio::sync::RwLock;
+
+/// This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
+/// value. It uses the `and_upsert_with` method of `Cache`.
+#[tokio::main]
+async fn main() {
+    // We want to store a raw value `Vec<i32>` for each `String` key. We are going to
+    // append `i32` values to the `Vec` in the cache.
+    //
+    // Note that we have to wrap the `Vec` in an `Arc<RwLock<_>>`. We need the `Arc`,
+    // an atomic reference counted shared pointer, because `and_upsert_with` method
+    // of `Cache` passes a _clone_ of the value to our closure, instead of passing a
+    // `&mut` reference. We do not want to clone the `Vec` every time we append a
+    // value to it, so we wrap it in an `Arc`. Then we need the `RwLock` because we
+    // mutate the `Vec` when we append a value to it.
+    //
+    // The reason that `and_upsert_with` cannot pass a `&mut Vec<_>` to the closure
+    // is because the internal concurrent hash table of `Cache` is a lock free data
+    // structure and does not use any mutexes. So it cannot guarantee: (1) the `&mut
+    // Vec<_>` is unique, and (2) it is not accessed concurrently by other threads.
+    let cache: Cache<String, Arc<RwLock<Vec<i32>>>> = Cache::new(100);
+
+    let key = "key".to_string();
+
+    let entry = append_to_cached_vec(&cache, &key, 1).await;
+    // assert_eq!(performed_op, PerformedOp::Inserted);
+    assert_eq!(*entry.into_value().read().await, &[1]);
+
+    let entry = append_to_cached_vec(&cache, &key, 2).await;
+    // assert_eq!(performed_op, PerformedOp::Updated);
+    assert_eq!(*entry.into_value().read().await, &[1, 2]);
+
+    let entry = append_to_cached_vec(&cache, &key, 3).await;
+    assert_eq!(*entry.into_value().read().await, &[1, 2, 3]);
+}
+
+async fn append_to_cached_vec(
+    cache: &Cache<String, Arc<RwLock<Vec<i32>>>>,
+    key: &str,
+    value: i32,
+) -> Entry<String, Arc<RwLock<Vec<i32>>>> {
+    cache
+        .entry_by_ref(key)
+        .and_upsert_with(|maybe_entry| async {
+            if let Some(entry) = maybe_entry {
+                // The entry exists, append the value to the Vec.
+                let v = entry.into_value();
+                v.write().await.push(value);
+                v
+            } else {
+                // The entry does not exist, insert a new Vec containing
+                // the value.
+                Arc::new(RwLock::new(vec![value]))
+            }
+        })
+        .await
+}

--- a/examples/append_value_async.rs
+++ b/examples/append_value_async.rs
@@ -26,14 +26,18 @@ async fn main() {
     let key = "key".to_string();
 
     let entry = append_to_cached_vec(&cache, &key, 1).await;
-    // assert_eq!(performed_op, PerformedOp::Inserted);
+    assert!(entry.is_fresh());
+    assert!(!entry.is_updated());
     assert_eq!(*entry.into_value().read().await, &[1]);
 
     let entry = append_to_cached_vec(&cache, &key, 2).await;
-    // assert_eq!(performed_op, PerformedOp::Updated);
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
     assert_eq!(*entry.into_value().read().await, &[1, 2]);
 
     let entry = append_to_cached_vec(&cache, &key, 3).await;
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
     assert_eq!(*entry.into_value().read().await, &[1, 2, 3]);
 }
 

--- a/examples/append_value_async.rs
+++ b/examples/append_value_async.rs
@@ -1,10 +1,11 @@
+//! This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
+//! value. It uses the `and_upsert_with` method of `Cache`.
+
 use std::sync::Arc;
 
 use moka::{future::Cache, Entry};
 use tokio::sync::RwLock;
 
-/// This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
-/// value. It uses the `and_upsert_with` method of `Cache`.
 #[tokio::main]
 async fn main() {
     // We want to store a raw value `Vec<i32>` for each `String` key. We are going to

--- a/examples/append_value_sync.rs
+++ b/examples/append_value_sync.rs
@@ -26,17 +26,17 @@ fn main() {
 
     let entry = append_to_cached_vec(&cache, &key, 1);
     assert!(entry.is_fresh());
-    assert!(!entry.is_updated());
+    assert!(!entry.is_old_value_replaced());
     assert_eq!(*entry.into_value().read().unwrap(), &[1]);
 
     let entry = append_to_cached_vec(&cache, &key, 2);
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(*entry.into_value().read().unwrap(), &[1, 2]);
 
     let entry = append_to_cached_vec(&cache, &key, 3);
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(*entry.into_value().read().unwrap(), &[1, 2, 3]);
 }
 

--- a/examples/append_value_sync.rs
+++ b/examples/append_value_sync.rs
@@ -1,0 +1,60 @@
+//! This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
+//! value. It uses the `and_upsert_with` method of `Cache`.
+
+use std::sync::{Arc, RwLock};
+
+use moka::{sync::Cache, Entry};
+
+fn main() {
+    // We want to store a raw value `Vec<i32>` for each `String` key. We are going to
+    // append `i32` values to the `Vec` in the cache.
+    //
+    // Note that we have to wrap the `Vec` in an `Arc<RwLock<_>>`. We need the `Arc`,
+    // an atomic reference counted shared pointer, because `and_upsert_with` method
+    // of `Cache` passes a _clone_ of the value to our closure, instead of passing a
+    // `&mut` reference. We do not want to clone the `Vec` every time we append a
+    // value to it, so we wrap it in an `Arc`. Then we need the `RwLock` because we
+    // mutate the `Vec` when we append a value to it.
+    //
+    // The reason that `and_upsert_with` cannot pass a `&mut Vec<_>` to the closure
+    // is because the internal concurrent hash table of `Cache` is a lock free data
+    // structure and does not use any mutexes. So it cannot guarantee: (1) the `&mut
+    // Vec<_>` is unique, and (2) it is not accessed concurrently by other threads.
+    let cache: Cache<String, Arc<RwLock<Vec<i32>>>> = Cache::new(100);
+
+    let key = "key".to_string();
+
+    let entry = append_to_cached_vec(&cache, &key, 1);
+    assert!(entry.is_fresh());
+    assert!(!entry.is_updated());
+    assert_eq!(*entry.into_value().read().unwrap(), &[1]);
+
+    let entry = append_to_cached_vec(&cache, &key, 2);
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
+    assert_eq!(*entry.into_value().read().unwrap(), &[1, 2]);
+
+    let entry = append_to_cached_vec(&cache, &key, 3);
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
+    assert_eq!(*entry.into_value().read().unwrap(), &[1, 2, 3]);
+}
+
+fn append_to_cached_vec(
+    cache: &Cache<String, Arc<RwLock<Vec<i32>>>>,
+    key: &str,
+    value: i32,
+) -> Entry<String, Arc<RwLock<Vec<i32>>>> {
+    cache.entry_by_ref(key).and_upsert_with(|maybe_entry| {
+        if let Some(entry) = maybe_entry {
+            // The entry exists, append the value to the Vec.
+            let v = entry.into_value();
+            v.write().unwrap().push(value);
+            v
+        } else {
+            // The entry does not exist, insert a new Vec containing
+            // the value.
+            Arc::new(RwLock::new(vec![value]))
+        }
+    })
+}

--- a/examples/bounded_counter_async.rs
+++ b/examples/bounded_counter_async.rs
@@ -1,5 +1,5 @@
 //! This example demonstrates how to increment a cached `u64` counter. It uses the
-//! `and_upsert_with` method of `Cache`.
+//! `and_compute_with` method of `Cache`.
 
 use moka::{
     future::Cache,

--- a/examples/bounded_counter_async.rs
+++ b/examples/bounded_counter_async.rs
@@ -1,0 +1,79 @@
+use moka::{
+    future::Cache,
+    ops::compute::{self, PerformedOp},
+    Entry,
+};
+
+/// This example demonstrates how to increment a cached `u64` counter. It uses the
+/// `and_upsert_with` method of `Cache`.
+#[tokio::main]
+async fn main() {
+    let cache: Cache<String, u64> = Cache::new(100);
+    let key = "key".to_string();
+
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    assert_eq!(performed_op, PerformedOp::Inserted);
+
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert!(entry.is_fresh());
+    assert!(!entry.is_updated());
+    assert_eq!(entry.into_value(), 1);
+
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    assert_eq!(performed_op, PerformedOp::Updated);
+
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
+    assert_eq!(entry.into_value(), 2);
+
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    assert_eq!(performed_op, PerformedOp::Removed);
+
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert!(!entry.is_fresh());
+    assert!(!entry.is_updated());
+    assert_eq!(entry.into_value(), 2);
+
+    assert!(!cache.contains_key(&key));
+
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    assert_eq!(performed_op, PerformedOp::Inserted);
+
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert!(entry.is_fresh());
+    assert!(!entry.is_updated());
+    assert_eq!(entry.into_value(), 1);
+}
+
+/// Increment a cached `u64` counter. If the counter is greater than or equal to 2,
+/// remove it.
+async fn inclement_or_remove_counter(
+    cache: &Cache<String, u64>,
+    key: &str,
+) -> (Option<Entry<String, u64>>, compute::PerformedOp) {
+    // - If the counter does not exist, insert a new value of 1.
+    // - If the counter is less than 2, increment it by 1.
+    // - If the counter is greater than or equal to 2, remove it.
+    cache
+        .entry_by_ref(key)
+        .and_compute_with(|maybe_entry| {
+            let op = if let Some(entry) = maybe_entry {
+                // The entry exists.
+                let counter = entry.into_value();
+                if counter < 2 {
+                    // Increment the counter by 1.
+                    compute::Op::Put(counter.saturating_add(1))
+                } else {
+                    // Remove the entry.
+                    compute::Op::Remove
+                }
+            } else {
+                // The entry does not exist, insert a new value of 1.
+                compute::Op::Put(1)
+            };
+            // Return a Future that is resolved to `op` immediately.
+            std::future::ready(op)
+        })
+        .await
+}

--- a/examples/bounded_counter_sync.rs
+++ b/examples/bounded_counter_sync.rs
@@ -1,0 +1,71 @@
+//! This example demonstrates how to increment a cached `u64` counter. It uses the
+//! `and_compute_with` method of `Cache`.
+
+use moka::{
+    ops::compute::{self, PerformedOp},
+    sync::Cache,
+    Entry,
+};
+
+fn main() {
+    let cache: Cache<String, u64> = Cache::new(100);
+    let key = "key".to_string();
+
+    // This should insert a now counter value 1 to the cache, and return the value
+    // with the kind of the operation performed.
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(entry.into_value(), 1);
+    assert_eq!(performed_op, PerformedOp::Inserted);
+
+    // This should increment the cached counter value by 1.
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(entry.into_value(), 2);
+    assert_eq!(performed_op, PerformedOp::Updated);
+
+    // This should remove the cached counter from the cache, and returns the
+    // _removed_ value.
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(entry.into_value(), 2);
+    assert_eq!(performed_op, PerformedOp::Removed);
+
+    // The key should no longer exist.
+    assert!(!cache.contains_key(&key));
+
+    // This should start over; insert a new counter value 1 to the cache.
+    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(entry.into_value(), 1);
+    assert_eq!(performed_op, PerformedOp::Inserted);
+}
+
+/// Increment a cached `u64` counter. If the counter is greater than or equal to 2,
+/// remove it.
+///
+/// This method uses cache's `and_compute_with` method.
+fn inclement_or_remove_counter(
+    cache: &Cache<String, u64>,
+    key: &str,
+) -> (Option<Entry<String, u64>>, compute::PerformedOp) {
+    // - If the counter does not exist, insert a new value of 1.
+    // - If the counter is less than 2, increment it by 1.
+    // - If the counter is greater than or equal to 2, remove it.
+    cache.entry_by_ref(key).and_compute_with(|maybe_entry| {
+        if let Some(entry) = maybe_entry {
+            // The entry exists.
+            let counter = entry.into_value();
+            if counter < 2 {
+                // Increment the counter by 1.
+                compute::Op::Put(counter.saturating_add(1))
+            } else {
+                // Remove the entry.
+                compute::Op::Remove
+            }
+        } else {
+            // The entry does not exist, insert a new value of 1.
+            compute::Op::Put(1)
+        }
+    })
+}

--- a/examples/bounded_counter_sync.rs
+++ b/examples/bounded_counter_sync.rs
@@ -2,53 +2,53 @@
 //! `and_compute_with` method of `Cache`.
 
 use moka::{
-    ops::compute::{self, PerformedOp},
+    ops::compute::{CompResult, Op},
     sync::Cache,
-    Entry,
 };
 
 fn main() {
     let cache: Cache<String, u64> = Cache::new(100);
     let key = "key".to_string();
 
-    // This should insert a now counter value 1 to the cache, and return the value
+    // This should insert a new counter value 1 to the cache, and return the value
     // with the kind of the operation performed.
-    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
-    let entry = maybe_entry.expect("An entry should be returned");
+    let result = inclement_or_remove_counter(&cache, &key);
+    let CompResult::Inserted(entry) = result else {
+        panic!("`Inserted` should be returned: {result:?}");
+    };
     assert_eq!(entry.into_value(), 1);
-    assert_eq!(performed_op, PerformedOp::Inserted);
 
     // This should increment the cached counter value by 1.
-    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
-    let entry = maybe_entry.expect("An entry should be returned");
+    let result = inclement_or_remove_counter(&cache, &key);
+    let CompResult::ReplacedWith(entry) = result else {
+        panic!("`ReplacedWith` should be returned: {result:?}");
+    };
     assert_eq!(entry.into_value(), 2);
-    assert_eq!(performed_op, PerformedOp::Updated);
 
     // This should remove the cached counter from the cache, and returns the
     // _removed_ value.
-    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
-    let entry = maybe_entry.expect("An entry should be returned");
+    let result = inclement_or_remove_counter(&cache, &key);
+    let CompResult::Removed(entry) = result else {
+        panic!("`Removed` should be returned: {result:?}");
+    };
     assert_eq!(entry.into_value(), 2);
-    assert_eq!(performed_op, PerformedOp::Removed);
 
     // The key should no longer exist.
     assert!(!cache.contains_key(&key));
 
     // This should start over; insert a new counter value 1 to the cache.
-    let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
-    let entry = maybe_entry.expect("An entry should be returned");
+    let result = inclement_or_remove_counter(&cache, &key);
+    let CompResult::Inserted(entry) = result else {
+        panic!("`Inserted` should be returned: {result:?}");
+    };
     assert_eq!(entry.into_value(), 1);
-    assert_eq!(performed_op, PerformedOp::Inserted);
 }
 
 /// Increment a cached `u64` counter. If the counter is greater than or equal to 2,
 /// remove it.
 ///
 /// This method uses cache's `and_compute_with` method.
-fn inclement_or_remove_counter(
-    cache: &Cache<String, u64>,
-    key: &str,
-) -> (Option<Entry<String, u64>>, compute::PerformedOp) {
+fn inclement_or_remove_counter(cache: &Cache<String, u64>, key: &str) -> CompResult<String, u64> {
     // - If the counter does not exist, insert a new value of 1.
     // - If the counter is less than 2, increment it by 1.
     // - If the counter is greater than or equal to 2, remove it.
@@ -58,14 +58,14 @@ fn inclement_or_remove_counter(
             let counter = entry.into_value();
             if counter < 2 {
                 // Increment the counter by 1.
-                compute::Op::Put(counter.saturating_add(1))
+                Op::Put(counter.saturating_add(1))
             } else {
                 // Remove the entry.
-                compute::Op::Remove
+                Op::Remove
             }
         } else {
             // The entry does not exist, insert a new value of 1.
-            compute::Op::Put(1)
+            Op::Put(1)
         }
     })
 }

--- a/examples/counter_async.rs
+++ b/examples/counter_async.rs
@@ -1,0 +1,37 @@
+use moka::{future::Cache, Entry};
+
+/// This example demonstrates how to increment a cached `u64` counter. It uses the
+/// `and_upsert_with` method of `Cache`.
+#[tokio::main]
+async fn main() {
+    let cache: Cache<String, u64> = Cache::new(100);
+    let key = "key".to_string();
+
+    let entry = inclement_counter(&cache, &key).await;
+    // assert_eq!(performed_op, PerformedOp::Inserted);
+    assert_eq!(entry.into_value(), 1);
+
+    let entry = inclement_counter(&cache, &key).await;
+    // assert_eq!(performed_op, PerformedOp::Updated);
+    assert_eq!(entry.into_value(), 2);
+
+    let entry = inclement_counter(&cache, &key).await;
+    assert_eq!(entry.into_value(), 3);
+}
+
+async fn inclement_counter(cache: &Cache<String, u64>, key: &str) -> Entry<String, u64> {
+    cache
+        .entry_by_ref(key)
+        .and_upsert_with(|maybe_entry| {
+            let v = if let Some(entry) = maybe_entry {
+                // The entry exists, increment the value by 1.
+                entry.into_value().saturating_add(1)
+            } else {
+                // The entry does not exist, insert a new value of 1.
+                1
+            };
+            // Return a Future that is resolved to `v` immediately.
+            std::future::ready(v)
+        })
+        .await
+}

--- a/examples/counter_async.rs
+++ b/examples/counter_async.rs
@@ -1,29 +1,30 @@
+//! This example demonstrates how to increment a cached `u64` counter. It uses the
+//! `and_upsert_with` method of `Cache`.
+
 use moka::{future::Cache, Entry};
 
-/// This example demonstrates how to increment a cached `u64` counter. It uses the
-/// `and_upsert_with` method of `Cache`.
 #[tokio::main]
 async fn main() {
     let cache: Cache<String, u64> = Cache::new(100);
     let key = "key".to_string();
 
-    let entry = inclement_counter(&cache, &key).await;
+    let entry = increment_counter(&cache, &key).await;
     assert!(entry.is_fresh());
     assert!(!entry.is_updated());
     assert_eq!(entry.into_value(), 1);
 
-    let entry = inclement_counter(&cache, &key).await;
+    let entry = increment_counter(&cache, &key).await;
     assert!(entry.is_fresh());
     assert!(entry.is_updated());
     assert_eq!(entry.into_value(), 2);
 
-    let entry = inclement_counter(&cache, &key).await;
+    let entry = increment_counter(&cache, &key).await;
     assert!(entry.is_fresh());
     assert!(entry.is_updated());
     assert_eq!(entry.into_value(), 3);
 }
 
-async fn inclement_counter(cache: &Cache<String, u64>, key: &str) -> Entry<String, u64> {
+async fn increment_counter(cache: &Cache<String, u64>, key: &str) -> Entry<String, u64> {
     cache
         .entry_by_ref(key)
         .and_upsert_with(|maybe_entry| {

--- a/examples/counter_async.rs
+++ b/examples/counter_async.rs
@@ -8,14 +8,18 @@ async fn main() {
     let key = "key".to_string();
 
     let entry = inclement_counter(&cache, &key).await;
-    // assert_eq!(performed_op, PerformedOp::Inserted);
+    assert!(entry.is_fresh());
+    assert!(!entry.is_updated());
     assert_eq!(entry.into_value(), 1);
 
     let entry = inclement_counter(&cache, &key).await;
-    // assert_eq!(performed_op, PerformedOp::Updated);
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
     assert_eq!(entry.into_value(), 2);
 
     let entry = inclement_counter(&cache, &key).await;
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
     assert_eq!(entry.into_value(), 3);
 }
 

--- a/examples/counter_async.rs
+++ b/examples/counter_async.rs
@@ -27,15 +27,15 @@ async fn inclement_counter(cache: &Cache<String, u64>, key: &str) -> Entry<Strin
     cache
         .entry_by_ref(key)
         .and_upsert_with(|maybe_entry| {
-            let v = if let Some(entry) = maybe_entry {
+            let counter = if let Some(entry) = maybe_entry {
                 // The entry exists, increment the value by 1.
                 entry.into_value().saturating_add(1)
             } else {
                 // The entry does not exist, insert a new value of 1.
                 1
             };
-            // Return a Future that is resolved to `v` immediately.
-            std::future::ready(v)
+            // Return a Future that is resolved to `counter` immediately.
+            std::future::ready(counter)
         })
         .await
 }

--- a/examples/counter_async.rs
+++ b/examples/counter_async.rs
@@ -10,17 +10,17 @@ async fn main() {
 
     let entry = increment_counter(&cache, &key).await;
     assert!(entry.is_fresh());
-    assert!(!entry.is_updated());
+    assert!(!entry.is_old_value_replaced());
     assert_eq!(entry.into_value(), 1);
 
     let entry = increment_counter(&cache, &key).await;
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(entry.into_value(), 2);
 
     let entry = increment_counter(&cache, &key).await;
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(entry.into_value(), 3);
 }
 

--- a/examples/counter_sync.rs
+++ b/examples/counter_sync.rs
@@ -1,0 +1,36 @@
+//! This example demonstrates how to increment a cached `u64` counter. It uses the
+//! `and_upsert_with` method of `Cache`.
+
+use moka::{sync::Cache, Entry};
+
+fn main() {
+    let cache: Cache<String, u64> = Cache::new(100);
+    let key = "key".to_string();
+
+    let entry = increment_counter(&cache, &key);
+    assert!(entry.is_fresh());
+    assert!(!entry.is_updated());
+    assert_eq!(entry.into_value(), 1);
+
+    let entry = increment_counter(&cache, &key);
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
+    assert_eq!(entry.into_value(), 2);
+
+    let entry = increment_counter(&cache, &key);
+    assert!(entry.is_fresh());
+    assert!(entry.is_updated());
+    assert_eq!(entry.into_value(), 3);
+}
+
+fn increment_counter(cache: &Cache<String, u64>, key: &str) -> Entry<String, u64> {
+    cache.entry_by_ref(key).and_upsert_with(|maybe_entry| {
+        if let Some(entry) = maybe_entry {
+            // The entry exists, increment the value by 1.
+            entry.into_value().saturating_add(1)
+        } else {
+            // The entry does not exist, insert a new value of 1.
+            1
+        }
+    })
+}

--- a/examples/counter_sync.rs
+++ b/examples/counter_sync.rs
@@ -9,17 +9,17 @@ fn main() {
 
     let entry = increment_counter(&cache, &key);
     assert!(entry.is_fresh());
-    assert!(!entry.is_updated());
+    assert!(!entry.is_old_value_replaced());
     assert_eq!(entry.into_value(), 1);
 
     let entry = increment_counter(&cache, &key);
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(entry.into_value(), 2);
 
     let entry = increment_counter(&cache, &key);
     assert!(entry.is_fresh());
-    assert!(entry.is_updated());
+    assert!(entry.is_old_value_replaced());
     assert_eq!(entry.into_value(), 3);
 }
 

--- a/examples/try_append_value_async.rs
+++ b/examples/try_append_value_async.rs
@@ -1,5 +1,5 @@
-//! This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
-//! value. It uses the `and_upsert_with` method of `Cache`.
+//! This example demonstrates how to append a `char` to a cached `Vec<String>` value.
+//! It uses the `and_upsert_with` method of `Cache`.
 
 use std::{io::Cursor, pin::Pin, sync::Arc};
 

--- a/examples/try_append_value_async.rs
+++ b/examples/try_append_value_async.rs
@@ -1,0 +1,109 @@
+//! This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
+//! value. It uses the `and_upsert_with` method of `Cache`.
+
+use std::{io::Cursor, pin::Pin, sync::Arc};
+
+use moka::{
+    future::Cache,
+    ops::compute::{self, PerformedOp},
+    Entry,
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt},
+    sync::RwLock,
+};
+
+/// The type of the cache key.
+type Key = i32;
+
+/// The type of the cache value.
+///
+/// We want to store a raw value `String` for each `i32` key. We are going to append
+/// `char` to the `String` value in the cache.
+///
+/// Note that we have to wrap the `String` in an `Arc<RwLock<_>>`. We need the `Arc`,
+/// an atomic reference counted shared pointer, because `and_try_compute_with` method
+/// of `Cache` passes a _clone_ of the value to our closure, instead of passing a
+/// `&mut` reference. We do not want to clone the `String` every time we append a
+/// `char` to it, so we wrap it in an `Arc`. Then we need the `RwLock` because we
+/// mutate the `String` when we append a value to it.
+///
+/// The reason that `and_try_compute_with` cannot pass a `&mut String` to the closure
+/// is because the internal concurrent hash table of `Cache` is a lock free data
+/// structure and does not use any mutexes. So it cannot guarantee: (1) the
+/// `&mut String` is unique, and (2) it is not accessed concurrently by other
+/// threads.
+type Value = Arc<RwLock<String>>;
+
+#[tokio::main]
+async fn main() -> Result<(), tokio::io::Error> {
+    let cache: Cache<Key, Value> = Cache::new(100);
+
+    let key = 0;
+
+    // We are going read a byte at a time from a byte string (`[u8; 3]`).
+    let reader = Cursor::new(b"abc");
+    tokio::pin!(reader);
+
+    // Read the first char 'a' from the reader, and insert a string "a" to the cache.
+    let (maybe_entry, performed_op) = append_to_cached_string(&cache, key, &mut reader).await?;
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(*entry.into_value().read().await, "a");
+    assert_eq!(performed_op, PerformedOp::Inserted);
+
+    // Read next char 'b' from the reader, and append it the cached string.
+    let (maybe_entry, performed_op) = append_to_cached_string(&cache, key, &mut reader).await?;
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(*entry.into_value().read().await, "ab");
+    assert_eq!(performed_op, PerformedOp::Updated);
+
+    // Read next char 'c' from the reader, and append it the cached string.
+    let (maybe_entry, performed_op) = append_to_cached_string(&cache, key, &mut reader).await?;
+    let entry = maybe_entry.expect("An entry should be returned");
+    assert_eq!(*entry.into_value().read().await, "abc");
+    assert_eq!(performed_op, PerformedOp::Updated);
+
+    // Reading should fail as no more char left.
+    let err = append_to_cached_string(&cache, key, &mut reader).await;
+    assert_eq!(
+        err.expect_err("An error should be returned").kind(),
+        tokio::io::ErrorKind::UnexpectedEof
+    );
+
+    Ok(())
+}
+
+/// Reads a byte from the `reader``, convert it into a `char`, append it to the
+/// cached `String` for the given `key`, and returns the resulting cached entry.
+///
+/// If reading from the `reader` fails with an IO error, it returns the error.
+///
+/// This method uses cache's `and_try_compute_with` method.
+async fn append_to_cached_string(
+    cache: &Cache<Key, Value>,
+    key: Key,
+    reader: &mut Pin<&mut impl AsyncRead>,
+) -> Result<(Option<Entry<Key, Value>>, PerformedOp), tokio::io::Error> {
+    cache
+        .entry(key)
+        .and_try_compute_with(|maybe_entry| async {
+            // Read a char from the reader.
+            let byte = reader.read_u8().await?;
+            let char =
+                char::from_u32(byte as u32).expect("An ASCII byte should be converted into a char");
+
+            // Check if the entry already exists.
+            if let Some(entry) = maybe_entry {
+                // The entry exists, append the char to the Vec.
+                let v = entry.into_value();
+                v.write().await.push(char);
+                Ok(compute::Op::Put(v))
+            } else {
+                // The entry does not exist, insert a new Vec containing
+                // the char.
+                let v = RwLock::new(String::from(char));
+                Ok(compute::Op::Put(Arc::new(v)))
+            }
+        })
+        .await
+}

--- a/examples/try_append_value_sync.rs
+++ b/examples/try_append_value_sync.rs
@@ -1,5 +1,5 @@
-//! This example demonstrates how to append an `i32` value to a cached `Vec<i32>`
-//! value. It uses the `and_upsert_with` method of `Cache`.
+//! This example demonstrates how to append a `char` to a cached `Vec<String>` value.
+//! It uses the `and_upsert_with` method of `Cache`.
 
 use std::{
     io::{self, Cursor, Read},

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -21,6 +21,7 @@ pub struct Entry<K, V> {
     key: Option<Arc<K>>,
     value: V,
     is_fresh: bool,
+    is_updated: bool,
 }
 
 impl<K, V> Debug for Entry<K, V>
@@ -33,16 +34,18 @@ where
             .field("key", self.key())
             .field("value", &self.value)
             .field("is_fresh", &self.is_fresh)
+            .field("is_updated", &self.is_updated)
             .finish()
     }
 }
 
 impl<K, V> Entry<K, V> {
-    pub(crate) fn new(key: Option<Arc<K>>, value: V, is_fresh: bool) -> Self {
+    pub(crate) fn new(key: Option<Arc<K>>, value: V, is_fresh: bool, is_updated: bool) -> Self {
         Self {
             key,
             value,
             is_fresh,
+            is_updated,
         }
     }
 
@@ -71,5 +74,10 @@ impl<K, V> Entry<K, V> {
     /// computed.
     pub fn is_fresh(&self) -> bool {
         self.is_fresh
+    }
+
+    /// Returns `true` if the value in this `Entry` replaced an old cached value.
+    pub fn is_updated(&self) -> bool {
+        self.is_updated
     }
 }

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -76,7 +76,11 @@ impl<K, V> Entry<K, V> {
         self.is_fresh
     }
 
-    /// Returns `true` if the value in this `Entry` replaced an old cached value.
+    /// Returns `true` if the value in this `Entry` was already cached and replaced
+    /// with a new value.
+    ///
+    /// Note that the new value can be the same as the old value. In that case, this
+    /// method still returns `true`.
     pub fn is_updated(&self) -> bool {
         self.is_updated
     }

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -21,7 +21,7 @@ pub struct Entry<K, V> {
     key: Option<Arc<K>>,
     value: V,
     is_fresh: bool,
-    is_updated: bool,
+    is_old_value_replaced: bool,
 }
 
 impl<K, V> Debug for Entry<K, V>
@@ -34,18 +34,23 @@ where
             .field("key", self.key())
             .field("value", &self.value)
             .field("is_fresh", &self.is_fresh)
-            .field("is_updated", &self.is_updated)
+            .field("is_old_value_replaced", &self.is_old_value_replaced)
             .finish()
     }
 }
 
 impl<K, V> Entry<K, V> {
-    pub(crate) fn new(key: Option<Arc<K>>, value: V, is_fresh: bool, is_updated: bool) -> Self {
+    pub(crate) fn new(
+        key: Option<Arc<K>>,
+        value: V,
+        is_fresh: bool,
+        is_old_value_replaced: bool,
+    ) -> Self {
         Self {
             key,
             value,
             is_fresh,
-            is_updated,
+            is_old_value_replaced,
         }
     }
 
@@ -76,12 +81,12 @@ impl<K, V> Entry<K, V> {
         self.is_fresh
     }
 
-    /// Returns `true` if the value in this `Entry` was already cached and replaced
-    /// with a new value.
+    /// Returns `true` if an old value existed in the cache and was replaced by the
+    /// value in this `Entry`.
     ///
-    /// Note that the new value can be the same as the old value. In that case, this
-    /// method still returns `true`.
-    pub fn is_updated(&self) -> bool {
-        self.is_updated
+    /// Note that the new value can be the same as the old value. This method still
+    /// returns `true` in that case.
+    pub fn is_old_value_replaced(&self) -> bool {
+        self.is_old_value_replaced
     }
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -35,10 +35,10 @@ pub type PredicateId = String;
 
 pub(crate) type PredicateIdStr<'a> = &'a str;
 
-// Empty struct to be used in InitResult::InitErr to represent the Option None.
+// Empty struct to be used in `InitResult::InitErr` to represent the Option None.
 pub(crate) struct OptionallyNone;
 
-// Empty struct to be used in InitResult::InitErr to represent the Compute None.
+// Empty struct to be used in `InitResult::InitErr` to represent the Compute None.
 pub(crate) struct ComputeNone;
 
 impl<T: ?Sized> FutureExt for T where T: Future {}

--- a/src/future.rs
+++ b/src/future.rs
@@ -38,6 +38,9 @@ pub(crate) type PredicateIdStr<'a> = &'a str;
 // Empty struct to be used in InitResult::InitErr to represent the Option None.
 pub(crate) struct OptionallyNone;
 
+// Empty struct to be used in InitResult::InitErr to represent the Compute None.
+pub(crate) struct ComputeNone;
+
 impl<T: ?Sized> FutureExt for T where T: Future {}
 
 pub trait FutureExt: Future {

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -326,7 +326,7 @@ where
                     entry.set_last_accessed(now);
 
                     let maybe_key = if need_key { Some(Arc::clone(k)) } else { None };
-                    let ent = Entry::new(maybe_key, entry.value.clone(), false);
+                    let ent = Entry::new(maybe_key, entry.value.clone(), false, false);
                     let maybe_op = if record_read {
                         Some(ReadOp::Hit {
                             value_entry: TrioArc::clone(entry),

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1063,6 +1063,7 @@ where
             .into_value()
     }
 
+    /// TODO: Remove this in v0.13.0.
     /// Deprecated, replaced with
     /// [`entry()::or_insert_with_if()`](./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
     #[deprecated(since = "0.10.0", note = "Replaced with `entry().or_insert_with_if()`")]
@@ -2159,6 +2160,7 @@ mod tests {
         common::time::Clock,
         future::FutureExt,
         notification::{ListenerFuture, RemovalCause},
+        ops::compute,
         policy::test_utils::ExpiryCallCounters,
         Expiry,
     };
@@ -2196,6 +2198,17 @@ mod tests {
         is_send(cache.try_get_with_by_ref(&(), async { Err(()) }));
 
         // entry fns
+        is_send(
+            cache
+                .entry(())
+                .and_compute_with(|_| async { compute::Op::Nop }),
+        );
+        is_send(
+            cache
+                .entry(())
+                .and_try_compute_with(|_| async { Ok(compute::Op::Nop) as Result<_, Infallible> }),
+        );
+        is_send(cache.entry(()).and_upsert_with(|_| async {}));
         is_send(cache.entry(()).or_default());
         is_send(cache.entry(()).or_insert(()));
         is_send(cache.entry(()).or_insert_with(async {}));
@@ -2204,6 +2217,17 @@ mod tests {
         is_send(cache.entry(()).or_try_insert_with(async { Err(()) }));
 
         // entry_by_ref fns
+        is_send(
+            cache
+                .entry_by_ref(&())
+                .and_compute_with(|_| async { compute::Op::Nop }),
+        );
+        is_send(
+            cache
+                .entry_by_ref(&())
+                .and_try_compute_with(|_| async { Ok(compute::Op::Nop) as Result<_, Infallible> }),
+        );
+        is_send(cache.entry_by_ref(&()).and_upsert_with(|_| async {}));
         is_send(cache.entry_by_ref(&()).or_default());
         is_send(cache.entry_by_ref(&()).or_insert(()));
         is_send(cache.entry_by_ref(&()).or_insert_with(async {}));

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -2083,10 +2083,10 @@ where
             .map(Entry::into_value)
     }
 
-    async fn get_entry_without_recording(&self, key: &Arc<K>, hash: u64) -> Option<Entry<K, V>> {
+    async fn get_entry(&self, key: &Arc<K>, hash: u64) -> Option<Entry<K, V>> {
         let ignore_if = None as Option<&mut fn(&V) -> bool>;
         self.base
-            .get_with_hash(key, hash, ignore_if, true, false)
+            .get_with_hash(key, hash, ignore_if, true, true)
             .await
     }
 

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -65,12 +65,12 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
-    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
-    ///   method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///   modify entry only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html
@@ -84,7 +84,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.12", features = ["future"] }
+    /// // moka = { version = "0.12.3", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::{
@@ -201,11 +201,11 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
     ///   the [`and_compute_with`] method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html
@@ -251,7 +251,7 @@ where
     /// 3. Upsert the new value to the cache.
     /// 4. Return the `Entry` having the upserted value.
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want to optionally upsert, that is to upsert only when certain
     ///   conditions meet, use the [`and_compute_with`] method.
@@ -269,7 +269,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.12", features = ["future"] }
+    /// // moka = { version = "0.12.3", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;
@@ -705,12 +705,12 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
-    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
-    ///   method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///   modify entry only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html
@@ -724,7 +724,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.12", features = ["future"] }
+    /// // moka = { version = "0.12.3", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::{
@@ -841,11 +841,11 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
     ///   the [`and_compute_with`] method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html
@@ -891,7 +891,7 @@ where
     /// 3. Upsert the new value to the cache.
     /// 4. Return the `Entry` having the upserted value.
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want to optionally upsert, that is to upsert only when certain
     ///   conditions meet, use the [`and_compute_with`] method.
@@ -909,7 +909,7 @@ where
     /// // Cargo.toml
     /// //
     /// // [dependencies]
-    /// // moka = { version = "0.12", features = ["future"] }
+    /// // moka = { version = "0.12.3", features = ["future"] }
     /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
     ///
     /// use moka::future::Cache;

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -1,4 +1,4 @@
-use crate::Entry;
+use crate::{ops::compute, Entry};
 
 use super::Cache;
 
@@ -362,6 +362,17 @@ where
         let key = Arc::new(self.owned_key);
         self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
     }
+
+    pub async fn and_compute_with<F, Fut>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = compute::Op<V>>,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
 }
 
 /// Provides advanced methods to select or insert an entry of the cache.
@@ -721,5 +732,16 @@ where
     {
         let key = Arc::new(self.ref_key.to_owned());
         self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
+    }
+
+    pub async fn and_compute_with<F, Fut>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = compute::Op<V>>,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache
+            .compute_with_hash_and_fun(key, self.hash, f)
+            .await
     }
 }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -373,6 +373,21 @@ where
             .compute_with_hash_and_fun(key, self.hash, f)
             .await
     }
+
+    pub async fn and_try_compute_with<F, Fut, E>(
+        self,
+        f: F,
+    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .try_compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
 }
 
 /// Provides advanced methods to select or insert an entry of the cache.
@@ -742,6 +757,21 @@ where
         let key = Arc::new(self.ref_key.to_owned());
         self.cache
             .compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
+    pub async fn and_try_compute_with<F, Fut, E>(
+        self,
+        f: F,
+    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache
+            .try_compute_with_hash_and_fun(key, self.hash, f)
             .await
     }
 }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -704,4 +704,14 @@ where
             .get_or_try_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, true)
             .await
     }
+
+    pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = V>,
+    {
+        self.cache
+            .upsert_with_hash_by_ref_and_fun(self.ref_key, self.hash, f)
+            .await
+    }
 }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -39,6 +39,312 @@ where
         }
     }
 
+    /// This method performs a compute operation on a key by using the given closure
+    /// `f`. A compute operation is either put, remove or nop (no-operation).
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a `Future` that resolves to an `ops::compute::Op<V>`
+    /// enum.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a `Future`.
+    /// 2. Resolve the `Future`, and get an `ops::compute::Op<V>`.
+    /// 3. Execute the op on the cache:
+    ///    - `Op::Put(V)`: Put the new value `V` to the cache.
+    ///    - `Op::Remove`: Remove the current cached entry.
+    ///    - `Op::Nop`: Do nothing.
+    /// 4. Return a `(Entry, ops::compute::PerformedOp)` as the followings:
+    ///
+    /// | [`Op<V>`] | `Entry` to return   | [`PerformedOp`]         |
+    /// |:--------- |:------------------- |:----------------------- |
+    /// | `Put(V)`  | The current entry   | `Inserted` or `Updated` |
+    /// | `Remove`  | The _removed_ entry | `Removed`               |
+    /// | `Nop`     | The current entry   | `Nop`                   |
+    ///
+    /// **Notes:**
+    ///
+    /// - `Op::Put(V)`: `PerformedOp::Updated` is returned when the key already
+    ///   existed in the cache. It is _not_ related to whether the value was actually
+    ///   updated or not.
+    /// - `Op::Remove`: Unlike other ops, the _removed_ entry is returned. If you mix
+    ///   `Remove` with other ops, ensure to check whether the performed op is
+    ///   `Removed` or not.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
+    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
+    ///   method.
+    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`Op<V>`]: ../ops/compute/enum.Op.html
+    /// [`PerformedOp`]: ../ops/compute/enum.PerformedOp.html
+    /// [`and_upsert_with`]: #method.and_upsert_with
+    /// [`and_try_compute_with`]: #method.and_try_compute_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.12", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::{
+    ///     future::Cache,
+    ///     ops::compute::{self, PerformedOp},
+    ///     Entry,
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, u64> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     /// Increment a cached `u64` counter. If the counter is greater than or
+    ///     /// equal to 2, remove it.
+    ///     async fn inclement_or_remove_counter(
+    ///         cache: &Cache<String, u64>,
+    ///         key: &str,
+    ///     ) -> (Option<Entry<String, u64>>, compute::PerformedOp) {
+    ///         cache
+    ///             .entry(key.to_string())
+    ///             .and_compute_with(|maybe_entry| {
+    ///                 let op = if let Some(entry) = maybe_entry {
+    ///                     let counter = entry.into_value();
+    ///                     if counter < 2 {
+    ///                         compute::Op::Put(counter.saturating_add(1)) // Update
+    ///                     } else {
+    ///                         compute::Op::Remove // Remove
+    ///                     }
+    ///                 } else {
+    ///                       compute::Op::Put(1) // Insert
+    ///                 };
+    ///                 // Return a Future that is resolved to `op` immediately.
+    ///                 std::future::ready(op)
+    ///             })
+    ///             .await
+    ///     }
+    ///
+    ///     // This should insert a now counter value 1 to the cache, and return the
+    ///     // value with the kind of the operation performed.
+    ///     let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    ///     let entry = maybe_entry.expect("An entry should be returned");
+    ///     assert_eq!(entry.into_value(), 1);
+    ///     assert_eq!(performed_op, PerformedOp::Inserted);
+    ///
+    ///     // This should increment the cached counter value by 1.
+    ///     let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    ///     let entry = maybe_entry.expect("An entry should be returned");
+    ///     assert_eq!(entry.into_value(), 2);
+    ///     assert_eq!(performed_op, PerformedOp::Updated);
+    ///
+    ///     // This should remove the cached counter from the cache, and returns the
+    ///     // _removed_ value.
+    ///     let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    ///     let entry = maybe_entry.expect("An entry should be returned");
+    ///     assert_eq!(entry.into_value(), 2);
+    ///     assert_eq!(performed_op, PerformedOp::Removed);
+    ///
+    ///     // The key should no longer exist.
+    ///     assert!(!cache.contains_key(&key));
+    ///
+    ///     // This should start over; insert a new counter value 1 to the cache.
+    ///     let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key).await;
+    ///     let entry = maybe_entry.expect("An entry should be returned");
+    ///     assert_eq!(entry.into_value(), 1);
+    ///     assert_eq!(performed_op, PerformedOp::Inserted);
+    /// }
+    /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_compute_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
+    pub async fn and_compute_with<F, Fut>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = compute::Op<V>>,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
+    /// This method performs a compute operation on a key by using the given closure
+    /// `f`. A compute operation is either put, remove or nop (no-operation).
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a `Future` that resolves to an
+    /// `Result<ops::compute::Op<V>, E>`.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a `Future`.
+    /// 2. Resolve the `Future`, and get a `Result<ops::compute::Op<V>, E>`.
+    /// 3. If resolved to `Err(E)`, return it.
+    /// 4. Else, execute the op on the cache:
+    ///    - `Ok(Op::Put(V))`: Put the new value `V` to the cache.
+    ///    - `Ok(Op::Remove)`: Remove the current cached entry.
+    ///    - `Ok(Op::Nop)`: Do nothing.
+    /// 5. Return a `Ok((Entry, ops::compute::PerformedOp))` as the followings:
+    ///
+    /// | [`Op<V>`] | `Entry` to return   | [`PerformedOp`]         |
+    /// |:--------- |:------------------- |:----------------------- |
+    /// | `Put(V)`  | The current entry   | `Inserted` or `Updated` |
+    /// | `Remove`  | The _removed_ entry | `Removed`               |
+    /// | `Nop`     | The current entry   | `Nop`                   |
+    ///
+    /// **Notes:**
+    ///
+    /// - `Op::Put(V)`: `PerformedOp::Updated` is returned when the key already
+    ///   existed in the cache. It is _not_ related to whether the value was actually
+    ///   updated or not.
+    /// - `Op::Remove`: Unlike other ops, the _removed_ entry is returned. If you mix
+    ///   `Remove` with other ops, ensure to check whether the performed op is
+    ///   `Removed` or not.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
+    ///   the [`and_compute_with`] method.
+    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`Op<V>`]: ../ops/compute/enum.Op.html
+    /// [`PerformedOp`]: ../ops/compute/enum.PerformedOp.html
+    /// [`and_upsert_with`]: #method.and_upsert_with
+    /// [`and_compute_with`]: #method.and_compute_with
+    ///
+    /// # Example
+    ///
+    /// See [`try_append_value_async.rs`] in the `examples` directory.
+    ///
+    /// [`try_append_value_async.rs`]:
+    ///     https://github.com/moka-rs/moka/tree/main/examples/try_append_value_async.rs
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_try_compute_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
+    pub async fn and_try_compute_with<F, Fut, E>(
+        self,
+        f: F,
+    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .try_compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
+    /// This method performs an upsert of an [`Entry`] by using the given closure
+    /// `f`. The word "upsert" here means "update" or "insert".
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a `Future` that resolves to a new value `V`.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a `Future`.
+    /// 2. Resolve the `Future`, and get a new value `V`.
+    /// 3. Upsert the new value to the cache.
+    /// 4. Return the `Entry` having the upserted value.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want to optionally upsert, that is to upsert only when certain
+    ///   conditions meet, use the [`and_compute_with`] method.
+    /// - If you try to upsert, that is to make the `Future` resolve to `Result<V>`
+    ///   instead of `V`, and upsert only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`and_compute_with`]: #method.and_compute_with
+    /// [`and_try_compute_with`]: #method.and_try_compute_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Cargo.toml
+    /// //
+    /// // [dependencies]
+    /// // moka = { version = "0.12", features = ["future"] }
+    /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+    ///
+    /// use moka::future::Cache;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let cache: Cache<String, u64> = Cache::new(100);
+    ///     let key = "key1".to_string();
+    ///
+    ///     let entry = cache
+    ///         .entry(key.clone())
+    ///         .and_upsert_with(|maybe_entry| {
+    ///             let counter = if let Some(entry) = maybe_entry {
+    ///                 entry.into_value().saturating_add(1) // Update
+    ///             } else {
+    ///                 1 // Insert
+    ///             };
+    ///             // Return a Future that is resolved to `counter` immediately.
+    ///             std::future::ready(counter)
+    ///         })
+    ///         .await;
+    ///     // It was not an update.
+    ///     assert!(!entry.is_updated());
+    ///     assert_eq!(entry.key(), &key);
+    ///     assert_eq!(entry.into_value(), 1);
+    ///
+    ///     let entry = cache
+    ///         .entry(key.clone())
+    ///         .and_upsert_with(|maybe_entry| {
+    ///             let counter = if let Some(entry) = maybe_entry {
+    ///                 entry.into_value().saturating_add(1)
+    ///             } else {
+    ///                 1
+    ///             };
+    ///             std::future::ready(counter)
+    ///         })
+    ///         .await;
+    ///     // It was an update.
+    ///     assert!(entry.is_updated());
+    ///     assert_eq!(entry.key(), &key);
+    ///     assert_eq!(entry.into_value(), 2);
+    /// }
+    /// ```
+    ///
+    /// Note: The `is_updated` method of the `Entry` returns `true` when the key
+    /// already existed in the cache. It is not related to whether the value was
+    /// actually updated or not.
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_upsert_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
+    pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = V>,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
+    }
+
     /// Returns the corresponding [`Entry`] for the key given when this entry
     /// selector was constructed. If the entry does not exist, inserts one by calling
     /// the [`default`][std-default-function] function of the value type `V`.
@@ -353,41 +659,6 @@ where
             .get_or_try_insert_with_hash_and_fun(key, self.hash, init, true)
             .await
     }
-
-    pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
-    where
-        F: FnOnce(Option<Entry<K, V>>) -> Fut,
-        Fut: Future<Output = V>,
-    {
-        let key = Arc::new(self.owned_key);
-        self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
-    }
-
-    pub async fn and_compute_with<F, Fut>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
-    where
-        F: FnOnce(Option<Entry<K, V>>) -> Fut,
-        Fut: Future<Output = compute::Op<V>>,
-    {
-        let key = Arc::new(self.owned_key);
-        self.cache
-            .compute_with_hash_and_fun(key, self.hash, f)
-            .await
-    }
-
-    pub async fn and_try_compute_with<F, Fut, E>(
-        self,
-        f: F,
-    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
-    where
-        F: FnOnce(Option<Entry<K, V>>) -> Fut,
-        Fut: Future<Output = Result<compute::Op<V>, E>>,
-        E: Send + Sync + 'static,
-    {
-        let key = Arc::new(self.owned_key);
-        self.cache
-            .try_compute_with_hash_and_fun(key, self.hash, f)
-            .await
-    }
 }
 
 /// Provides advanced methods to select or insert an entry of the cache.
@@ -422,6 +693,41 @@ where
             hash,
             cache,
         }
+    }
+
+    pub async fn and_compute_with<F, Fut>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = compute::Op<V>>,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache
+            .compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
+    pub async fn and_try_compute_with<F, Fut, E>(
+        self,
+        f: F,
+    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache
+            .try_compute_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
+    pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = V>,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
     }
 
     /// Returns the corresponding [`Entry`] for the reference of the key given when
@@ -737,41 +1043,6 @@ where
         futures_util::pin_mut!(init);
         self.cache
             .get_or_try_insert_with_hash_by_ref_and_fun(self.ref_key, self.hash, init, true)
-            .await
-    }
-
-    pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
-    where
-        F: FnOnce(Option<Entry<K, V>>) -> Fut,
-        Fut: Future<Output = V>,
-    {
-        let key = Arc::new(self.ref_key.to_owned());
-        self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
-    }
-
-    pub async fn and_compute_with<F, Fut>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
-    where
-        F: FnOnce(Option<Entry<K, V>>) -> Fut,
-        Fut: Future<Output = compute::Op<V>>,
-    {
-        let key = Arc::new(self.ref_key.to_owned());
-        self.cache
-            .compute_with_hash_and_fun(key, self.hash, f)
-            .await
-    }
-
-    pub async fn and_try_compute_with<F, Fut, E>(
-        self,
-        f: F,
-    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
-    where
-        F: FnOnce(Option<Entry<K, V>>) -> Fut,
-        Fut: Future<Output = Result<compute::Op<V>, E>>,
-        E: Send + Sync + 'static,
-    {
-        let key = Arc::new(self.ref_key.to_owned());
-        self.cache
-            .try_compute_with_hash_and_fun(key, self.hash, f)
             .await
     }
 }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -360,9 +360,7 @@ where
         Fut: Future<Output = V>,
     {
         let key = Arc::new(self.owned_key);
-        self.cache
-            .upsert_with_hash_and_fun(key, self.hash, f)
-            .await
+        self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
     }
 }
 
@@ -722,8 +720,6 @@ where
         Fut: Future<Output = V>,
     {
         let key = Arc::new(self.ref_key.to_owned());
-        self.cache
-            .upsert_with_hash_and_fun(key, self.hash, f)
-            .await
+        self.cache.upsert_with_hash_and_fun(key, self.hash, f).await
     }
 }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -353,6 +353,17 @@ where
             .get_or_try_insert_with_hash_and_fun(key, self.hash, init, true)
             .await
     }
+
+    pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = V>,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .upsert_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
 }
 
 /// Provides advanced methods to select or insert an entry of the cache.
@@ -710,8 +721,9 @@ where
         F: FnOnce(Option<Entry<K, V>>) -> Fut,
         Fut: Future<Output = V>,
     {
+        let key = Arc::new(self.ref_key.to_owned());
         self.cache
-            .upsert_with_hash_by_ref_and_fun(self.ref_key, self.hash, f)
+            .upsert_with_hash_and_fun(key, self.hash, f)
             .await
     }
 }

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -408,8 +408,8 @@ where
             Op::Remove => {
                 let maybe_prev_v = cache.remove(&c_key, c_hash).await;
                 if let Some(prev_v) = maybe_prev_v {
-                    let entry = Entry::new(Some(c_key), prev_v, false, false);
                     crossbeam_epoch::pin().flush();
+                    let entry = Entry::new(Some(c_key), prev_v, false, false);
                     Ok(CompResult::Removed(entry))
                 } else {
                     Ok(CompResult::StillNone(c_key))

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -427,6 +427,16 @@ where
         Ok(op)
     }
 
+    /// The `post_init` function for the `and_try_compute_with` method of cache.
+    pub(crate) fn post_init_for_try_compute_with<E>(
+        op: Result<compute::Op<V>, E>,
+    ) -> Result<compute::Op<V>, E>
+    where
+        E: Send + Sync + 'static,
+    {
+        op
+    }
+
     /// Returns the `type_id` for `get_with` method of cache.
     pub(crate) fn type_id_for_get_with() -> TypeId {
         // NOTE: We use a regular function here instead of a const fn because TypeId

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,10 @@ pub(crate) mod cht;
 pub(crate) mod common;
 
 #[cfg(any(feature = "sync", feature = "future"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "sync", feature = "future"))))]
+pub mod ops;
+
+#[cfg(any(feature = "sync", feature = "future"))]
 pub(crate) mod policy;
 
 #[cfg(any(feature = "sync", feature = "future"))]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -2,6 +2,9 @@
 
 /// Operations used by the `and_compute_with` and similar methods.
 pub mod compute {
+    use std::sync::Arc;
+
+    use crate::Entry;
 
     /// Instructs the `and_compute_with` and similar methods how to modify the cached
     /// entry.
@@ -15,24 +18,54 @@ pub mod compute {
         Remove,
     }
 
-    /// Will be returned by the `and_compute_with` and similar methods to indicate
-    /// what kind of operation was performed.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub enum PerformedOp {
-        /// The entry did not exist, or already existed but was not modified.
-        Nop,
-        /// The entry did not exist and was inserted.
-        Inserted,
-        /// The entry already existed and its value may have been updated.
+    /// The result of the `and_compute_with` and similar methods.
+    #[derive(Debug)]
+    pub enum CompResult<K, V> {
+        /// The entry did not exist and still does not exist.
+        StillNone(Arc<K>),
+        /// The entry already existed and was not modified. The returned entry
+        /// contains the existing value.
+        Unchanged(Entry<K, V>),
+        /// The entry did not exist and was inserted. The returned entry contains
+        /// the inserted value.
+        Inserted(Entry<K, V>),
+        /// The entry already existed and its value was replaced with a new one. The
+        /// returned entry contains the new value (not the replaced value).
+        ReplacedWith(Entry<K, V>),
+        /// The entry already existed and was removed. The returned entry contains
+        /// the removed value.
         ///
-        /// Note: `Updated` is returned if `Op::Put` was requested and the entry
-        /// already existed. It is _not_ related to whether the value was actually
-        /// updated or not.
-        Updated,
-        /// The entry already existed and was removed.
-        ///
-        /// Note: `Nop` is returned instead of `Removed` if `Op::Remove` was
+        /// Note: `StillNone` is returned instead of `Removed` if `Op::Remove` was
         /// requested but the entry did not exist.
-        Removed,
+        Removed(Entry<K, V>),
+    }
+
+    impl<K, V> CompResult<K, V> {
+        /// Returns the contained `Some(Entry)` if any. Otherwise returns `None`.
+        /// Consumes the `self` value.
+        pub fn into_entry(self) -> Option<Entry<K, V>> {
+            match self {
+                CompResult::StillNone(_) => None,
+                CompResult::Unchanged(entry) => Some(entry),
+                CompResult::Inserted(entry) => Some(entry),
+                CompResult::ReplacedWith(entry) => Some(entry),
+                CompResult::Removed(entry) => Some(entry),
+            }
+        }
+
+        /// Unwraps the contained `Entry`, consuming the `self` value.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the `self` value is `StillNone`.
+        pub fn unwrap(self) -> Entry<K, V> {
+            match self {
+                CompResult::StillNone(_) => panic!("`CompResult::unwrap` called on `StillNone`"),
+                CompResult::Unchanged(entry) => entry,
+                CompResult::Inserted(entry) => entry,
+                CompResult::ReplacedWith(entry) => entry,
+                CompResult::Removed(entry) => entry,
+            }
+        }
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,7 @@
 pub mod compute {
 
     /// Instructs the `and_compute` method how to modify the cache entry.
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum Op<V> {
         /// No-op. Do not modify the cached entry.
         Nop,
@@ -12,10 +13,11 @@ pub mod compute {
 
     /// Will be returned from `and_compute_with` and similar methods to indicate what
     /// kind of operation was performed.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum PerformedOp {
         /// The entry did not exist, or already existed but was not modified.
         Nop,
-        /// The entry did not exist and inserted.
+        /// The entry did not exist and was inserted.
         Inserted,
         /// The entry already existed and its value was updated.
         Updated,
@@ -23,6 +25,6 @@ pub mod compute {
         ///
         /// Note: If `and_compute_with` tried to remove a not-exiting entry, `Nop`
         /// will be returned.
-        Remove,
+        Removed,
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,30 +1,38 @@
+//! Cache operations.
+
+/// Operations used by the `and_compute_with` and similar methods.
 pub mod compute {
 
-    /// Instructs the `and_compute` method how to modify the cache entry.
+    /// Instructs the `and_compute_with` and similar methods how to modify the cached
+    /// entry.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum Op<V> {
-        /// No-op. Do not modify the cached entry.
+        /// No-operation. Do not modify the cached entry.
         Nop,
-        /// Insert or replace the value of the cached entry.
+        /// Insert or update the value of the cached entry.
         Put(V),
         /// Remove the cached entry.
         Remove,
     }
 
-    /// Will be returned from `and_compute_with` and similar methods to indicate what
-    /// kind of operation was performed.
+    /// Will be returned by the `and_compute_with` and similar methods to indicate
+    /// what kind of operation was performed.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum PerformedOp {
         /// The entry did not exist, or already existed but was not modified.
         Nop,
         /// The entry did not exist and was inserted.
         Inserted,
-        /// The entry already existed and its value was updated.
-        Updated,
-        /// The entry existed and was removed.
+        /// The entry already existed and its value may have been updated.
         ///
-        /// Note: If `and_compute_with` tried to remove a not-exiting entry, `Nop`
-        /// will be returned.
+        /// Note: `Updated` is returned if `Op::Put` was requested and the entry
+        /// already existed. It is _not_ related to whether the value was actually
+        /// updated or not.
+        Updated,
+        /// The entry already existed and was removed.
+        ///
+        /// Note: `Nop` is returned instead of `Removed` if `Op::Remove` was
+        /// requested but the entry did not exist.
         Removed,
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,28 @@
+pub mod compute {
+
+    /// Instructs the `and_compute` method how to modify the cache entry.
+    pub enum Op<V> {
+        /// No-op. Do not modify the cached entry.
+        Nop,
+        /// Insert or replace the value of the cached entry.
+        Put(V),
+        /// Remove the cached entry.
+        Remove,
+    }
+
+    /// Will be returned from `and_compute_with` and similar methods to indicate what
+    /// kind of operation was performed.
+    pub enum PerformedOp {
+        /// The entry did not exist, or already existed but was not modified.
+        Nop,
+        /// The entry did not exist and inserted.
+        Inserted,
+        /// The entry already existed and its value was updated.
+        Updated,
+        /// The entry existed and was removed.
+        ///
+        /// Note: If `and_compute_with` tried to remove a not-exiting entry, `Nop`
+        /// will be returned.
+        Remove,
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -20,6 +20,8 @@ pub trait ConcurrentCacheExt<K, V> {
     fn sync(&self);
 }
 
-// Empty internal struct to be used in optionally_get_with to represent the None
-// results.
+// Empty struct to be used in `InitResult::InitErr` to represent the Option None.
 pub(crate) struct OptionallyNone;
+
+// Empty struct to be used in `InitResult::InitErr`` to represent the Compute None.
+pub(crate) struct ComputeNone;

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1047,9 +1047,9 @@ where
         {
             InitResult::Initialized(v) => {
                 crossbeam_epoch::pin().flush();
-                Entry::new(k, v, true)
+                Entry::new(k, v, true, false)
             }
-            InitResult::ReadExisting(v) => Entry::new(k, v, false),
+            InitResult::ReadExisting(v) => Entry::new(k, v, false, false),
             InitResult::InitErr(_) => unreachable!(),
         }
     }
@@ -1065,7 +1065,7 @@ where
             None => {
                 let value = init();
                 self.insert_with_hash(Arc::clone(&key), hash, value.clone());
-                Entry::new(Some(key), value, true)
+                Entry::new(Some(key), value, true, false)
             }
         }
     }
@@ -1086,7 +1086,7 @@ where
                 let key = Arc::new(key.to_owned());
                 let value = init();
                 self.insert_with_hash(Arc::clone(&key), hash, value.clone());
-                Entry::new(Some(key), value, true)
+                Entry::new(Some(key), value, true, false)
             }
         }
     }
@@ -1271,9 +1271,9 @@ where
         {
             InitResult::Initialized(v) => {
                 crossbeam_epoch::pin().flush();
-                Some(Entry::new(k, v, true))
+                Some(Entry::new(k, v, true, false))
             }
-            InitResult::ReadExisting(v) => Some(Entry::new(k, v, false)),
+            InitResult::ReadExisting(v) => Some(Entry::new(k, v, false, false)),
             InitResult::InitErr(_) => {
                 crossbeam_epoch::pin().flush();
                 None
@@ -1465,9 +1465,9 @@ where
         {
             InitResult::Initialized(v) => {
                 crossbeam_epoch::pin().flush();
-                Ok(Entry::new(k, v, true))
+                Ok(Entry::new(k, v, true, false))
             }
-            InitResult::ReadExisting(v) => Ok(Entry::new(k, v, false)),
+            InitResult::ReadExisting(v) => Ok(Entry::new(k, v, false, false)),
             InitResult::InitErr(e) => {
                 crossbeam_epoch::pin().flush();
                 Err(e)

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -966,6 +966,7 @@ where
             .into_value()
     }
 
+    /// TODO: Remove this in v0.13.0.
     /// Deprecated, replaced with
     /// [`entry()::or_insert_with_if()`](./struct.OwnedKeyEntrySelector.html#method.or_insert_with_if)
     #[deprecated(since = "0.10.0", note = "Replaced with `entry().or_insert_with_if()`")]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1905,7 +1905,7 @@ where
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
-    fn get_entry_without_recording(&self, key: &Arc<K>, hash: u64) -> Option<Entry<K, V>> {
+    fn get_entry(&self, key: &Arc<K>, hash: u64) -> Option<Entry<K, V>> {
         let ignore_if = None as Option<&mut fn(&V) -> bool>;
         self.base
             .get_with_hash_and_ignore_if(key, hash, ignore_if, true)
@@ -4033,7 +4033,7 @@ mod tests {
 
         // Spawn three threads to call `and_upsert_with` for the same key and each
         // task increments the current value by 1. Ensure the key-level lock is
-        // working by verifying the value is 3 after all tasks finish.
+        // working by verifying the value is 3 after all threads finish.
         //
         // |        | thread 1 | thread 2 | thread 3 |
         // |--------|----------|----------|----------|
@@ -4103,7 +4103,7 @@ mod tests {
         const KEY: u32 = 0;
 
         // Spawn six threads to call `and_compute_with` for the same key. Ensure the
-        // key-level lock is working by verifying the value after all tasks finish.
+        // key-level lock is working by verifying the value after all threads finish.
         //
         // |         |  thread 1  |   thread 2    |  thread 3  | thread 4 |  thread 5  | thread 6 |
         // |---------|------------|---------------|------------|----------|------------|----------|
@@ -4271,7 +4271,7 @@ mod tests {
         const KEY: u32 = 0;
 
         // Spawn four threads to call `and_try_compute_with` for the same key. Ensure
-        // the key-level lock is working by verifying the value after all tasks
+        // the key-level lock is working by verifying the value after all threads
         // finish.
         //
         // |         |  thread 1  |   thread 2    |  thread 3  | thread 4   |

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -1,4 +1,4 @@
-use crate::Entry;
+use crate::{ops::compute, Entry};
 
 use super::Cache;
 
@@ -36,6 +36,34 @@ where
             hash,
             cache,
         }
+    }
+
+    pub fn and_compute_with<F>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> compute::Op<V>,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache.compute_with_hash_and_fun(key, self.hash, f)
+    }
+
+    pub fn and_try_compute_with<F, E>(
+        self,
+        f: F,
+    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Result<compute::Op<V>, E>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache.try_compute_with_hash_and_fun(key, self.hash, f)
+    }
+
+    pub fn and_upsert_with<F>(self, f: F) -> Entry<K, V>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> V,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache.upsert_with_hash_and_fun(key, self.hash, f)
     }
 
     /// Returns the corresponding [`Entry`] for the key given when this entry
@@ -323,6 +351,34 @@ where
             hash,
             cache,
         }
+    }
+
+    pub fn and_compute_with<F>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> compute::Op<V>,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache.compute_with_hash_and_fun(key, self.hash, f)
+    }
+
+    pub fn and_try_compute_with<F, E>(
+        self,
+        f: F,
+    ) -> Result<(Option<Entry<K, V>>, compute::PerformedOp), E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Result<compute::Op<V>, E>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache.try_compute_with_hash_and_fun(key, self.hash, f)
+    }
+
+    pub fn and_upsert_with<F>(self, f: F) -> Entry<K, V>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> V,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache.upsert_with_hash_and_fun(key, self.hash, f)
     }
 
     /// Returns the corresponding [`Entry`] for the reference of the key given when

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -63,12 +63,12 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
-    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
-    ///   method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///   modify entry only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html
@@ -183,7 +183,7 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
     ///   the [`and_compute_with`] method.
@@ -230,7 +230,7 @@ where
     /// 2. Upsert the new value to the cache.
     /// 3. Return the `Entry` having the upserted value.
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want to optionally upsert, that is to upsert only when certain
     ///   conditions meet, use the [`and_compute_with`] method.
@@ -605,12 +605,12 @@ where
     /// | `Nop`     | no  | `StillNone(Arc<K>)`         |                                 |
     /// | `Nop`     | yes | `Unchanged(Entry<K, V>)`    | The existing entry is returned. |
     ///
-    /// # Similar Methods
+    /// # See Also
     ///
     /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
-    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
-    ///   method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///   modify entry only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html
@@ -729,7 +729,7 @@ where
     ///
     /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
     ///   the [`and_compute_with`] method.
-    /// - If you only want to put, use the [`and_upsert_with`] method.
+    /// - If you only want to update or insert, use the [`and_upsert_with`] method.
     ///
     /// [`Entry<K, V>`]: ../struct.Entry.html
     /// [`Op<V>`]: ../ops/compute/enum.Op.html

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -38,6 +38,120 @@ where
         }
     }
 
+    /// Performs a compute operation on a cached entry by using the given closure
+    /// `f`. A compute operation is either put, remove or no-operation (nop).
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return an `ops::compute::Op<V>` enum.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get an
+    ///    `ops::compute::Op<V>`.
+    /// 2. Execute the op on the cache:
+    ///    - `Op::Put(V)`: Put the new value `V` to the cache.
+    ///    - `Op::Remove`: Remove the current cached entry.
+    ///    - `Op::Nop`: Do nothing.
+    /// 3. Return an `(Option<Entry>, ops::compute::PerformedOp)` as the followings:
+    ///
+    /// | [`Op<V>`] | `Entry` to return           | [`PerformedOp`]         |
+    /// |:--------- |:--------------------------- |:----------------------- |
+    /// | `Put(V)`  | The inserted/updated entry  | `Inserted` or `Updated` |
+    /// | `Remove`  | The _removed_ entry         | `Removed`               |
+    /// | `Nop`     | The current entry or `None` | `Nop`                   |
+    ///
+    /// **Notes:**
+    ///
+    /// - `Op::Put(V)`: `PerformedOp::Updated` is returned when the key already
+    ///   existed in the cache. It is _not_ related to whether the value was actually
+    ///   updated or not. It can be replaced with the same value.
+    /// - `Op::Remove`: Unlike other ops, the _removed_ entry is returned. If you mix
+    ///   `Remove` with other ops, ensure to check whether the performed op is
+    ///   `Removed` or not.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
+    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
+    ///   method.
+    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`Op<V>`]: ../ops/compute/enum.Op.html
+    /// [`PerformedOp`]: ../ops/compute/enum.PerformedOp.html
+    /// [`and_upsert_with`]: #method.and_upsert_with
+    /// [`and_try_compute_with`]: #method.and_try_compute_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::{
+    ///     sync::Cache,
+    ///     ops::compute::{self, PerformedOp},
+    ///     Entry,
+    /// };
+    ///
+    /// let cache: Cache<String, u64> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// /// Increment a cached `u64` counter. If the counter is greater than or
+    /// /// equal to 2, remove it.
+    /// fn inclement_or_remove_counter(
+    ///     cache: &Cache<String, u64>,
+    ///     key: &str,
+    /// ) -> (Option<Entry<String, u64>>, compute::PerformedOp) {
+    ///     cache
+    ///         .entry(key.to_string())
+    ///         .and_compute_with(|maybe_entry| {
+    ///             if let Some(entry) = maybe_entry {
+    ///                 let counter = entry.into_value();
+    ///                 if counter < 2 {
+    ///                     compute::Op::Put(counter.saturating_add(1)) // Update
+    ///                 } else {
+    ///                     compute::Op::Remove // Remove
+    ///                 }
+    ///             } else {
+    ///                   compute::Op::Put(1) // Insert
+    ///             }
+    ///         })
+    /// }
+    ///
+    /// // This should insert a now counter value 1 to the cache, and return the
+    /// // value with the kind of the operation performed.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 1);
+    /// assert_eq!(performed_op, PerformedOp::Inserted);
+    ///
+    /// // This should increment the cached counter value by 1.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 2);
+    /// assert_eq!(performed_op, PerformedOp::Updated);
+    ///
+    /// // This should remove the cached counter from the cache, and returns the
+    /// // _removed_ value.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 2);
+    /// assert_eq!(performed_op, PerformedOp::Removed);
+    ///
+    /// // The key should no longer exist.
+    /// assert!(!cache.contains_key(&key));
+    ///
+    /// // This should start over; insert a new counter value 1 to the cache.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 1);
+    /// assert_eq!(performed_op, PerformedOp::Inserted);
+    /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_compute_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
     pub fn and_compute_with<F>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
     where
         F: FnOnce(Option<Entry<K, V>>) -> compute::Op<V>,
@@ -46,6 +160,64 @@ where
         self.cache.compute_with_hash_and_fun(key, self.hash, f)
     }
 
+    /// Performs a compute operation on a cached entry by using the given closure
+    /// `f`. A compute operation is either put, remove or no-operation (nop).
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a `Result<ops::compute::Op<V>, E>`.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a
+    ///    `Result<ops::compute::Op<V>, E>`.
+    /// 2. If resolved to `Err(E)`, return it.
+    /// 3. Else, execute the op on the cache:
+    ///    - `Ok(Op::Put(V))`: Put the new value `V` to the cache.
+    ///    - `Ok(Op::Remove)`: Remove the current cached entry.
+    ///    - `Ok(Op::Nop)`: Do nothing.
+    /// 4. Return a `Ok((Option<Entry>, ops::compute::PerformedOp))` as the
+    ///    followings:
+    ///
+    /// | [`Op<V>`] | `Entry` to return           | [`PerformedOp`]         |
+    /// |:--------- |:--------------------------- |:----------------------- |
+    /// | `Put(V)`  | The inserted/updated entry  | `Inserted` or `Updated` |
+    /// | `Remove`  | The _removed_ entry         | `Removed`               |
+    /// | `Nop`     | The current entry or `None` | `Nop`                   |
+    ///
+    /// **Notes:**
+    ///
+    /// - `Ok(Op::Put(V))`: `PerformedOp::Updated` is returned when the key already
+    ///   existed in the cache. It is _not_ related to whether the value was actually
+    ///   updated or not. It can be replaced with the same value.
+    /// - `Ok(Op::Remove)`: Unlike other ops, the _removed_ entry is returned. If you
+    ///   mix `Remove` with other ops, ensure to check whether the performed op is
+    ///   `Removed` or not.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
+    ///   the [`and_compute_with`] method.
+    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`Op<V>`]: ../ops/compute/enum.Op.html
+    /// [`PerformedOp`]: ../ops/compute/enum.PerformedOp.html
+    /// [`and_upsert_with`]: #method.and_upsert_with
+    /// [`and_compute_with`]: #method.and_compute_with
+    ///
+    /// # Example
+    ///
+    /// See [`try_append_value_async.rs`] in the `examples` directory.
+    ///
+    /// [`try_append_value_sync.rs`]:
+    ///     https://github.com/moka-rs/moka/tree/main/examples/try_append_value_sync.rs
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_try_compute_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
     pub fn and_try_compute_with<F, E>(
         self,
         f: F,
@@ -58,6 +230,78 @@ where
         self.cache.try_compute_with_hash_and_fun(key, self.hash, f)
     }
 
+    /// Performs an upsert of an [`Entry`] by using the given closure `f`. The word
+    /// "upsert" here means "update" or "insert".
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a new value `V`.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a new value
+    ///    `V`.
+    /// 2. Upsert the new value to the cache.
+    /// 3. Return the `Entry` having the upserted value.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want to optionally upsert, that is to upsert only when certain
+    ///   conditions meet, use the [`and_compute_with`] method.
+    /// - If you try to upsert, that is to make the `Future` resolve to `Result<V>`
+    ///   instead of `V`, and upsert only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`and_compute_with`]: #method.and_compute_with
+    /// [`and_try_compute_with`]: #method.and_try_compute_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, u64> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache
+    ///     .entry(key.clone())
+    ///     .and_upsert_with(|maybe_entry| {
+    ///         if let Some(entry) = maybe_entry {
+    ///             entry.into_value().saturating_add(1) // Update
+    ///         } else {
+    ///             1 // Insert
+    ///         }
+    ///     });
+    /// // It was not an update.
+    /// assert!(!entry.is_updated());
+    /// assert_eq!(entry.key(), &key);
+    /// assert_eq!(entry.into_value(), 1);
+    ///
+    /// let entry = cache
+    ///     .entry(key.clone())
+    ///     .and_upsert_with(|maybe_entry| {
+    ///         if let Some(entry) = maybe_entry {
+    ///             entry.into_value().saturating_add(1)
+    ///         } else {
+    ///             1
+    ///         }
+    ///     });
+    /// // It was an update.
+    /// assert!(entry.is_updated());
+    /// assert_eq!(entry.key(), &key);
+    /// assert_eq!(entry.into_value(), 2);
+    /// ```
+    ///
+    /// Note: The `is_updated` method of the `Entry` returns `true` when the key
+    /// already existed in the cache. It is not related to whether the value was
+    /// actually updated or not. It can be replaced with the same value.
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_upsert_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
     pub fn and_upsert_with<F>(self, f: F) -> Entry<K, V>
     where
         F: FnOnce(Option<Entry<K, V>>) -> V,
@@ -353,6 +597,120 @@ where
         }
     }
 
+    /// Performs a compute operation on a cached entry by using the given closure
+    /// `f`. A compute operation is either put, remove or no-operation (nop).
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return an `ops::compute::Op<V>` enum.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get an
+    ///    `ops::compute::Op<V>`.
+    /// 2. Execute the op on the cache:
+    ///    - `Op::Put(V)`: Put the new value `V` to the cache.
+    ///    - `Op::Remove`: Remove the current cached entry.
+    ///    - `Op::Nop`: Do nothing.
+    /// 3. Return an `(Option<Entry>, ops::compute::PerformedOp)` as the followings:
+    ///
+    /// | [`Op<V>`] | `Entry` to return           | [`PerformedOp`]         |
+    /// |:--------- |:--------------------------- |:----------------------- |
+    /// | `Put(V)`  | The inserted/updated entry  | `Inserted` or `Updated` |
+    /// | `Remove`  | The _removed_ entry         | `Removed`               |
+    /// | `Nop`     | The current entry or `None` | `Nop`                   |
+    ///
+    /// **Notes:**
+    ///
+    /// - `Op::Put(V)`: `PerformedOp::Updated` is returned when the key already
+    ///   existed in the cache. It is _not_ related to whether the value was actually
+    ///   updated or not. It can be replaced with the same value.
+    /// - `Op::Remove`: Unlike other ops, the _removed_ entry is returned. If you mix
+    ///   `Remove` with other ops, ensure to check whether the performed op is
+    ///   `Removed` or not.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want the `Future` resolve to `Result<Op<V>>` instead of `Op<V>`, and
+    ///   upsert only when resolved to `Ok(V)`, use the [`and_try_compute_with`]
+    ///   method.
+    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`Op<V>`]: ../ops/compute/enum.Op.html
+    /// [`PerformedOp`]: ../ops/compute/enum.PerformedOp.html
+    /// [`and_upsert_with`]: #method.and_upsert_with
+    /// [`and_try_compute_with`]: #method.and_try_compute_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::{
+    ///     sync::Cache,
+    ///     ops::compute::{self, PerformedOp},
+    ///     Entry,
+    /// };
+    ///
+    /// let cache: Cache<String, u64> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// /// Increment a cached `u64` counter. If the counter is greater than or
+    /// /// equal to 2, remove it.
+    /// fn inclement_or_remove_counter(
+    ///     cache: &Cache<String, u64>,
+    ///     key: &str,
+    /// ) -> (Option<Entry<String, u64>>, compute::PerformedOp) {
+    ///     cache
+    ///         .entry_by_ref(key)
+    ///         .and_compute_with(|maybe_entry| {
+    ///             if let Some(entry) = maybe_entry {
+    ///                 let counter = entry.into_value();
+    ///                 if counter < 2 {
+    ///                     compute::Op::Put(counter.saturating_add(1)) // Update
+    ///                 } else {
+    ///                     compute::Op::Remove // Remove
+    ///                 }
+    ///             } else {
+    ///                   compute::Op::Put(1) // Insert
+    ///             }
+    ///         })
+    /// }
+    ///
+    /// // This should insert a now counter value 1 to the cache, and return the
+    /// // value with the kind of the operation performed.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 1);
+    /// assert_eq!(performed_op, PerformedOp::Inserted);
+    ///
+    /// // This should increment the cached counter value by 1.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 2);
+    /// assert_eq!(performed_op, PerformedOp::Updated);
+    ///
+    /// // This should remove the cached counter from the cache, and returns the
+    /// // _removed_ value.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 2);
+    /// assert_eq!(performed_op, PerformedOp::Removed);
+    ///
+    /// // The key should no longer exist.
+    /// assert!(!cache.contains_key(&key));
+    ///
+    /// // This should start over; insert a new counter value 1 to the cache.
+    /// let (maybe_entry, performed_op) = inclement_or_remove_counter(&cache, &key);
+    /// let entry = maybe_entry.expect("An entry should be returned");
+    /// assert_eq!(entry.into_value(), 1);
+    /// assert_eq!(performed_op, PerformedOp::Inserted);
+    /// ```
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_compute_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
     pub fn and_compute_with<F>(self, f: F) -> (Option<Entry<K, V>>, compute::PerformedOp)
     where
         F: FnOnce(Option<Entry<K, V>>) -> compute::Op<V>,
@@ -361,6 +719,64 @@ where
         self.cache.compute_with_hash_and_fun(key, self.hash, f)
     }
 
+    /// Performs a compute operation on a cached entry by using the given closure
+    /// `f`. A compute operation is either put, remove or no-operation (nop).
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a `Result<ops::compute::Op<V>, E>`.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a
+    ///    `Result<ops::compute::Op<V>, E>`.
+    /// 2. If resolved to `Err(E)`, return it.
+    /// 3. Else, execute the op on the cache:
+    ///    - `Ok(Op::Put(V))`: Put the new value `V` to the cache.
+    ///    - `Ok(Op::Remove)`: Remove the current cached entry.
+    ///    - `Ok(Op::Nop)`: Do nothing.
+    /// 4. Return a `Ok((Option<Entry>, ops::compute::PerformedOp))` as the
+    ///    followings:
+    ///
+    /// | [`Op<V>`] | `Entry` to return           | [`PerformedOp`]         |
+    /// |:--------- |:--------------------------- |:----------------------- |
+    /// | `Put(V)`  | The inserted/updated entry  | `Inserted` or `Updated` |
+    /// | `Remove`  | The _removed_ entry         | `Removed`               |
+    /// | `Nop`     | The current entry or `None` | `Nop`                   |
+    ///
+    /// **Notes:**
+    ///
+    /// - `Ok(Op::Put(V))`: `PerformedOp::Updated` is returned when the key already
+    ///   existed in the cache. It is _not_ related to whether the value was actually
+    ///   updated or not. It can be replaced with the same value.
+    /// - `Ok(Op::Remove)`: Unlike other ops, the _removed_ entry is returned. If you
+    ///   mix `Remove` with other ops, ensure to check whether the performed op is
+    ///   `Removed` or not.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want the `Future` resolve to `Op<V>` instead of `Result<Op<V>>`, use
+    ///   the [`and_compute_with`] method.
+    /// - If you only want to put, use the [`and_upsert_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`Op<V>`]: ../ops/compute/enum.Op.html
+    /// [`PerformedOp`]: ../ops/compute/enum.PerformedOp.html
+    /// [`and_upsert_with`]: #method.and_upsert_with
+    /// [`and_compute_with`]: #method.and_compute_with
+    ///
+    /// # Example
+    ///
+    /// See [`try_append_value_async.rs`] in the `examples` directory.
+    ///
+    /// [`try_append_value_sync.rs`]:
+    ///     https://github.com/moka-rs/moka/tree/main/examples/try_append_value_sync.rs
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_try_compute_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
     pub fn and_try_compute_with<F, E>(
         self,
         f: F,
@@ -373,6 +789,78 @@ where
         self.cache.try_compute_with_hash_and_fun(key, self.hash, f)
     }
 
+    /// Performs an upsert of an [`Entry`] by using the given closure `f`. The word
+    /// "upsert" here means "update" or "insert".
+    ///
+    /// The closure `f` should take the current entry of `Option<Entry<K, V>>` for
+    /// the key, and return a new value `V`.
+    ///
+    /// This method works as the followings:
+    ///
+    /// 1. Apply the closure `f` to the current cached `Entry`, and get a new value
+    ///    `V`.
+    /// 2. Upsert the new value to the cache.
+    /// 3. Return the `Entry` having the upserted value.
+    ///
+    /// # Similar Methods
+    ///
+    /// - If you want to optionally upsert, that is to upsert only when certain
+    ///   conditions meet, use the [`and_compute_with`] method.
+    /// - If you try to upsert, that is to make the `Future` resolve to `Result<V>`
+    ///   instead of `V`, and upsert only when resolved to `Ok(V)`, use the
+    ///   [`and_try_compute_with`] method.
+    ///
+    /// [`Entry`]: ../struct.Entry.html
+    /// [`and_compute_with`]: #method.and_compute_with
+    /// [`and_try_compute_with`]: #method.and_try_compute_with
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use moka::sync::Cache;
+    ///
+    /// let cache: Cache<String, u64> = Cache::new(100);
+    /// let key = "key1".to_string();
+    ///
+    /// let entry = cache
+    ///     .entry_by_ref(&key)
+    ///     .and_upsert_with(|maybe_entry| {
+    ///         if let Some(entry) = maybe_entry {
+    ///             entry.into_value().saturating_add(1) // Update
+    ///         } else {
+    ///             1 // Insert
+    ///         }
+    ///     });
+    /// // It was not an update.
+    /// assert!(!entry.is_updated());
+    /// assert_eq!(entry.key(), &key);
+    /// assert_eq!(entry.into_value(), 1);
+    ///
+    /// let entry = cache
+    ///     .entry_by_ref(&key)
+    ///     .and_upsert_with(|maybe_entry| {
+    ///         if let Some(entry) = maybe_entry {
+    ///             entry.into_value().saturating_add(1)
+    ///         } else {
+    ///             1
+    ///         }
+    ///     });
+    /// // It was an update.
+    /// assert!(entry.is_updated());
+    /// assert_eq!(entry.key(), &key);
+    /// assert_eq!(entry.into_value(), 2);
+    /// ```
+    ///
+    /// Note: The `is_updated` method of the `Entry` returns `true` when the key
+    /// already existed in the cache. It is not related to whether the value was
+    /// actually updated or not. It can be replaced with the same value.
+    ///
+    /// # Concurrent calls on the same key
+    ///
+    /// This method guarantees that concurrent calls on the same key are executed
+    /// serially. That is, `and_upsert_with` calls on the same key never run
+    /// concurrently. The calls are serialized by the order of their invocation. It
+    /// uses a key-level lock to achieve this.
     pub fn and_upsert_with<F>(self, f: F) -> Entry<K, V>
     where
         F: FnOnce(Option<Entry<K, V>>) -> V,

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -284,12 +284,14 @@ where
         RefKeyEntrySelector::new(key, hash, cache)
     }
 
+    /// TODO: Remove this in v0.13.0.
     /// Deprecated, replaced with [`get_with`](#method.get_with)
     #[deprecated(since = "0.8.0", note = "Replaced with `get_with`")]
     pub fn get_or_insert_with(&self, key: K, init: impl FnOnce() -> V) -> V {
         self.get_with(key, init)
     }
 
+    /// TODO: Remove this in v0.13.0.
     /// Deprecated, replaced with [`try_get_with`](#method.try_get_with)
     #[deprecated(since = "0.8.0", note = "Replaced with `try_get_with`")]
     pub fn get_or_try_insert_with<F, E>(&self, key: K, init: F) -> Result<V, Arc<E>>

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -170,7 +170,6 @@ where
                     }
                     Err(e) => {
                         let err: ErrorObject = Arc::new(e);
-
                         *lock = WaiterValue::Ready(Err(Arc::clone(&err)));
                         InitResult::InitErr(err.downcast().unwrap())
                     }
@@ -301,8 +300,8 @@ where
             Op::Remove => {
                 let maybe_prev_v = cache.remove(&c_key, c_hash);
                 if let Some(prev_v) = maybe_prev_v {
-                    let entry = Entry::new(Some(c_key), prev_v, false, false);
                     crossbeam_epoch::pin().flush();
+                    let entry = Entry::new(Some(c_key), prev_v, false, false);
                     Ok(CompResult::Removed(entry))
                 } else {
                     Ok(CompResult::StillNone(c_key))

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -1,23 +1,64 @@
 use parking_lot::RwLock;
 use std::{
     any::{Any, TypeId},
+    fmt,
     hash::{BuildHasher, Hash},
     sync::Arc,
 };
 use triomphe::Arc as TrioArc;
 
-use super::OptionallyNone;
+use crate::{ops::compute, Entry};
+
+use super::{ComputeNone, OptionallyNone};
 
 const WAITER_MAP_NUM_SEGMENTS: usize = 64;
 
+pub(crate) trait GetOrInsert<K, V> {
+    fn get_entry_without_recording(&self, key: &Arc<K>, hash: u64) -> Option<Entry<K, V>>
+    where
+        V: 'static;
+
+    fn insert(&self, key: Arc<K>, hash: u64, value: V);
+
+    fn remove(&self, key: &Arc<K>, hash: u64) -> Option<V>;
+}
+
 type ErrorObject = Arc<dyn Any + Send + Sync + 'static>;
-type WaiterValue<V> = Option<Result<V, ErrorObject>>;
+
+// type WaiterValue<V> = Option<Result<V, ErrorObject>>;
+enum WaiterValue<V> {
+    Computing,
+    Ready(Result<V, ErrorObject>),
+    ReadyNone,
+    // https://github.com/moka-rs/moka/issues/43
+    InitFuturePanicked,
+}
+
+impl<V> fmt::Debug for WaiterValue<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WaiterValue::Computing => write!(f, "Computing"),
+            WaiterValue::Ready(_) => write!(f, "Ready"),
+            WaiterValue::ReadyNone => write!(f, "ReadyNone"),
+            WaiterValue::InitFuturePanicked => write!(f, "InitFuturePanicked"),
+        }
+    }
+}
+
 type Waiter<V> = TrioArc<RwLock<WaiterValue<V>>>;
 
 pub(crate) enum InitResult<V, E> {
     Initialized(V),
     ReadExisting(V),
     InitErr(Arc<E>),
+}
+
+pub(crate) enum ComputeResult<V, E> {
+    Inserted(V),
+    Updated(V),
+    Removed(V),
+    Nop(Option<V>),
+    EvalErr(E),
 }
 
 pub(crate) struct ValueInitializer<K, V, S> {
@@ -70,7 +111,7 @@ where
 
         let (w_key, w_hash) = self.waiter_key_hash(key, type_id);
 
-        let waiter = TrioArc::new(RwLock::new(None));
+        let waiter = TrioArc::new(RwLock::new(WaiterValue::Computing));
         let mut lock = waiter.write();
 
         loop {
@@ -82,10 +123,10 @@ where
             // Somebody else's waiter already exists, so wait for its result to become available.
             let waiter_result = existing_waiter.read();
             match &*waiter_result {
-                Some(Ok(value)) => return ReadExisting(value.clone()),
-                Some(Err(e)) => return InitErr(Arc::clone(e).downcast().unwrap()),
-                // None means somebody else's init closure has been panicked.
-                None => {
+                WaiterValue::Ready(Ok(value)) => return ReadExisting(value.clone()),
+                WaiterValue::Ready(Err(e)) => return InitErr(Arc::clone(e).downcast().unwrap()),
+                // Somebody else's init closure has been panicked.
+                WaiterValue::InitFuturePanicked => {
                     retries += 1;
                     assert!(
                         retries < MAX_RETRIES,
@@ -96,6 +137,11 @@ where
                     // Retry from the beginning.
                     continue;
                 }
+                // Unexpected state.
+                s @ (WaiterValue::Computing | WaiterValue::ReadyNone) => panic!(
+                    "Got unexpected state `{s:?}` after resolving `init` future. \
+                    This might be a bug in Moka"
+                ),
             }
         }
 
@@ -105,7 +151,7 @@ where
         if let Some(value) = get() {
             // Yes. Set the waiter value, remove our waiter, and return
             // the existing value.
-            *lock = Some(Ok(value.clone()));
+            *lock = WaiterValue::Ready(Ok(value.clone()));
             self.remove_waiter(w_key, w_hash);
             return InitResult::ReadExisting(value);
         }
@@ -116,32 +162,134 @@ where
         match catch_unwind(AssertUnwindSafe(init)) {
             // Evaluated.
             Ok(value) => {
-                let (waiter_val, init_res) = match post_init(value) {
+                let init_res = match post_init(value) {
                     Ok(value) => {
                         insert(value.clone());
-                        (Some(Ok(value.clone())), InitResult::Initialized(value))
+                        *lock = WaiterValue::Ready(Ok(value.clone()));
+                        InitResult::Initialized(value)
                     }
                     Err(e) => {
                         let err: ErrorObject = Arc::new(e);
-                        (
-                            Some(Err(Arc::clone(&err))),
-                            InitResult::InitErr(err.downcast().unwrap()),
-                        )
+
+                        *lock = WaiterValue::Ready(Err(Arc::clone(&err)));
+                        InitResult::InitErr(err.downcast().unwrap())
                     }
                 };
-                *lock = waiter_val;
                 self.remove_waiter(w_key, w_hash);
                 init_res
             }
             // Panicked.
             Err(payload) => {
-                *lock = None;
+                *lock = WaiterValue::InitFuturePanicked;
                 // Remove the waiter so that others can retry.
                 self.remove_waiter(w_key, w_hash);
                 resume_unwind(payload);
             }
         }
         // The write lock will be unlocked here.
+    }
+
+    /// # Panics
+    /// Panics if the `init` future has been panicked.
+    pub(crate) fn try_compute<'a, C, F, O, E>(
+        &'a self,
+        c_key: &Arc<K>,
+        c_hash: u64,
+        cache: &C, // Future to initialize a new value.
+        f: F,
+        post_init: fn(O) -> Result<compute::Op<V>, E>,
+        allow_nop: bool,
+    ) -> ComputeResult<V, E>
+    where
+        V: 'static,
+        C: GetOrInsert<K, V> + Send + 'a,
+        F: FnOnce(Option<Entry<K, V>>) -> O,
+        E: Send + Sync + 'static,
+    {
+        use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+        use ComputeResult::{EvalErr, Inserted, Nop, Removed, Updated};
+
+        let type_id = TypeId::of::<ComputeNone>();
+
+        let (w_key, w_hash) = self.waiter_key_hash(c_key, type_id);
+
+        let waiter = TrioArc::new(RwLock::new(WaiterValue::Computing));
+        // NOTE: We have to acquire a write lock before `try_insert_waiter`,
+        // so that any concurrent attempt will get our lock and wait on it.
+        let mut lock = waiter.write();
+
+        loop {
+            let Some(existing_waiter) = self.try_insert_waiter(w_key.clone(), w_hash, &waiter)
+            else {
+                break;
+            };
+
+            // Somebody else's waiter already exists, so wait for its result to become available.
+            let waiter_result = existing_waiter.read();
+            match &*waiter_result {
+                // Unexpected state.
+                WaiterValue::Computing => panic!(
+                    "Got unexpected state `Computing` after resolving `init` future. \
+                    This might be a bug in Moka"
+                ),
+                _ => {
+                    // Retry from the beginning.
+                    continue;
+                }
+            }
+        }
+
+        // Our waiter was inserted.
+
+        // Get the current value.
+        let maybe_entry = cache.get_entry_without_recording(c_key, c_hash);
+        let maybe_value = if allow_nop {
+            maybe_entry.as_ref().map(|ent| ent.value().clone())
+        } else {
+            None
+        };
+        let entry_existed = maybe_entry.is_some();
+
+        // Let's evaluate the `f` closure and get a future. Catching panic is safe
+        // here as we will not evaluate the closure again.
+        match catch_unwind(AssertUnwindSafe(|| f(maybe_entry))) {
+            // Evaluated.
+            Ok(op) => {
+                let init_res = match post_init(op) {
+                    Ok(op) => match op {
+                        compute::Op::Nop => Nop(maybe_value),
+                        compute::Op::Put(value) => {
+                            cache.insert(Arc::clone(c_key), c_hash, value.clone());
+                            if entry_existed {
+                                Updated(value)
+                            } else {
+                                Inserted(value)
+                            }
+                        }
+                        compute::Op::Remove => {
+                            let maybe_prev_v = cache.remove(c_key, c_hash);
+                            if let Some(prev_v) = maybe_prev_v {
+                                Removed(prev_v)
+                            } else {
+                                Nop(None)
+                            }
+                        }
+                    },
+                    Err(e) => EvalErr(e),
+                };
+                *lock = WaiterValue::ReadyNone;
+                self.remove_waiter(w_key, w_hash);
+                init_res
+            }
+            // Panicked.
+            Err(payload) => {
+                *lock = WaiterValue::InitFuturePanicked;
+                // Remove the waiter so that others can retry.
+                self.remove_waiter(w_key, w_hash);
+                resume_unwind(payload);
+            }
+        }
+        // The lock will be unlocked here.
     }
 
     /// The `post_init` function for the `get_with` method of cache.
@@ -163,6 +311,26 @@ where
     /// The `post_init` function for `try_get_with` method of cache.
     pub(crate) fn post_init_for_try_get_with<E>(result: Result<V, E>) -> Result<V, E> {
         result
+    }
+
+    /// The `post_init` function for the `and_upsert_with` method of cache.
+    pub(crate) fn post_init_for_upsert_with(value: V) -> Result<compute::Op<V>, ()> {
+        Ok(compute::Op::Put(value))
+    }
+
+    /// The `post_init` function for the `and_compute_with` method of cache.
+    pub(crate) fn post_init_for_compute_with(op: compute::Op<V>) -> Result<compute::Op<V>, ()> {
+        Ok(op)
+    }
+
+    /// The `post_init` function for the `and_try_compute_with` method of cache.
+    pub(crate) fn post_init_for_try_compute_with<E>(
+        op: Result<compute::Op<V>, E>,
+    ) -> Result<compute::Op<V>, E>
+    where
+        E: Send + Sync + 'static,
+    {
+        op
     }
 
     /// Returns the `type_id` for `get_with` method of cache.

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -357,7 +357,7 @@ where
                 is_expiry_modified,
             };
             read_recorder(op, now);
-            Some(Entry::new(maybe_key, v, false))
+            Some(Entry::new(maybe_key, v, false, false))
         } else {
             read_recorder(ReadOp::Miss(hash), now);
             None


### PR DESCRIPTION
Fixes #227, #353.

This PR adds compute family-methods to the `entry` API. They take a closure to insert, update, or remove a value for a key depending on the current cached value.

Also bumps the version to `v0.12.3`.

## API: `future::Cache`

```rust
/// Upsert (update or insert) the cached entry.
pub async fn and_upsert_with<F, Fut>(self, f: F) -> Entry<K, V>
where
    F: FnOnce(Option<Entry<K, V>>) -> Fut,
    Fut: Future<Output = V>;


/// Upsert, remove or nop (no-operation) on the cached entry.
pub async fn and_compute_with<F, Fut>(self, f: F) -> compute::CompResult<K, V>)
where
    F: FnOnce(Option<Entry<K, V>>) -> Fut,
    Fut: Future<Output = compute::Op<V>>;


/// When Ok(Op), upsert, remove or nop (no-operation) on the cached entry.
/// Otherwise return Err(E)
pub async fn and_try_compute_with<F, Fut, E>(
    self,
    f: F,
) -> Result<compute::CompResult<K, V>, E>
where
    F: FnOnce(Option<Entry<K, V>>) -> Fut,
    Fut: Future<Output = Result<compute::Op<V>, E>>,
    E: Send + Sync + 'static;
```

### Examples

See the following examples in the `examples` directory of the `compute-api` branch:

- [counter_async.rs](https://github.com/moka-rs/moka/blob/compute-api/examples/counter_async.rs)
    - Uses the `and_upsert_with` method.
    - Atomically increment a cached `u64`.
- [bounded_counter_async.rs](https://github.com/moka-rs/moka/blob/compute-api/examples/bounded_counter_async.rs)
    - Uses the `and_compute_with` method.
    - Atomically increment a cached `u64` but reset (remove) it when it is 2.
- [append_value_async.rs](https://github.com/moka-rs/moka/blob/compute-api/examples/append_value_async.rs)
    - Uses the `and_upsert_with` method.
    - Atomically append an `i32` to a cached `Arc<RwLock<Vec<i32>>>`.
- [try_append_value_async.rs](https://github.com/moka-rs/moka/blob/compute-api/examples/try_append_value_async.rs)
    - Uses the `and_try_compute_with` method.
    - Atomically read an `char` and append to a cached `Arc<RwLock<String>>`, but reading can fail by EOF. 

## API: `sync::Cache` and `sync::SegmentedCache`

```rust
/// Upsert (update or insert) the cached entry.
pub fn and_upsert_with<F>(self, f: F) -> Entry<K, V>
where
    F: FnOnce(Option<Entry<K, V>>) -> V;


/// Upsert, remove or nop (no-operation) on the cached entry.
pub fn and_compute_with<F>(self, f: F) -> compute::CompResult<K, V>
where
    F: FnOnce(Option<Entry<K, V>>) -> compute::Op<V>;


/// When Ok(Op), upsert, remove or nop (no-operation) on the cached entry.
/// Otherwise return Err(E)
pub fn and_try_compute_with<F, E>(
    self,
    f: F,
) -> Result<compute::CompResult<K, V>, E>
where
    F: FnOnce(Option<Entry<K, V>>) -> Result<compute::Op<V>, E>,
    E: Send + Sync + 'static;
```

## Tasks

`future::Cache`:

- `and_upsert_with` method. (upsert: insert or update)
    - [x] Implementation.
    - [x] Automated tests.
    - [x] Documents.
    - [x] Examples.
- `and_compute_with` method.
    - [x] Implementation.
    - [x] Automated tests.
    - [x] Documents.
    - [x] Examples.
- `and_try_compute_with` method.
    - [x] Implementation.
    - [x] Automated tests.
    - [x] Documents.
    - [x] Examples.

`sync::Cache`, `sync::SegmentedCache`:

- `and_upsert_with` method. (upsert: insert or update)
    - [x] Implementation.
    - [x] Automated tests.
    - [x] Documents.
    - [x] Examples.
- `and_compute_with` method.
    - [x] Implementation.
    - [x] Automated tests.
    - [x] Documents.
    - [x] Examples.
- `and_try_compute_with` method.
    - [x] Implementation.
    - [x] Automated tests.
    - [x] Documents.
    - [x] Examples.
