### PR TITLE
Remove a comment about a race condition from the eviction listener example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,11 @@
 # Moka Examples
 
 This directory contains examples of how to use Moka cache. Each example is a
-standalone binary that can be run with `cargo run --example <example_name>`.
+standalone binary that can be run with the following command:
+
+```console
+$ cargo run --example <example_name> -F sync,future
+```
 
 Each example has a suffix `_async` or `_sync`:
 

--- a/examples/eviction_listener_sync.rs
+++ b/examples/eviction_listener_sync.rs
@@ -17,8 +17,7 @@ fn main() {
         cache.insert(&0, "zero".to_string());
         cache.insert(&1, "one".to_string());
         cache.insert(&2, "twice".to_string());
-        // Due to race condition spilled over maybe evicted twice by cause
-        // Replaced and Size.
+        // This causes "twice" to be evicted by cause Replaced.
         cache.insert(&2, "two".to_string());
         // With 1-second ttl, keys 0 and 1 will be evicted if we wait long enough.
         sleep(Duration::from_secs(ttl + 1));


### PR DESCRIPTION
Remove the following comment from the `eviction_listener_sync` example because it was addressed by #348 for `v0.12.2`.

```rust
        cache.insert(&2, "twice".to_string());
        // Due to race condition spilled over maybe evicted twice by cause
        // Replaced and Size.
        cache.insert(&2, "two".to_string());
```


**v0.12.1**

```console
$ cargo run --example eviction_listener -F sync

Evicted (2,"twice") because Replaced
Wake up!
Evicted (2,"twice") because Size
Evicted (2,"two") because Size
Evicted (0,"zero") because Expired
Evicted (1,"one") because Expired
Evicted (3,"three") because Explicit
Evicted (4,"four") because Explicit
Evicted (5,"five") because Explicit
Cache structure removed.
Exit program.
```

**v0.12.2**

```console
$ cargo run --example eviction_listener -F sync

Evicted (2,"twice") because Replaced
Wake up!
Evicted (2,"two") because Size
Evicted (0,"zero") because Expired
Evicted (1,"one") because Expired
Evicted (3,"three") because Explicit
Removed: three
Evicted (4,"four") because Explicit
Evicted (5,"five") because Explicit
Cache structure removed.
Exit program.
```
