### PR TITLE
Fix Clippy warnings (v0.12.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,6 @@ in `u32`, and the cache will evict entries when the total weighted size exceeds 
 `max_capacity`.
 
 ```rust
-use std::convert::TryInto;
 use moka::sync::Cache;
 
 fn main() {

--- a/examples/reinsert_expired_entries_sync.rs
+++ b/examples/reinsert_expired_entries_sync.rs
@@ -45,7 +45,8 @@ fn main() {
     // We are going to solve this by making the Sender globally accessible via the
     // static OnceLock, and make the eviction listener to clone it per thread.
     static SND: OnceLock<Mutex<Sender<Command>>> = OnceLock::new();
-    #[allow(clippy::incompatible_msrv)] // `set` is stable since 1.70.0.
+    #[cfg_attr(beta_clippy, allow(clippy::incompatible_msrv))]
+    // `set` is stable since 1.70.0.
     SND.set(Mutex::new(snd.clone())).unwrap();
 
     // Create the eviction listener.
@@ -53,7 +54,8 @@ fn main() {
         // Keep a clone of the Sender in our thread-local variable, so that we can
         // send a command without locking the Mutex every time.
         thread_local! {
-            #[allow(clippy::incompatible_msrv)] // `get` is stable since 1.70.0.
+            #[cfg_attr(beta_clippy, allow(clippy::incompatible_msrv))]
+            // `get` is stable since 1.70.0.
             static THREAD_SND: Sender<Command> = SND.get().unwrap().lock().unwrap().clone();
         }
 

--- a/examples/reinsert_expired_entries_sync.rs
+++ b/examples/reinsert_expired_entries_sync.rs
@@ -45,6 +45,7 @@ fn main() {
     // We are going to solve this by making the Sender globally accessible via the
     // static OnceLock, and make the eviction listener to clone it per thread.
     static SND: OnceLock<Mutex<Sender<Command>>> = OnceLock::new();
+    #[allow(clippy::incompatible_msrv)] // `set` is stable since 1.70.0.
     SND.set(Mutex::new(snd.clone())).unwrap();
 
     // Create the eviction listener.
@@ -52,6 +53,7 @@ fn main() {
         // Keep a clone of the Sender in our thread-local variable, so that we can
         // send a command without locking the Mutex every time.
         thread_local! {
+            #[allow(clippy::incompatible_msrv)] // `get` is stable since 1.70.0.
             static THREAD_SND: Sender<Command> = SND.get().unwrap().lock().unwrap().clone();
         }
 

--- a/examples/size_aware_eviction_sync.rs
+++ b/examples/size_aware_eviction_sync.rs
@@ -1,5 +1,4 @@
 use moka::sync::Cache;
-use std::convert::TryInto;
 
 fn main() {
     let cache = Cache::builder()

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 pub(crate) mod builder_utils;
 pub(crate) mod concurrent;
 pub(crate) mod deque;

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -200,7 +200,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
 /// // futures-util = "0.3"
 ///
-/// use std::convert::TryInto;
 /// use moka::future::Cache;
 ///
 /// #[tokio::main]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -177,7 +177,6 @@ use std::{
 /// # Example: Size-based Eviction
 ///
 /// ```rust
-/// use std::convert::TryInto;
 /// use moka::sync::Cache;
 ///
 /// // Evict based on the number of entries in the cache.


### PR DESCRIPTION
This PR fixes Clippy warnings for `moka` v0.12.x.

- clippy 0.1.78 (4147533e05e 2024-03-27)

**NOTE**: Miri test is failing now. It will be tracked by #414.