### PR TITLE
docs: fix per-entry expiration policy documentation

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -313,9 +313,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// //
 /// // [dependencies]
 /// // moka = { version = "0.12", features = ["future"] }
-/// // tokio = { version = "1", features = ["rt-multi-thread", "macros" ] }
+/// // tokio = { version = "1", features = ["rt-multi-thread", "macros", "time" ] }
 ///
-/// use moka::{future::{Cache, FutureExt}, Expiry, notification::ListenerFuture};
+/// use moka::{future::Cache, Expiry};
 /// use std::time::{Duration, Instant};
 ///
 /// // In this example, we will create a `future::Cache` with `u32` as the key, and
@@ -403,6 +403,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///     // Sleep for 6 seconds. Key 0 should expire.
 ///     println!("\nSleeping for 6 seconds...\n");
 ///     tokio::time::sleep(Duration::from_secs(6)).await;
+///     cache.run_pending_tasks().await;
 ///     println!("Entry count: {}", cache.entry_count());
 ///
 ///     // Verify that key 0 has been evicted.
@@ -413,6 +414,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///     // Sleep for 10 more seconds. Key 1 should expire.
 ///     println!("\nSleeping for 10 seconds...\n");
 ///     tokio::time::sleep(Duration::from_secs(10)).await;
+///     cache.run_pending_tasks().await;
 ///     println!("Entry count: {}", cache.entry_count());
 ///
 ///     // Verify that key 1 has been evicted.
@@ -425,6 +427,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 ///     println!("\nSleeping for a second...\n");
 ///     tokio::time::sleep(Duration::from_secs(1)).await;
+///     cache.run_pending_tasks().await;
 ///     println!("Entry count: {}", cache.entry_count());
 ///
 ///     println!("\nDone!");


### PR DESCRIPTION
* remove unused imports
* add feature time to tokio, since the example uses tokio::time
* do cache.run_pending_tasks() before emitting the entry count so that it's accurate