### PR TITLE
Ensure `crossbeam-epoch` to run GC when dropping a cache

### DIFF
--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -89,12 +89,9 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
 
         // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
         // global bag so that previously cached values will be dropped.
-
-        // First call should push the `deferred_fn`s in the thread local storage
-        // (TLS) of the current thread to the global bag.
-        crossbeam_epoch::pin().flush();
-        // Second call should collect the `deferred_fn`s in the global bag.
-        crossbeam_epoch::pin().flush();
+        for _ in 0..10 {
+            crossbeam_epoch::pin().flush();
+        }
 
         // NOTE: inner, read_op_ch, and write_op_ch will be dropped after returning
         // from this `drop` method. They use crossbeam-epoch internally, but we do

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -89,7 +89,7 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
 
         // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
         // global bag so that previously cached values will be dropped.
-        for _ in 0..10 {
+        for _ in 0..128 {
             crossbeam_epoch::pin().flush();
         }
 

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -86,6 +86,20 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
     fn drop(&mut self) {
         // The housekeeper needs to be dropped before the inner is dropped.
         std::mem::drop(self.housekeeper.take());
+
+        // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
+        // global bag so that previously cached values will be dropped.
+
+        // First call should push the `deferred_fn`s in the thread local storage
+        // (TLS) of the current thread to the global bag.
+        crossbeam_epoch::pin().flush();
+        // Second call should collect the `deferred_fn`s in the global bag.
+        crossbeam_epoch::pin().flush();
+
+        // NOTE: inner, read_op_ch, and write_op_ch will be dropped after returning
+        // from this `drop` method. They use crossbeam-epoch internally, but we do
+        // not have to call `flush` for them because their `drop` methods do not
+        // create `deferred_fn`s, and drop their values in place.
     }
 }
 

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -86,20 +86,6 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
     fn drop(&mut self) {
         // The housekeeper needs to be dropped before the inner is dropped.
         std::mem::drop(self.housekeeper.take());
-
-        if Arc::strong_count(&self.inner) <= 1 {
-            dbg!(Arc::strong_count(&self.inner));
-            // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
-            // global bag so that previously cached values will be dropped.
-            for _ in 0..128 {
-                crossbeam_epoch::pin().flush();
-            }
-
-            // NOTE: The `inner` will be dropped after returning from this `drop`
-            // method. It uses crossbeam-epoch internally, but we do not have to call
-            // `flush` for it because its `drop` methods do not create
-            // `deferred_fn`s, and drop its values in place.
-        }
     }
 }
 
@@ -1062,6 +1048,21 @@ pub(crate) struct Inner<K, V, S> {
     key_locks: Option<KeyLockMap<K, S>>,
     invalidator: Option<Invalidator<K, V, S>>,
     clocks: Clocks,
+}
+
+impl<K, V, S> Drop for Inner<K, V, S> {
+    fn drop(&mut self) {
+        // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
+        // global bag so that previously cached values will be dropped.
+        for _ in 0..128 {
+            crossbeam_epoch::pin().flush();
+        }
+
+        // NOTE: The `CacheStore` (`cht`) will be dropped after returning from this
+        // `drop` method. It uses crossbeam-epoch internally, but we do not have to
+        // call `flush` for it because its `drop` methods do not create
+        // `deferred_fn`s, and drop its values in place.
+    }
 }
 
 //

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5454,6 +5454,18 @@ mod tests {
         assert_eq!(counters.value_dropped(), KEYS, "value_dropped");
     }
 
+    // https://github.com/moka-rs/moka/issues/383
+    #[tokio::test]
+    async fn ensure_gc_runs_when_dropping_cache() {
+        let cache = Cache::builder().build();
+        let val = Arc::new(0);
+        cache
+            .get_with(1, std::future::ready(Arc::clone(&val)))
+            .await;
+        drop(cache);
+        assert_eq!(Arc::strong_count(&val), 1);
+    }
+
     #[tokio::test]
     async fn test_debug_format() {
         let cache = Cache::new(10);

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -4831,6 +4831,19 @@ mod tests {
         assert_eq!(counters.value_dropped(), KEYS, "value_dropped");
     }
 
+    // https://github.com/moka-rs/moka/issues/383
+    #[test]
+    fn ensure_gc_runs_when_dropping_cache() {
+        let cache = Cache::builder().build();
+        let val = Arc::new(0);
+        {
+            let val = Arc::clone(&val);
+            cache.get_with(1, move || val);
+        }
+        drop(cache);
+        assert_eq!(Arc::strong_count(&val), 1);
+    }
+
     #[test]
     fn test_debug_format() {
         let cache = Cache::new(10);

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -78,7 +78,7 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
 
         // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
         // global bag so that previously cached values will be dropped.
-        for _ in 0..10 {
+        for _ in 0..128 {
             crossbeam_epoch::pin().flush();
         }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -76,16 +76,18 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
         // The housekeeper needs to be dropped before the inner is dropped.
         std::mem::drop(self.housekeeper.take());
 
-        // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
-        // global bag so that previously cached values will be dropped.
-        for _ in 0..128 {
-            crossbeam_epoch::pin().flush();
-        }
+        if Arc::strong_count(&self.inner) <= 1 {
+            // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
+            // global bag so that previously cached values will be dropped.
+            for _ in 0..128 {
+                crossbeam_epoch::pin().flush();
+            }
 
-        // NOTE: inner, read_op_ch, and write_op_ch will be dropped after returning
-        // from this `drop` method. They use crossbeam-epoch internally, but we do
-        // not have to call `flush` for them because their `drop` methods do not
-        // create `deferred_fn`s, and drop their values in place.
+            // NOTE: The `inner` will be dropped after returning from this `drop`
+            // method. It uses crossbeam-epoch internally, but we do not have to call
+            // `flush` for it because its `drop` methods do not create
+            // `deferred_fn`s, and drop its values in place.
+        }
     }
 }
 

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -78,12 +78,9 @@ impl<K, V, S> Drop for BaseCache<K, V, S> {
 
         // Ensure crossbeam-epoch to collect garbages (`deferred_fn`s) in the
         // global bag so that previously cached values will be dropped.
-
-        // First call should push the `deferred_fn`s in the thread local storage
-        // (TLS) of the current thread to the global bag.
-        crossbeam_epoch::pin().flush();
-        // Second call should collect the `deferred_fn`s in the global bag.
-        crossbeam_epoch::pin().flush();
+        for _ in 0..10 {
+            crossbeam_epoch::pin().flush();
+        }
 
         // NOTE: inner, read_op_ch, and write_op_ch will be dropped after returning
         // from this `drop` method. They use crossbeam-epoch internally, but we do


### PR DESCRIPTION
Fixes #383.

This PR ensures `crossbeam-epoch` to run GC (run the `deferred_fn`s in the global bag) when dropping a `moka` cache. This should help the entries, who are currently or previously in the cache, to be dropped.

We have been struggling this `crossbeam-epoch` spec for years. I added a comment to [our notes about this issue](https://github.com/orgs/moka-rs/projects/1?pane=issue&itemId=1314133).