### PR TITLE
CI: Skip duplicate GitHub Actions (v0.10.x)

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -13,3 +13,16 @@ cargo update -p regex --precise 1.9.6
 cargo update -p memchr --precise 2.6.2
 cargo update -p h2 --precise 0.3.20
 cargo update -p actix-rt --precise 2.8.0
+cargo update -p cargo-platform --precise 0.1.5
+cargo update -p crossbeam-epoch --precise 0.9.15
+
+# To use memchr 2.5.0, we need to use regex 1.9.4 and regex-automata 0.3.7.
+cargo update -p regex --precise 1.9.4
+cargo update -p regex-automata --precise 0.3.7
+
+# The following crates require rustc to support target feature "neon",
+# which is unstable in Rust 1.60.0.
+cargo update -p aho-corasick --precise 1.0.5
+cargo update -p bytecount --precise 0.6.3
+cargo update -p memchr --precise 2.5.0
+cargo update -p value-bag --precise 1.4.1

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -5,4 +5,4 @@ set -eux
 # Pin some dependencies to specific versions for the nightly toolchain.
 cargo update -p openssl --precise 0.10.39
 cargo update -p cc --precise 1.0.61
-cargo update -p proc-macro2 --precise 1.0.60
+cargo update -p proc-macro2 --precise 1.0.63

--- a/.github/workflows/Audit.yml
+++ b/.github/workflows/Audit.yml
@@ -10,7 +10,21 @@ on:
     - cron: '5 20 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   audit:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Moka

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,8 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,21 @@ on:
     - cron: '0 20 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -33,6 +33,8 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -16,7 +16,21 @@ on:
     - cron: '0 20 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -11,7 +11,21 @@ on:
     - cron:  '0 19 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -18,7 +18,21 @@ on:
     - cron:  '0 21 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   linux-cross:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       # Continue running other jobs in the matrix even if one fails.

--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -18,7 +18,21 @@ on:
     - cron:  '0 21 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/Skeptic.yml
+++ b/.github/workflows/Skeptic.yml
@@ -11,7 +11,21 @@ on:
     - cron:  '0 21 * * 5'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
- Add `skip-duplicate-actions@v5` action to skip duplicate GitHub Actions in a pull request.
- Add `fail-fast: false` to CI and CIQuantaDisabled jobs.
- Fix the CI for nightly + minimal crate versions by pining the following crate:
    - `proc-macro2@v1.0.63`
- Fix the CI for the MSRV 1.60.0 by pining the following crates:
    - `aho-corasick@v1.0.5`
    - `bytecount@v0.6.3`
    - `cargo-platform@v0.1.5`
    - `crossbeam-epoch@v0.9.15`
    - `memchr@v2.5.0`
    - `regex-automata@v0.3.7`
    - `regex@v1.9.4`
    - `value-bag@v1.4.1`