### PR TITLE
Fix Clippy warnings (v0.12.x)

### DIFF
--- a/examples/reinsert_expired_entries_sync.rs
+++ b/examples/reinsert_expired_entries_sync.rs
@@ -1,3 +1,6 @@
+// This example requires Rust 1.70.0 or newer.
+#![allow(clippy::incompatible_msrv)]
+
 //! This example demonstrates how to write an eviction listener that will reinsert
 //! the expired entries.
 //!

--- a/src/common/concurrent/atomic_time/atomic_time.rs
+++ b/src/common/concurrent/atomic_time/atomic_time.rs
@@ -13,7 +13,7 @@ pub(crate) struct AtomicInstant {
 impl Default for AtomicInstant {
     fn default() -> Self {
         Self {
-            instant: AtomicU64::new(std::u64::MAX),
+            instant: AtomicU64::new(u64::MAX),
         }
     }
 }
@@ -45,7 +45,9 @@ impl AtomicInstant {
                 TypeId::of::<ClockInstant>(),
                 TypeId::of::<quanta::Instant>()
             );
-            Some(Instant::new(unsafe { std::mem::transmute(ts) }))
+            Some(Instant::new(unsafe {
+                std::mem::transmute::<u64, quanta::Instant>(ts)
+            }))
         }
     }
 
@@ -54,7 +56,7 @@ impl AtomicInstant {
             TypeId::of::<ClockInstant>(),
             TypeId::of::<quanta::Instant>()
         );
-        let ts = unsafe { std::mem::transmute(instant.inner_clock()) };
+        let ts = unsafe { std::mem::transmute::<quanta::Instant, u64>(instant.inner_clock()) };
         self.instant.store(ts, Ordering::Release);
     }
 }

--- a/src/common/concurrent/debug_counters.rs
+++ b/src/common/concurrent/debug_counters.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "unstable-debug-counters")]
-
 use crossbeam_utils::atomic::AtomicCell;
 use once_cell::sync::Lazy;
 

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -117,7 +117,7 @@ impl FrequencySketch {
         }
 
         let start = ((hash & 3) << 2) as u8;
-        let mut frequency = std::u8::MAX;
+        let mut frequency = u8::MAX;
         for i in 0..4 {
             let index = self.index_of(hash, i);
             let count = (self.table[index] >> ((start + i) << 2) & 0xF) as u8;
@@ -257,7 +257,7 @@ mod tests {
         let mut sketch = FrequencySketch::default();
         sketch.ensure_capacity(512);
         let mut indexes = std::collections::HashSet::new();
-        let hashes = [std::u64::MAX, 0, 1];
+        let hashes = [u64::MAX, 0, 1];
         for hash in hashes.iter() {
             for depth in 0..4 {
                 indexes.insert(sketch.index_of(*hash, depth));


### PR DESCRIPTION
Fix the following Clippy warnings:

### Stable: clippy 0.1.78 (9b00956e 2024-04-29)

- Allow `clippy::incompatible_msrv` on `examples/reinsert_expired_entries_sync.rs`, which requires Rust 1.70.0 or newer.
   ```console
   warning: current MSRV (Minimum Supported Rust Version) is `1.65.0` but this item is stable since `1.70.0`
   --> examples/reinsert_expired_entries_sync.rs:50:9
      |
   50 |     SND.set(Mutex::new(snd.clone())).unwrap();
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ```

### Beta: clippy 0.1.79 (d9e85b56e7f 2024-05-25)

- Fix `clippy::legacy_numeric_constants` as suggested.
- Fix `clippy::missing-transmute-annotations` as suggested.
- Fix `clippy::duplicated-attributes` as suggested.