### PR TITLE
CI: Remove `actions-rs` GH Actions from the CI where possible (v0.12.x)

### DIFF
--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust nightly toolchain with Miri
+      - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly

--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -28,34 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
-
-      - name: Install Rust toolchain (Nightly)
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+        uses: actions/checkout@v4
 
       - name: Check for known security vulnerabilities (Latest versions)
-        uses: actions-rs/audit-check@v1
+        uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Downgrade dependencies to minimal versions
-        uses: actions-rs/cargo@v1
+      - name: Install Rust nightly toolchain with Miri
+        uses: dtolnay/rust-toolchain@master
         with:
-          command: update
-          args: -Z minimal-versions
+          toolchain: nightly
+
+      - name: Downgrade dependencies to minimal versions
+        run: cargo update -Z minimal-versions
 
       - name: Check for known security vulnerabilities (Minimal versions)
-        uses: actions-rs/audit-check@v1
+        uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
       # 2-core CPU (x86_64), 7 GB of RAM
@@ -54,26 +54,13 @@ jobs:
           lscpu
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
 
       - name: Downgrade dependencies to minimal versions (Nightly only)
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: update
-          args: -Z minimal-versions
+        run: cargo update -Z minimal-versions
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
@@ -88,59 +75,32 @@ jobs:
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Show cargo tree
-        uses: actions-rs/cargo@v1
-        with:
-          command: tree
-          args: --features 'sync, future'
+        run: cargo tree --features 'sync, future'
 
       - name: Run tests (debug, sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features sync
+        run: cargo test --features sync
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (release, sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features sync
+        run: cargo test --release --features sync
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (sync feature, key lock test for notification)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact --ignored
 
       - name: Run tests (sync feature, drop value after eviction for sync::Cache)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact --ignored
 
       - name: Run tests (sync feature, drop value after eviction for sync::SegmentedCache)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact --ignored
 
       - name: Run tests (sync feature, drop cache)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
 
       - name: Run tests (future feature, but no sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features 'future, atomic64, quanta'
+        run: cargo test --no-default-features --features 'future, atomic64, quanta'
 
       - name: Run tests (future, sync and logging features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features 'future, sync, logging'
+        run: cargo test --features 'future, sync, logging'

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -44,29 +44,16 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
 
       - name: Downgrade dependencies to minimal versions (Nightly only)
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: update
-          args: -Z minimal-versions
+        run: cargo update -Z minimal-versions
 
       - name: Pin some dependencies to specific versions (Nightly only)
         if: ${{ matrix.rust == 'nightly' }}
@@ -81,35 +68,20 @@ jobs:
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Run tests (debug, but no quanta feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features 'sync, atomic64'
+        run: cargo test --no-default-features --features 'sync, atomic64'
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (release, but no quanta feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --no-default-features --features 'sync, atomic64'
+        run: cargo test --release --no-default-features --features 'sync, atomic64'
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (future feature, but no quanta and sync features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features 'future, atomic64'
+        run: cargo test --no-default-features --features 'future, atomic64'
 
       - name: Run tests (future, sync and logging features, but no quanta feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features 'sync, future, atomic64, logging'
+        run: cargo test --no-default-features --features 'sync, future, atomic64, logging'
 
       - name: Run tests (sync feature, but no quanta feature, drop cache)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --lib --no-default-features --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+        run: cargo test --release --lib --no-default-features --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Show CPU into
         run: |
@@ -44,6 +44,6 @@ jobs:
           free -m
 
       - name: Run Kani
-        uses: model-checking/kani-github-action@v0.28
+        uses: model-checking/kani-github-action@v1.0
         with:
           args: --features 'sync, future'

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -36,22 +36,13 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust.toolchain }}
-          override: true
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
@@ -62,8 +53,5 @@ jobs:
           RUSTFLAGS: ${{ matrix.rust.rustflags }}
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust.toolchain == 'stable' }}
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust.toolchain }}
           components: rustfmt, clippy
 
       - name: Run Clippy

--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -37,31 +37,18 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust nightly toolchain with Miri
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: miri
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+      - run: cargo miri setup
 
       - name: Run Miri test (deque)
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test deque --features 'sync, future'
+        run: cargo miri test deque --features 'sync, future'
 
       - name: Run Miri test (timer_wheel)
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test deque --features 'sync, future'
+        run: cargo miri test timer_wheel --features 'sync, future'

--- a/.github/workflows/Skeptic.yml
+++ b/.github/workflows/Skeptic.yml
@@ -35,52 +35,31 @@ jobs:
 
     steps:
       - name: Checkout Moka
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
-
       - name: Run tests (sync feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features sync
+        run: cargo test --release --features sync
         env:
           RUSTFLAGS: '--cfg skeptic'
 
       - name: Run tests (release, sync and future)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features 'sync, future'
+        run: cargo test --release --features 'sync, future'
         env:
           RUSTFLAGS: '--cfg skeptic'
 
       - name: Run tests (sync and future, without atomic64 and quanta)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --no-default-features --features 'sync, future'
+        run: cargo test --release --no-default-features --features 'sync, future'
         env:
           RUSTFLAGS: '--cfg skeptic'
 
       - name: Run compile error tests (sync and future features, trybuild)
-        uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'stable' }}
-        with:
-          command: test
-          args: ui_trybuild --release --features 'sync, future'
+        run: cargo test ui_trybuild --release --features 'sync, future'
         env:
           RUSTFLAGS: '--cfg trybuild'


### PR DESCRIPTION
- Remove `actions-rs` GitHub Actions from the CI, except Clippy lint:
    - Replace `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@master`.
    - Remove `actions-rs/cargo@v1` and use simple `run` action (e.g. `run: cargo test ...`).
    - Replace `actions-rs/audit-check@v1` with `rustsec/audit-check@v1`
- Upgrade `model-checking/kani-github-action` from `v0.28` to `v1.0`.