### PR TITLE
CI: Fix the CI (remove Skeptic etc.) for v0.12.x

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -3,4 +3,4 @@
 set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
-cargo update -p cargo-platform --precise 0.1.5
+# cargo update -p <crate> --precise <version>

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -4,3 +4,5 @@ set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain.
 cargo update -p proc-macro2 --precise 1.0.63
+# https://github.com/tkaitchuck/aHash/issues/200
+cargo update -p ahash --precise 0.8.7

--- a/.github/workflows/Lints.yml
+++ b/.github/workflows/Lints.yml
@@ -28,6 +28,8 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         rust:
           - toolchain: stable
@@ -45,10 +47,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --lib --tests --all-features --all-targets -- -D warnings
+        run: cargo clippy --lib --tests --all-features --all-targets -- -D warnings
         env:
           RUSTFLAGS: ${{ matrix.rust.rustflags }}
 

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Remove integration tests and force enable rustc_version crate
         run: |
           rm -rf tests
-          sed -i '/actix-rt\|async-std\|reqwest\|skeptic/d' Cargo.toml
+          sed -i '/actix-rt\|async-std\|reqwest/d' Cargo.toml
           sed -i 's/target.*rustver.*\.//' Cargo.toml
           sed -i 's/build = "build.rs"/build = ".ci_extras\/build_linux_cross.rs"/' Cargo.toml
           cat Cargo.toml

--- a/.github/workflows/Skeptic.yml
+++ b/.github/workflows/Skeptic.yml
@@ -28,6 +28,8 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -41,7 +43,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Run tests (sync feature)
         run: cargo test --release --features sync

--- a/.github/workflows/Trybuild.yml
+++ b/.github/workflows/Trybuild.yml
@@ -1,4 +1,4 @@
-name: Skeptic and Trybuild
+name: Trybuild
 
 on:
   push:
@@ -43,21 +43,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-
-      - name: Run tests (sync feature)
-        run: cargo test --release --features sync
-        env:
-          RUSTFLAGS: '--cfg skeptic'
-
-      - name: Run tests (release, sync and future)
-        run: cargo test --release --features 'sync, future'
-        env:
-          RUSTFLAGS: '--cfg skeptic'
-
-      - name: Run tests (sync and future, without atomic64 and quanta)
-        run: cargo test --release --no-default-features --features 'sync, future'
-        env:
-          RUSTFLAGS: '--cfg skeptic'
 
       - name: Run compile error tests (sync and future features, trybuild)
         if: ${{ matrix.rust == 'stable' }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,8 @@
         "Descheduled",
         "devcontainer",
         "docsrs",
+        "doctest",
+        "doctests",
         "Einziger",
         "else's",
         "ENHANCEME",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,14 +80,10 @@ env_logger = "0.10.0"
 getrandom = "0.2"
 paste = "1.0.9"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls"] }
-skeptic = "0.13"
 tokio = { version = "1.19", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time" ] }
 
 [target.'cfg(trybuild)'.dev-dependencies]
 trybuild = "1.0"
-
-[target.'cfg(skeptic)'.build-dependencies]
-skeptic = "0.13.5"
 
 [target.'cfg(rustver)'.build-dependencies]
 rustc_version = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -497,13 +497,13 @@ To run all tests including `future` feature and doc tests on the README, use the
 following command:
 
 ```console
-$ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test --all-features
+$ RUSTFLAGS='--cfg trybuild' cargo test --all-features
 ```
 
 **Running All Tests without Default Features**
 
 ```console
-$ RUSTFLAGS='--cfg skeptic --cfg trybuild' cargo test \
+$ RUSTFLAGS='--cfg trybuild' cargo test \
     --no-default-features --features 'future, sync'
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,3 @@
-#[cfg(skeptic)]
-fn main() {
-    // generates doc tests for `README.md`.
-    skeptic::generate_doc_tests(&["README.md"]);
-}
-
 #[cfg(rustver)]
 fn main() {
     use rustc_version::version;
@@ -14,5 +8,5 @@ fn main() {
     );
 }
 
-#[cfg(not(any(skeptic, rustver)))]
+#[cfg(not(rustver))]
 fn main() {}

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -77,7 +77,7 @@ impl<K, V, S> Clone for BaseCache<K, V, S> {
             write_op_ch: self.write_op_ch.clone(),
             interrupted_op_ch_snd: self.interrupted_op_ch_snd.clone(),
             interrupted_op_ch_rcv: self.interrupted_op_ch_rcv.clone(),
-            housekeeper: self.housekeeper.as_ref().map(Arc::clone),
+            housekeeper: self.housekeeper.clone(),
         }
     }
 }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -3916,7 +3916,7 @@ mod tests {
         // Note that MyError does not implement std::error::Error trait
         // like anyhow::Error.
         #[derive(Debug)]
-        pub struct MyError(String);
+        pub struct MyError(#[allow(dead_code)] String);
 
         type MyResult<T> = Result<T, Arc<MyError>>;
 
@@ -4053,7 +4053,7 @@ mod tests {
         // Note that MyError does not implement std::error::Error trait
         // like anyhow::Error.
         #[derive(Debug)]
-        pub struct MyError(String);
+        pub struct MyError(#[allow(dead_code)] String);
 
         type MyResult<T> = Result<T, Arc<MyError>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,3 +151,10 @@ mod tests {
         t.compile_fail("tests/compile_tests/future/clone/*.rs");
     }
 }
+
+#[cfg(all(doctest, sync))]
+mod doctests {
+    // https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#include-items-only-when-collecting-doctests
+    #[doc = include_str!("../README.md")]
+    struct ReadMeDoctests;
+}

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -299,7 +299,7 @@ impl<K, V> Clone for ExpirationPolicy<K, V> {
         Self {
             time_to_live: self.time_to_live,
             time_to_idle: self.time_to_idle,
-            expiry: self.expiry.as_ref().map(Arc::clone),
+            expiry: self.expiry.clone(),
         }
     }
 }
@@ -337,7 +337,7 @@ impl<K, V> ExpirationPolicy<K, V> {
     }
 
     pub(crate) fn expiry(&self) -> Option<Arc<dyn Expiry<K, V> + Send + Sync + 'static>> {
-        self.expiry.as_ref().map(Arc::clone)
+        self.expiry.clone()
     }
 
     pub(crate) fn set_expiry(&mut self, expiry: Arc<dyn Expiry<K, V> + Send + Sync + 'static>) {

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -3556,7 +3556,7 @@ mod tests {
         // Note that MyError does not implement std::error::Error trait like
         // anyhow::Error.
         #[derive(Debug)]
-        pub struct MyError(String);
+        pub struct MyError(#[allow(dead_code)] String);
 
         type MyResult<T> = Result<T, Arc<MyError>>;
 
@@ -3697,7 +3697,7 @@ mod tests {
         // Note that MyError does not implement std::error::Error trait like
         // anyhow::Error.
         #[derive(Debug)]
-        pub struct MyError(String);
+        pub struct MyError(#[allow(dead_code)] String);
 
         type MyResult<T> = Result<T, Arc<MyError>>;
 

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -754,9 +754,9 @@ where
                     seg_max_capacity,
                     seg_init_capacity,
                     build_hasher.clone(),
-                    weigher.as_ref().map(Arc::clone),
+                    weigher.clone(),
                     eviction_policy.clone(),
-                    eviction_listener.as_ref().map(Arc::clone),
+                    eviction_listener.clone(),
                     expiration_policy.clone(),
                     invalidator_enabled,
                 )

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -66,7 +66,7 @@ impl<K, V, S> Clone for BaseCache<K, V, S> {
             inner: Arc::clone(&self.inner),
             read_op_ch: self.read_op_ch.clone(),
             write_op_ch: self.write_op_ch.clone(),
-            housekeeper: self.housekeeper.as_ref().map(Arc::clone),
+            housekeeper: self.housekeeper.clone(),
         }
     }
 }

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,2 +1,0 @@
-#[cfg(skeptic)]
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
- Update the doc tests on the `README.md` by replacing Skeptic with a regular `cargo test` command.
- Rename a CI job `Skeptic` to `Trybuild`.
- Fix the CI for nightly + minimal crate versions by pinning `ahash` to v0.8.7.
- Fix beta Clippy warnings.
  - clippy 0.1.77 (f2048098a1c 2024-02-09)
- Fix beta compiler warnings.
  - rustc 1.77.0-beta.2 (f2048098a 2024-02-09)
- Replace `actions-rs/clippy-check` with a regular GHA `run` command.
- Disable the `fail-fast` flag for the `Lints` and `Trybuild` jobs.