### PR TITLE
Make a single call to `run_pending_tasks` to evict as many entries as possible from the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Ensure a single call to `run_pending_tasks` to evict as many entries as possible
-  from the cache ([#417](gh-pull-0417).
+  from the cache ([#417][gh-pull-0417]).
 
 
 ## Version 0.12.6
@@ -880,6 +880,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0417]: https://github.com/moka-rs/moka/pull/417/
 [gh-pull-0390]: https://github.com/moka-rs/moka/pull/390/
 [gh-pull-0384]: https://github.com/moka-rs/moka/pull/384/
 [gh-pull-0382]: https://github.com/moka-rs/moka/pull/382/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.7
+
+### Changed
+
+- Ensure a single call to `run_pending_tasks` to evict as many entries as possible
+  from the cache ([#417](gh-pull-0417).
+
+
 ## Version 0.12.6
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2021"
 # Rust 1.65 was released on Nov 3, 2022.
 rust-version = "1.65"

--- a/src/common.rs
+++ b/src/common.rs
@@ -76,10 +76,10 @@ pub(crate) struct HousekeeperConfig {
     pub(crate) maintenance_task_timeout: Duration,
     /// The maximum repeat count for receiving operation logs from the read and write
     /// log channels. Default: `MAX_LOG_SYNC_REPEATS`.
-    pub(crate) max_log_sync_repeats: usize,
+    pub(crate) max_log_sync_repeats: u32,
     /// The batch size of entries to be processed by each internal eviction method.
     /// Default: `EVICTION_BATCH_SIZE`.
-    pub(crate) eviction_batch_size: usize,
+    pub(crate) eviction_batch_size: u32,
 }
 
 impl Default for HousekeeperConfig {
@@ -88,7 +88,7 @@ impl Default for HousekeeperConfig {
             maintenance_task_timeout: Duration::from_millis(
                 DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS,
             ),
-            max_log_sync_repeats: DEFAULT_MAX_LOG_SYNC_REPEATS,
+            max_log_sync_repeats: DEFAULT_MAX_LOG_SYNC_REPEATS as u32,
             eviction_batch_size: DEFAULT_EVICTION_BATCH_SIZE,
         }
     }
@@ -98,14 +98,15 @@ impl HousekeeperConfig {
     #[cfg(test)]
     pub(crate) fn new(
         maintenance_task_timeout: Option<Duration>,
-        max_log_sync_repeats: Option<usize>,
-        eviction_batch_size: Option<usize>,
+        max_log_sync_repeats: Option<u32>,
+        eviction_batch_size: Option<u32>,
     ) -> Self {
         Self {
             maintenance_task_timeout: maintenance_task_timeout.unwrap_or(Duration::from_millis(
                 DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS,
             )),
-            max_log_sync_repeats: max_log_sync_repeats.unwrap_or(DEFAULT_MAX_LOG_SYNC_REPEATS),
+            max_log_sync_repeats: max_log_sync_repeats
+                .unwrap_or(DEFAULT_MAX_LOG_SYNC_REPEATS as u32),
             eviction_batch_size: eviction_batch_size.unwrap_or(DEFAULT_EVICTION_BATCH_SIZE),
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub(crate) mod builder_utils;
 pub(crate) mod concurrent;
 pub(crate) mod deque;
@@ -9,6 +11,11 @@ pub(crate) mod timer_wheel;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
+
+use self::concurrent::constants::{
+    DEFAULT_EVICTION_BATCH_SIZE, DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS,
+    DEFAULT_MAX_LOG_SYNC_REPEATS,
+};
 
 // Note: `CacheRegion` cannot have more than four enum variants. This is because
 // `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`
@@ -53,6 +60,54 @@ impl PartialEq<Self> for CacheRegion {
 impl PartialEq<usize> for CacheRegion {
     fn eq(&self, other: &usize) -> bool {
         *self as usize == *other
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct HousekeeperConfig {
+    /// The timeout duration for the `run_pending_tasks` method. This is a safe-guard
+    /// to prevent cache read/write operations (that may call `run_pending_tasks`
+    /// internally) from being blocked for a long time when the user wrote a slow
+    /// eviction listener closure.
+    ///
+    /// Used only when the eviction listener closure is set for the cache instance.
+    ///
+    /// Default: `DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS`
+    pub(crate) maintenance_task_timeout: Duration,
+    /// The maximum repeat count for receiving operation logs from the read and write
+    /// log channels. Default: `MAX_LOG_SYNC_REPEATS`.
+    pub(crate) max_log_sync_repeats: usize,
+    /// The batch size of entries to be processed by each internal eviction method.
+    /// Default: `EVICTION_BATCH_SIZE`.
+    pub(crate) eviction_batch_size: usize,
+}
+
+impl Default for HousekeeperConfig {
+    fn default() -> Self {
+        Self {
+            maintenance_task_timeout: Duration::from_millis(
+                DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS,
+            ),
+            max_log_sync_repeats: DEFAULT_MAX_LOG_SYNC_REPEATS,
+            eviction_batch_size: DEFAULT_EVICTION_BATCH_SIZE,
+        }
+    }
+}
+
+impl HousekeeperConfig {
+    #[cfg(test)]
+    pub(crate) fn new(
+        maintenance_task_timeout: Option<Duration>,
+        max_log_sync_repeats: Option<usize>,
+        eviction_batch_size: Option<usize>,
+    ) -> Self {
+        Self {
+            maintenance_task_timeout: maintenance_task_timeout.unwrap_or(Duration::from_millis(
+                DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS,
+            )),
+            max_log_sync_repeats: max_log_sync_repeats.unwrap_or(DEFAULT_MAX_LOG_SYNC_REPEATS),
+            eviction_batch_size: eviction_batch_size.unwrap_or(DEFAULT_EVICTION_BATCH_SIZE),
+        }
     }
 }
 

--- a/src/common/concurrent/constants.rs
+++ b/src/common/concurrent/constants.rs
@@ -14,7 +14,7 @@ pub(crate) const WRITE_LOG_CH_SIZE: usize =
 
 // TODO: Calculate the batch size based on the number of entries in the cache (or an
 // estimated number of entries to evict)
-pub(crate) const DEFAULT_EVICTION_BATCH_SIZE: usize = WRITE_LOG_CH_SIZE;
+pub(crate) const DEFAULT_EVICTION_BATCH_SIZE: u32 = WRITE_LOG_CH_SIZE as u32;
 
 /// The default timeout duration for the `run_pending_tasks` method.
 pub(crate) const DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS: u64 = 100;

--- a/src/common/concurrent/constants.rs
+++ b/src/common/concurrent/constants.rs
@@ -1,19 +1,23 @@
-pub(crate) const MAX_SYNC_REPEATS: usize = 4;
-pub(crate) const PERIODICAL_SYNC_INITIAL_DELAY_MILLIS: u64 = 300;
+pub(crate) const DEFAULT_MAX_LOG_SYNC_REPEATS: usize = 4;
+pub(crate) const LOG_SYNC_INTERVAL_MILLIS: u64 = 300;
 
 pub(crate) const READ_LOG_FLUSH_POINT: usize = 64;
-pub(crate) const READ_LOG_SIZE: usize = READ_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2); // 384
-
 pub(crate) const WRITE_LOG_FLUSH_POINT: usize = 64;
-pub(crate) const WRITE_LOG_SIZE: usize = WRITE_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2); // 384
+
+// 384 elements
+pub(crate) const READ_LOG_CH_SIZE: usize =
+    READ_LOG_FLUSH_POINT * (DEFAULT_MAX_LOG_SYNC_REPEATS + 2);
+
+// 384 elements
+pub(crate) const WRITE_LOG_CH_SIZE: usize =
+    WRITE_LOG_FLUSH_POINT * (DEFAULT_MAX_LOG_SYNC_REPEATS + 2);
 
 // TODO: Calculate the batch size based on the number of entries in the cache (or an
 // estimated number of entries to evict)
-pub(crate) const EVICTION_BATCH_SIZE: usize = WRITE_LOG_SIZE;
-pub(crate) const INVALIDATION_BATCH_SIZE: usize = WRITE_LOG_SIZE;
+pub(crate) const DEFAULT_EVICTION_BATCH_SIZE: usize = WRITE_LOG_CH_SIZE;
 
 /// The default timeout duration for the `run_pending_tasks` method.
-pub(crate) const DEFAULT_RUN_PENDING_TASKS_TIMEOUT_MILLIS: u64 = 100;
+pub(crate) const DEFAULT_MAINTENANCE_TASK_TIMEOUT_MILLIS: u64 = 100;
 
 #[cfg(feature = "sync")]
 pub(crate) const WRITE_RETRY_INTERVAL_MICROS: u64 = 50;

--- a/src/common/concurrent/constants.rs
+++ b/src/common/concurrent/constants.rs
@@ -1,11 +1,19 @@
 pub(crate) const MAX_SYNC_REPEATS: usize = 4;
 pub(crate) const PERIODICAL_SYNC_INITIAL_DELAY_MILLIS: u64 = 300;
 
-pub(crate) const READ_LOG_FLUSH_POINT: usize = 512;
-pub(crate) const READ_LOG_SIZE: usize = READ_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2);
+pub(crate) const READ_LOG_FLUSH_POINT: usize = 64;
+pub(crate) const READ_LOG_SIZE: usize = READ_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2); // 384
 
-pub(crate) const WRITE_LOG_FLUSH_POINT: usize = 512;
-pub(crate) const WRITE_LOG_SIZE: usize = WRITE_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2);
+pub(crate) const WRITE_LOG_FLUSH_POINT: usize = 64;
+pub(crate) const WRITE_LOG_SIZE: usize = WRITE_LOG_FLUSH_POINT * (MAX_SYNC_REPEATS + 2); // 384
+
+// TODO: Calculate the batch size based on the number of entries in the cache (or an
+// estimated number of entries to evict)
+pub(crate) const EVICTION_BATCH_SIZE: usize = WRITE_LOG_SIZE;
+pub(crate) const INVALIDATION_BATCH_SIZE: usize = WRITE_LOG_SIZE;
+
+/// The default timeout duration for the `run_pending_tasks` method.
+pub(crate) const DEFAULT_RUN_PENDING_TASKS_TIMEOUT_MILLIS: u64 = 100;
 
 #[cfg(feature = "sync")]
 pub(crate) const WRITE_RETRY_INTERVAL_MICROS: u64 = 50;

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -14,12 +14,13 @@ use std::{
 };
 
 pub(crate) trait InnerSync {
-    /// Runs the pending tasks. Returns `true` if there are more entries to evict.
+    /// Runs the pending tasks. Returns `true` if there are more entries to evict in
+    /// next run.
     fn run_pending_tasks(
         &self,
         timeout: Option<Duration>,
-        max_log_sync_repeats: usize,
-        eviction_batch_size: usize,
+        max_log_sync_repeats: u32,
+        eviction_batch_size: u32,
     ) -> bool;
 
     fn now(&self) -> Instant;
@@ -43,10 +44,10 @@ pub(crate) struct Housekeeper {
     maintenance_task_timeout: Option<Duration>,
     /// The maximum repeat count for receiving operation logs from the read and write
     /// log channels. Default: `MAX_LOG_SYNC_REPEATS`.
-    max_log_sync_repeats: usize,
+    max_log_sync_repeats: u32,
     /// The batch size of entries to be processed by each internal eviction method.
     /// Default: `EVICTION_BATCH_SIZE`.
-    eviction_batch_size: usize,
+    eviction_batch_size: u32,
     auto_run_enabled: AtomicBool,
 }
 

--- a/src/common/concurrent/housekeeper.rs
+++ b/src/common/concurrent/housekeeper.rs
@@ -36,11 +36,11 @@ impl Default for Housekeeper {
 
 impl Housekeeper {
     pub(crate) fn should_apply_reads(&self, ch_len: usize, now: Instant) -> bool {
-        self.should_apply(ch_len, READ_LOG_FLUSH_POINT / 8, now)
+        self.should_apply(ch_len, READ_LOG_FLUSH_POINT, now)
     }
 
     pub(crate) fn should_apply_writes(&self, ch_len: usize, now: Instant) -> bool {
-        self.should_apply(ch_len, WRITE_LOG_FLUSH_POINT / 8, now)
+        self.should_apply(ch_len, WRITE_LOG_FLUSH_POINT, now)
     }
 
     #[inline]

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5,7 +5,7 @@ use super::{
     WriteOp,
 };
 use crate::{
-    common::concurrent::Weigher,
+    common::{concurrent::Weigher, HousekeeperConfig},
     notification::AsyncEvictionListener,
     ops::compute::{self, CompResult},
     policy::{EvictionPolicy, ExpirationPolicy},
@@ -789,6 +789,7 @@ where
             EvictionPolicy::default(),
             None,
             ExpirationPolicy::default(),
+            HousekeeperConfig::default(),
             false,
         )
     }
@@ -819,6 +820,7 @@ where
         eviction_policy: EvictionPolicy,
         eviction_listener: Option<AsyncEvictionListener<K, V>>,
         expiration_policy: ExpirationPolicy<K, V>,
+        housekeeper_config: HousekeeperConfig,
         invalidator_enabled: bool,
     ) -> Self {
         Self {
@@ -831,6 +833,7 @@ where
                 eviction_policy,
                 eviction_listener,
                 expiration_policy,
+                housekeeper_config,
                 invalidator_enabled,
             ),
             value_initializer: Arc::new(ValueInitializer::with_hasher(build_hasher)),
@@ -2113,7 +2116,7 @@ fn never_ignore<'a, V>() -> Option<&'a mut fn(&V) -> bool> {
 mod tests {
     use super::Cache;
     use crate::{
-        common::time::Clock,
+        common::{time::Clock, HousekeeperConfig},
         future::FutureExt,
         notification::{ListenerFuture, RemovalCause},
         ops::compute,
@@ -2125,7 +2128,7 @@ mod tests {
     use std::{
         convert::Infallible,
         sync::{
-            atomic::{AtomicU32, Ordering},
+            atomic::{AtomicU32, AtomicU8, Ordering},
             Arc,
         },
         time::{Duration, Instant as StdInstant},
@@ -5101,6 +5104,159 @@ mod tests {
         assert_eq!(cache.entry_count(), 0);
 
         verify_notification_vec(&cache, actual, &expected).await;
+    }
+
+    // When the eviction listener is not set, calling `run_pending_tasks` once should
+    // evict all entries that can be removed.
+    #[tokio::test]
+    async fn no_batch_size_limit_on_eviction() {
+        const MAX_CAPACITY: u64 = 20;
+
+        const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
+        const MAX_LOG_SYNC_REPEATS: usize = 1;
+        const EVICTION_BATCH_SIZE: usize = 1;
+
+        let hk_conf = HousekeeperConfig::new(
+            Some(EVICTION_TIMEOUT),
+            Some(MAX_LOG_SYNC_REPEATS),
+            Some(EVICTION_BATCH_SIZE),
+        );
+
+        // Create a cache with the LRU policy.
+        let mut cache = Cache::builder()
+            .max_capacity(MAX_CAPACITY)
+            .eviction_policy(EvictionPolicy::lru())
+            .housekeeper_config(hk_conf)
+            .build();
+        cache.reconfigure_for_testing().await;
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        // Fill the cache.
+        for i in 0..MAX_CAPACITY {
+            let v = format!("v{i}");
+            cache.insert(i, v).await
+        }
+        // The max capacity should not change because we have not called
+        // `run_pending_tasks` yet.
+        assert_eq!(cache.entry_count(), 0);
+
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.entry_count(), MAX_CAPACITY);
+
+        // Insert more items the cache.
+        for i in MAX_CAPACITY..(MAX_CAPACITY * 2) {
+            let v = format!("v{i}");
+            cache.insert(i, v).await
+        }
+        // The max capacity should not change because we have not called
+        // `run_pending_tasks` yet.
+        assert_eq!(cache.entry_count(), MAX_CAPACITY);
+        // Both old and new keys should exist.
+        assert!(cache.contains_key(&0)); // old
+        assert!(cache.contains_key(&(MAX_CAPACITY - 1))); // old
+        assert!(cache.contains_key(&(MAX_CAPACITY * 2 - 1))); // new
+
+        // Process the remaining write op logs (there should be MAX_CAPACITY logs),
+        // and evict the LRU entries.
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.entry_count(), MAX_CAPACITY);
+
+        // Now the old keys should be gone.
+        assert!(!cache.contains_key(&0));
+        assert!(!cache.contains_key(&(MAX_CAPACITY - 1)));
+        // And the new keys should exist.
+        assert!(cache.contains_key(&(MAX_CAPACITY * 2 - 1)));
+    }
+
+    #[tokio::test]
+    async fn slow_eviction_listener() {
+        const MAX_CAPACITY: u64 = 20;
+
+        const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
+        const LISTENER_DELAY: Duration = Duration::from_millis(11);
+        const MAX_LOG_SYNC_REPEATS: usize = 1;
+        const EVICTION_BATCH_SIZE: usize = 1;
+
+        let hk_conf = HousekeeperConfig::new(
+            Some(EVICTION_TIMEOUT),
+            Some(MAX_LOG_SYNC_REPEATS),
+            Some(EVICTION_BATCH_SIZE),
+        );
+
+        let (clock, mock) = Clock::mock();
+        let listener_call_count = Arc::new(AtomicU8::new(0));
+        let lcc = Arc::clone(&listener_call_count);
+
+        // A slow eviction listener that spend `LISTENER_DELAY` to process a removal
+        // notification.
+        let listener = move |_k, _v, _cause| {
+            mock.increment(LISTENER_DELAY);
+            lcc.fetch_add(1, Ordering::AcqRel);
+        };
+
+        // Create a cache with the LRU policy.
+        let mut cache = Cache::builder()
+            .max_capacity(MAX_CAPACITY)
+            .eviction_policy(EvictionPolicy::lru())
+            .eviction_listener(listener)
+            .housekeeper_config(hk_conf)
+            .build();
+        cache.reconfigure_for_testing().await;
+        cache.set_expiration_clock(Some(clock)).await;
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        // Fill the cache.
+        for i in 0..MAX_CAPACITY {
+            let v = format!("v{i}");
+            cache.insert(i, v).await
+        }
+        // The max capacity should not change because we have not called
+        // `run_pending_tasks` yet.
+        assert_eq!(cache.entry_count(), 0);
+
+        cache.run_pending_tasks().await;
+        assert_eq!(listener_call_count.load(Ordering::Acquire), 0);
+        assert_eq!(cache.entry_count(), MAX_CAPACITY);
+
+        // Insert more items the cache.
+        for i in MAX_CAPACITY..(MAX_CAPACITY * 2) {
+            let v = format!("v{i}");
+            cache.insert(i, v).await
+        }
+        assert_eq!(cache.entry_count(), MAX_CAPACITY);
+
+        cache.run_pending_tasks().await;
+        // Because of the slow listener, cache should get an over capacity.
+        let mut expected_call_count = 3;
+        assert_eq!(
+            listener_call_count.load(Ordering::Acquire) as u64,
+            expected_call_count
+        );
+        assert_eq!(cache.entry_count(), MAX_CAPACITY * 2 - expected_call_count);
+
+        loop {
+            cache.run_pending_tasks().await;
+
+            expected_call_count += 3;
+            if expected_call_count > MAX_CAPACITY {
+                expected_call_count = MAX_CAPACITY;
+            }
+
+            let actual_count = listener_call_count.load(Ordering::Acquire) as u64;
+            assert_eq!(actual_count, expected_call_count);
+            let expected_entry_count = MAX_CAPACITY * 2 - expected_call_count;
+            assert_eq!(cache.entry_count(), expected_entry_count);
+
+            if expected_call_count >= MAX_CAPACITY {
+                break;
+            }
+        }
+
+        assert_eq!(cache.entry_count(), MAX_CAPACITY);
     }
 
     // NOTE: To enable the panic logging, run the following command:

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5113,8 +5113,8 @@ mod tests {
         const MAX_CAPACITY: u64 = 20;
 
         const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
-        const MAX_LOG_SYNC_REPEATS: usize = 1;
-        const EVICTION_BATCH_SIZE: usize = 1;
+        const MAX_LOG_SYNC_REPEATS: u32 = 1;
+        const EVICTION_BATCH_SIZE: u32 = 1;
 
         let hk_conf = HousekeeperConfig::new(
             Some(EVICTION_TIMEOUT),
@@ -5176,8 +5176,8 @@ mod tests {
 
         const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
         const LISTENER_DELAY: Duration = Duration::from_millis(11);
-        const MAX_LOG_SYNC_REPEATS: usize = 1;
-        const EVICTION_BATCH_SIZE: usize = 1;
+        const MAX_LOG_SYNC_REPEATS: u32 = 1;
+        const EVICTION_BATCH_SIZE: u32 = 1;
 
         let hk_conf = HousekeeperConfig::new(
             Some(EVICTION_TIMEOUT),

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5112,11 +5112,12 @@ mod tests {
     async fn no_batch_size_limit_on_eviction() {
         const MAX_CAPACITY: u64 = 20;
 
-        const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
+        const EVICTION_TIMEOUT: Duration = Duration::from_nanos(0);
         const MAX_LOG_SYNC_REPEATS: u32 = 1;
         const EVICTION_BATCH_SIZE: u32 = 1;
 
         let hk_conf = HousekeeperConfig::new(
+            // Timeout should be ignored when the eviction listener is not provided.
             Some(EVICTION_TIMEOUT),
             Some(MAX_LOG_SYNC_REPEATS),
             Some(EVICTION_BATCH_SIZE),
@@ -5145,7 +5146,7 @@ mod tests {
         cache.run_pending_tasks().await;
         assert_eq!(cache.entry_count(), MAX_CAPACITY);
 
-        // Insert more items the cache.
+        // Insert more items to the cache.
         for i in MAX_CAPACITY..(MAX_CAPACITY * 2) {
             let v = format!("v{i}");
             cache.insert(i, v).await
@@ -5163,7 +5164,7 @@ mod tests {
         cache.run_pending_tasks().await;
         assert_eq!(cache.entry_count(), MAX_CAPACITY);
 
-        // Now the old keys should be gone.
+        // Now all the old keys should be gone.
         assert!(!cache.contains_key(&0));
         assert!(!cache.contains_key(&(MAX_CAPACITY - 1)));
         // And the new keys should exist.
@@ -5222,7 +5223,7 @@ mod tests {
         assert_eq!(listener_call_count.load(Ordering::Acquire), 0);
         assert_eq!(cache.entry_count(), MAX_CAPACITY);
 
-        // Insert more items the cache.
+        // Insert more items to the cache.
         for i in MAX_CAPACITY..(MAX_CAPACITY * 2) {
             let v = format!("v{i}");
             cache.insert(i, v).await

--- a/src/future/housekeeper.rs
+++ b/src/future/housekeeper.rs
@@ -1,12 +1,10 @@
 use crate::common::{
     concurrent::{
         atomic_time::AtomicInstant,
-        constants::{
-            DEFAULT_RUN_PENDING_TASKS_TIMEOUT_MILLIS, MAX_SYNC_REPEATS,
-            PERIODICAL_SYNC_INITIAL_DELAY_MILLIS, READ_LOG_FLUSH_POINT, WRITE_LOG_FLUSH_POINT,
-        },
+        constants::{LOG_SYNC_INTERVAL_MILLIS, READ_LOG_FLUSH_POINT, WRITE_LOG_FLUSH_POINT},
     },
     time::{CheckedTimeOps, Instant},
+    HousekeeperConfig,
 };
 
 use std::{
@@ -27,7 +25,12 @@ use futures_util::future::{BoxFuture, Shared};
 #[async_trait]
 pub(crate) trait InnerSync {
     /// Runs the pending tasks. Returns `true` if there are more entries to evict.
-    async fn run_pending_tasks(&self, max_sync_repeats: usize, timeout: Option<Duration>) -> bool;
+    async fn run_pending_tasks(
+        &self,
+        timeout: Option<Duration>,
+        max_log_sync_repeats: usize,
+        eviction_batch_size: usize,
+    ) -> bool;
 
     /// Notifies all the async tasks waiting in `BaseCache::schedule_write_op` method
     /// for the write op channel to have enough room.
@@ -40,11 +43,11 @@ pub(crate) struct Housekeeper {
     /// A shared `Future` of the maintenance task that is currently being resolved.
     current_task: Mutex<Option<Shared<BoxFuture<'static, bool>>>>,
     run_after: AtomicInstant,
-    /// A flag to indicate if the last `run_pending_tasks` call left more entries to
-    /// evict.
+    /// A flag to indicate if the last call on `run_pending_tasks` method left some
+    /// entries to evict.
     ///
     /// Used only when the eviction listener closure is set for this cache instance
-    /// because, if not, `run_pending_tasks` will never leave more entries to evict.
+    /// because, if not, `run_pending_tasks` will never leave entries to evict.
     more_entries_to_evict: Option<AtomicBool>,
     /// The timeout duration for the `run_pending_tasks` method. This is a safe-guard
     /// to prevent cache read/write operations (that may call `run_pending_tasks`
@@ -53,6 +56,12 @@ pub(crate) struct Housekeeper {
     ///
     /// Used only when the eviction listener closure is set for this cache instance.
     maintenance_task_timeout: Option<Duration>,
+    /// The maximum repeat count for receiving operation logs from the read and write
+    /// log channels. Default: `MAX_LOG_SYNC_REPEATS`.
+    max_log_sync_repeats: usize,
+    /// The batch size of entries to be processed by each internal eviction method.
+    /// Default: `EVICTION_BATCH_SIZE`.
+    eviction_batch_size: usize,
     auto_run_enabled: AtomicBool,
     #[cfg(test)]
     pub(crate) start_count: AtomicUsize,
@@ -61,13 +70,11 @@ pub(crate) struct Housekeeper {
 }
 
 impl Housekeeper {
-    pub(crate) fn new(is_eviction_listener_enabled: bool) -> Self {
+    pub(crate) fn new(is_eviction_listener_enabled: bool, config: HousekeeperConfig) -> Self {
         let (more_entries_to_evict, maintenance_task_timeout) = if is_eviction_listener_enabled {
             (
                 Some(AtomicBool::new(false)),
-                Some(Duration::from_millis(
-                    DEFAULT_RUN_PENDING_TASKS_TIMEOUT_MILLIS,
-                )),
+                Some(config.maintenance_task_timeout),
             )
         } else {
             (None, None)
@@ -78,6 +85,8 @@ impl Housekeeper {
             run_after: AtomicInstant::new(Self::sync_after(Instant::now())),
             more_entries_to_evict,
             maintenance_task_timeout,
+            max_log_sync_repeats: config.max_log_sync_repeats,
+            eviction_batch_size: config.eviction_batch_size,
             auto_run_enabled: AtomicBool::new(true),
             #[cfg(test)]
             start_count: Default::default(),
@@ -168,8 +177,10 @@ impl Housekeeper {
             more_to_evict = task.clone().await;
         } else {
             let timeout = self.maintenance_task_timeout;
+            let repeats = self.max_log_sync_repeats;
+            let batch_size = self.eviction_batch_size;
             // Create a new maintenance task and await it.
-            let task = async move { cache.run_pending_tasks(MAX_SYNC_REPEATS, timeout).await }
+            let task = async move { cache.run_pending_tasks(timeout, repeats, batch_size).await }
                 .boxed()
                 .shared();
             *current_task = Some(task.clone());
@@ -191,7 +202,7 @@ impl Housekeeper {
     }
 
     fn sync_after(now: Instant) -> Instant {
-        let dur = Duration::from_millis(PERIODICAL_SYNC_INITIAL_DELAY_MILLIS);
+        let dur = Duration::from_millis(LOG_SYNC_INTERVAL_MILLIS);
         let ts = now.checked_add(dur);
         // Assuming that `now` is current wall clock time, this should never fail at
         // least next millions of years.

--- a/src/future/housekeeper.rs
+++ b/src/future/housekeeper.rs
@@ -88,12 +88,10 @@ impl Housekeeper {
 
     pub(crate) fn should_apply_reads(&self, ch_len: usize, now: Instant) -> bool {
         self.more_entries_to_evict() || self.should_apply(ch_len, READ_LOG_FLUSH_POINT, now)
-        // self.should_apply(ch_len, READ_LOG_FLUSH_POINT, now)
     }
 
     pub(crate) fn should_apply_writes(&self, ch_len: usize, now: Instant) -> bool {
         self.more_entries_to_evict() || self.should_apply(ch_len, WRITE_LOG_FLUSH_POINT, now)
-        // self.should_apply(ch_len, WRITE_LOG_FLUSH_POINT, now)
     }
 
     #[inline]

--- a/src/sync/builder.rs
+++ b/src/sync/builder.rs
@@ -1,6 +1,6 @@
 use super::{Cache, SegmentedCache};
 use crate::{
-    common::{builder_utils, concurrent::Weigher},
+    common::{builder_utils, concurrent::Weigher, HousekeeperConfig},
     notification::{EvictionListener, RemovalCause},
     policy::{EvictionPolicy, ExpirationPolicy},
     Expiry,
@@ -56,6 +56,7 @@ pub struct CacheBuilder<K, V, C> {
     eviction_policy: EvictionPolicy,
     eviction_listener: Option<EvictionListener<K, V>>,
     expiration_policy: ExpirationPolicy<K, V>,
+    housekeeper_config: HousekeeperConfig,
     invalidator_enabled: bool,
     cache_type: PhantomData<C>,
 }
@@ -75,6 +76,7 @@ where
             eviction_listener: None,
             eviction_policy: EvictionPolicy::default(),
             expiration_policy: ExpirationPolicy::default(),
+            housekeeper_config: HousekeeperConfig::default(),
             invalidator_enabled: false,
             cache_type: PhantomData,
         }
@@ -115,6 +117,7 @@ where
             eviction_policy: self.eviction_policy,
             eviction_listener: self.eviction_listener,
             expiration_policy: self.expiration_policy,
+            housekeeper_config: self.housekeeper_config,
             invalidator_enabled: self.invalidator_enabled,
             cache_type: PhantomData,
         }
@@ -143,6 +146,7 @@ where
             self.eviction_policy,
             self.eviction_listener,
             self.expiration_policy,
+            self.housekeeper_config,
             self.invalidator_enabled,
         )
     }
@@ -230,6 +234,7 @@ where
             self.eviction_policy,
             self.eviction_listener,
             self.expiration_policy,
+            self.housekeeper_config,
             self.invalidator_enabled,
         )
     }
@@ -264,6 +269,7 @@ where
             self.eviction_policy,
             self.eviction_listener,
             self.expiration_policy,
+            self.housekeeper_config,
             self.invalidator_enabled,
         )
     }
@@ -353,6 +359,7 @@ where
             self.eviction_policy,
             self.eviction_listener,
             self.expiration_policy,
+            self.housekeeper_config,
             self.invalidator_enabled,
         )
     }
@@ -474,6 +481,14 @@ impl<K, V, C> CacheBuilder<K, V, C> {
         let mut builder = self;
         builder.expiration_policy.set_expiry(Arc::new(expiry));
         builder
+    }
+
+    #[cfg(test)]
+    pub(crate) fn housekeeper_config(self, conf: HousekeeperConfig) -> Self {
+        Self {
+            housekeeper_config: conf,
+            ..self
+        }
     }
 
     /// Enables support for [`Cache::invalidate_entries_if`][cache-invalidate-if]

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -4803,8 +4803,8 @@ mod tests {
         const MAX_CAPACITY: u64 = 20;
 
         const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
-        const MAX_LOG_SYNC_REPEATS: usize = 1;
-        const EVICTION_BATCH_SIZE: usize = 1;
+        const MAX_LOG_SYNC_REPEATS: u32 = 1;
+        const EVICTION_BATCH_SIZE: u32 = 1;
 
         let hk_conf = HousekeeperConfig::new(
             Some(EVICTION_TIMEOUT),
@@ -4866,8 +4866,8 @@ mod tests {
 
         const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
         const LISTENER_DELAY: Duration = Duration::from_millis(11);
-        const MAX_LOG_SYNC_REPEATS: usize = 1;
-        const EVICTION_BATCH_SIZE: usize = 1;
+        const MAX_LOG_SYNC_REPEATS: u32 = 1;
+        const EVICTION_BATCH_SIZE: u32 = 1;
 
         let hk_conf = HousekeeperConfig::new(
             Some(EVICTION_TIMEOUT),

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -4802,11 +4802,12 @@ mod tests {
     fn no_batch_size_limit_on_eviction() {
         const MAX_CAPACITY: u64 = 20;
 
-        const EVICTION_TIMEOUT: Duration = Duration::from_millis(30);
+        const EVICTION_TIMEOUT: Duration = Duration::from_nanos(0);
         const MAX_LOG_SYNC_REPEATS: u32 = 1;
         const EVICTION_BATCH_SIZE: u32 = 1;
 
         let hk_conf = HousekeeperConfig::new(
+            // Timeout should be ignored when the eviction listener is not provided.
             Some(EVICTION_TIMEOUT),
             Some(MAX_LOG_SYNC_REPEATS),
             Some(EVICTION_BATCH_SIZE),
@@ -4835,7 +4836,7 @@ mod tests {
         cache.run_pending_tasks();
         assert_eq!(cache.entry_count(), MAX_CAPACITY);
 
-        // Insert more items the cache.
+        // Insert more items to the cache.
         for i in MAX_CAPACITY..(MAX_CAPACITY * 2) {
             let v = format!("v{i}");
             cache.insert(i, v)
@@ -4853,7 +4854,7 @@ mod tests {
         cache.run_pending_tasks();
         assert_eq!(cache.entry_count(), MAX_CAPACITY);
 
-        // Now the old keys should be gone.
+        // Now all the old keys should be gone.
         assert!(!cache.contains_key(&0));
         assert!(!cache.contains_key(&(MAX_CAPACITY - 1)));
         // And the new keys should exist.
@@ -4912,7 +4913,7 @@ mod tests {
         assert_eq!(listener_call_count.load(Ordering::Acquire), 0);
         assert_eq!(cache.entry_count(), MAX_CAPACITY);
 
-        // Insert more items the cache.
+        // Insert more items to the cache.
         for i in MAX_CAPACITY..(MAX_CAPACITY * 2) {
             let v = format!("v{i}");
             cache.insert(i, v);

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1,6 +1,7 @@
 use super::{cache::Cache, CacheBuilder, OwnedKeyEntrySelector, RefKeyEntrySelector};
+use crate::common::concurrent::Weigher;
 use crate::{
-    common::concurrent::Weigher,
+    common::HousekeeperConfig,
     notification::EvictionListener,
     policy::{EvictionPolicy, ExpirationPolicy},
     sync_base::iter::{Iter, ScanningGet},
@@ -105,6 +106,7 @@ where
             EvictionPolicy::default(),
             None,
             ExpirationPolicy::default(),
+            HousekeeperConfig::default(),
             false,
         )
     }
@@ -211,6 +213,7 @@ where
         eviction_policy: EvictionPolicy,
         eviction_listener: Option<EvictionListener<K, V>>,
         expiration_policy: ExpirationPolicy<K, V>,
+        housekeeper_config: HousekeeperConfig,
         invalidator_enabled: bool,
     ) -> Self {
         Self {
@@ -224,6 +227,7 @@ where
                 eviction_policy,
                 eviction_listener,
                 expiration_policy,
+                housekeeper_config,
                 invalidator_enabled,
             )),
         }
@@ -735,6 +739,7 @@ where
         eviction_policy: EvictionPolicy,
         eviction_listener: Option<EvictionListener<K, V>>,
         expiration_policy: ExpirationPolicy<K, V>,
+        housekeeper_config: HousekeeperConfig,
         invalidator_enabled: bool,
     ) -> Self {
         assert!(num_segments > 0);
@@ -758,6 +763,7 @@ where
                     eviction_policy.clone(),
                     eviction_listener.clone(),
                     expiration_policy.clone(),
+                    housekeeper_config.clone(),
                     invalidator_enabled,
                 )
             })

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -2198,10 +2198,6 @@ where
                 // `Option<Instant>` to `Instant`.
                 Some((key, hash, true, _) | (key, hash, false, None)) => {
                     self.skip_updated_entry_wo(&key, hash, deqs);
-                    // If the key is the caller key, set `more_to_evict` to `false`
-                    // to make `run_pending_tasks` to return early. This will help
-                    // that `schedule_write_op`, a caller in the call tree, to send
-                    // the `WriteOp` to the write op channel.
                     more_to_evict = false;
                     continue;
                 }
@@ -2229,9 +2225,7 @@ where
                 Self::handle_remove(deqs, timer_wheel, entry, None, &mut eviction_state.counters);
             } else {
                 self.skip_updated_entry_wo(&key, hash, deqs);
-                // if caller_key.map(|ck| ck == &key).unwrap_or_default() {
                 more_to_evict = false;
-                // }
             }
         }
 
@@ -2389,9 +2383,7 @@ where
                 evicted = evicted.saturating_add(weight as u64);
             } else {
                 self.skip_updated_entry_ao(&key, hash, deq_name, ao_deq, wo_deq);
-                // if caller_key.map(|ck| ck == &key).unwrap_or_default() {
                 more_to_evict = false;
-                // }
             }
         }
 


### PR DESCRIPTION
Fixes #408.

## Changes

This PR ensures that a single call to `run_pending_tasks` to evict as many entries as possible from the cache.

- Disable the batch limits when the eviction listener is not set to the cache.
  - So single `run_pending_tasks` call should remove all the entries that can be evicted from the cache.
- Add a hard-coded maintenance task timeout duration.
  - When the eviction listener is set, `run_pending_tasks` should stop (return) after the timeout duration is elapsed.
  - This is a safe-guard to prevent the maintenance task from running long time when the user provided a slow eviction listener.
  - In older versions, the batch size was used to limit the time spent on the maintenance task.
  - Note that `run_pending_tasks` checks the timeout only after processing a batch of entries, so `run_pending_tasks` can run longer than the timeout duration.
- Reduce the size of the read op and write op channels.

## Tests

1. Add a unit test using a cache with _no_ eviction listener. It verifies that a single call to `run_pending_tasks` to evict as many entries as possible.
2. Add a unit test using a cache with a eviction listener. It verifies that timeout duration is working.