### PR TITLE
Remove an experimental `js` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,6 @@ logging = ["log"]
 # https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
 atomic64 = []
 
-# This is an **experimental** feature to make `sync` caches to compile for
-# `wasm32-unknown-unknown` target. Note that we have not tested if these caches work
-# correctly in wasm32 environment.
-js = ["uuid/js"]
-
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns
 # counters of internal object construction and destruction. It will have some
 # performance impacts and is intended for debugging.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ routers. Here are some highlights:
     - [Choosing the right cache for your use case](#choosing-the-right-cache-for-your-use-case)
 - [Moka in Production](#moka-in-production)
 - [Change Log](#change-log)
+- [Supported Platforms](#supported-platforms)
 - [Usage](#usage)
 - Examples (Part 1)
     - [Synchronous Cache](#example-synchronous-cache)
@@ -151,6 +152,35 @@ routers. Here are some highlights:
 - [License](#license)
 
 
+## Supported Platforms
+
+Moka should work on most 64-bit and 32-bit platforms if Rust `std` library is
+available with threading support. However, WebAssembly (Wasm) and WASI targets are
+not supported.
+
+The following platforms are tested on CI:
+
+- Linux 64-bit (x86_64, arm aarch64)
+- Linux 32-bit (i646, armv7, armv5, mips)
+    - If you get compile errors on 32-bit platforms, see
+      [troubleshooting](#compile-errors-on-some-32-bit-platforms).
+
+The following platforms are not tested on CI but should work:
+
+- macOS (arm64)
+- Windows (x86_64 msvc and gnu)
+- iOS (arm64)
+
+The following platforms are _not_ supported:
+
+- WebAssembly (Wasm) and WASI targets are not supported.
+  (See [this project task][gh-proj-49877487])
+- `nostd` environment (platforms without `std` library) are not supported.
+- 16-bit platforms are not supported.
+
+[gh-proj-49877487]: https://github.com/orgs/moka-rs/projects/1?pane=issue&itemId=49877487
+
+
 ## Usage
 
 To add Moka to your dependencies, run `cargo add` as the followings:
@@ -162,6 +192,8 @@ cargo add moka --features sync
 # To use the asynchronous cache:
 cargo add moka --features future
 ```
+
+If you want to use the cache under an async runtime such as `tokio` or `async-std`, you should specify the `future` feature. Otherwise, specify the `sync` feature.
 
 
 ## Example: Synchronous Cache
@@ -515,6 +547,12 @@ $ cargo +nightly -Z unstable-options --config 'build.rustdocflags="--cfg docsrs"
 
 ## Roadmap
 
+See the [project roadmap][gh-proj-1] for the updated and detailed plans.
+
+But here are some highlights:
+
+[gh-proj-1]: https://github.com/orgs/moka-rs/projects/1/views/1
+
 - [x] Size-aware eviction. (`v0.7.0` via [#24][gh-pull-024])
 - [x] API stabilization. (Smaller core API, shorter names for frequently used
        methods) (`v0.8.0` via [#105][gh-pull-105])
@@ -529,8 +567,8 @@ $ cargo +nightly -Z unstable-options --config 'build.rustdocflags="--cfg docsrs"
   [#316][gh-pull-316])
 - [x] Add upsert and compute methods. (`v0.12.3` via [#370][gh-pull-370])
 - [ ] Cache statistics (Hit rate, etc.). ([details][cache-stats])
-- [ ] Restore cache from a snapshot. ([details][restore])
 - [ ] Upgrade TinyLFU to Window-TinyLFU. ([details][tiny-lfu])
+- [ ] Restore cache from a snapshot. ([details][restore])
 
 [gh-pull-024]: https://github.com/moka-rs/moka/pull/24
 [gh-pull-105]: https://github.com/moka-rs/moka/pull/105


### PR DESCRIPTION
Remove the `js` feature.

The `js` feature is experimental and it is actually broken (will not compile). Moka currently does not support Wasm and WASI targets.

Fixes #423.