### PR TITLE
CI: Unpin `syn` and `proc-macro2` versions as a new version `0.50.0` of `kani` is released

### DIFF
--- a/.ci_extras/pin-crate-vers-kani.sh
+++ b/.ci_extras/pin-crate-vers-kani.sh
@@ -4,5 +4,4 @@ set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain
 # used by Kani verifier.
-cargo update -p syn@2.0 --precise 2.0.58
-cargo update -p proc-macro2 --precise 1.0.79
+# cargo update -p crate-name --precise x.y.z


### PR DESCRIPTION
Related to:

- #419

Kani verifier `0.50.0` has been released. It uses Rust `nightyl-2024-04-15` so `proc-macro2@1.0.80` and newer should compile with it. This pull request unpins `syn` and `proc-macro2` versions for the CI job for Kani verifier.