### PR TITLE
CI: Stabilize `ensure_gc_runs_when_dropping_cache` test for `sync::Cache`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,6 +113,12 @@ jobs:
           command: test
           args: --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact --ignored
 
+      - name: Run tests (sync feature, drop cache)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+
       - name: Run tests (future feature, but no sync feature)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -98,6 +98,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: |
-            --release --lib --no-default-features --features sync \
-            sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+          args: --release --lib --no-default-features --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -93,3 +93,11 @@ jobs:
         with:
           command: test
           args: --no-default-features --features 'sync, future, atomic64, logging'
+
+      - name: Run tests (sync feature, but no quanta feature, drop cache)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: |
+            --release --lib --no-default-features --features sync \
+            sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -80,3 +80,9 @@ jobs:
         run: |
           cross ${{ matrix.platform.cargo-version }} test --release -F future \
             --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+
+      - name: Run tests (sync feature, drop cache)
+        run: |
+          cross ${{ matrix.platform.cargo-version }} test --release -F sync \
+            --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }} \
+            --lib sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -4831,8 +4831,12 @@ mod tests {
         assert_eq!(counters.value_dropped(), KEYS, "value_dropped");
     }
 
-    // https://github.com/moka-rs/moka/issues/383
+    // For testing the issue reported by: https://github.com/moka-rs/moka/issues/383
+    //
+    // Ignored by default. This test becomes unstable when run in parallel with
+    // other tests.
     #[test]
+    #[ignore]
     fn ensure_gc_runs_when_dropping_cache() {
         let cache = Cache::builder().build();
         let val = Arc::new(0);


### PR DESCRIPTION
Run a flaky test `ensure_gc_runs_when_dropping_cache` for `sync::Cache` separately from other tests to avoid interference from other tests running in parallel.

The test was added by #384 to mitigate #383.