### PR TITLE
CI: codecov.io - Measure the code coverage with `cargo-llvm-cov` and upload the report to codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.com/docs/quick-start#tips-and-tricks
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -1,0 +1,91 @@
+name: Codecov
+
+on:
+  push:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+  pull_request:
+    paths-ignore:
+    - '.devcontainer/**'
+    - '.gitpod.yml'
+    - '.vscode/**'
+
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        # https://github.com/marketplace/actions/skip-duplicate-actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      # Continue running other jobs in the matrix even if one fails.
+      fail-fast: false
+
+    steps:
+      - name: Checkout Moka
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run tests (sync and future features)
+        run: cargo llvm-cov --no-report --features 'sync, future'
+        env:
+          RUSTFLAGS: '--cfg rustver'
+
+      - name: Run tests (no quanta feature)
+        run: cargo llvm-cov --no-report --no-default-features --features 'sync, future, atomic64'
+        env:
+          RUSTFLAGS: '--cfg rustver'
+
+      - name: Run tests (sync feature, key lock test for notification)
+        run: |
+          cargo llvm-cov --no-report --lib --features sync \
+            -- sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications \
+            --exact --ignored
+
+      - name: Run tests (sync feature, drop value after eviction for sync::Cache)
+        run: |
+          cargo llvm-cov --no-report --lib --features sync \
+            -- sync::cache::tests::drop_value_immediately_after_eviction \
+            --exact --ignored
+
+      - name: Run tests (sync feature, drop value after eviction for sync::SegmentedCache)
+        run: |
+          cargo llvm-cov --no-report --lib --features sync \
+            -- sync::segment::tests::drop_value_immediately_after_eviction \
+            --exact --ignored
+
+      - name: Run tests (sync feature, drop cache)
+        run: |
+          cargo llvm-cov --no-report --lib --features sync \
+            -- sync::cache::tests::ensure_gc_runs_when_dropping_cache \
+            --exact --ignored
+
+      - name: Generate coverage report
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          files: ./lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions job called "Codecov", which does the followings:

- Measure the code coverage on `cargo test`s with `cargo-llvm-cov`.
- Upload the report to codecov.io.

