### PR TITLE
CI: Pin `syn` and `proc-macro2` versions for `kani@v0.49.0`

### DIFF
--- a/.ci_extras/pin-crate-vers-kani.sh
+++ b/.ci_extras/pin-crate-vers-kani.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eux
+
+# Pin some dependencies to specific versions for the nightly toolchain
+# used by Kani verifier.
+cargo update -p syn@2.0 --precise 2.0.58
+cargo update -p proc-macro2 --precise 1.0.79

--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -43,6 +43,12 @@ jobs:
           lscpu
           free -m
 
+      - name: Pin some dependencies to specific versions
+        run: ./.ci_extras/pin-crate-vers-kani.sh
+
+      - name: Show cargo tree
+        run: cargo tree
+
       - name: Run Kani
         uses: model-checking/kani-github-action@v1.0
         with:


### PR DESCRIPTION
Fixes #418.

As of April 16, 2024, the latest version `0.49.0` of Kani verifier uses Rust `nightly-2024-03-29`, which cannot compile `proc-macro2@1.0.80`, causing a CI job to tail.

To address the issue, a new version of Kani will be released soon (https://github.com/model-checking/kani/pull/3144). But for now, we workaround the issue by pining some crate versions to older versions.

This PR does the followings when running GitHub CI for Kani verifier:

- Pin `proc-macro2` to `1.0.79`.
- Pin `syn` to `2.0.58`.
  - Pinning (downgrading) the `proc-macro2` version requires downgrading `syn`. 