### PR TITLE
CI: Run Cirrus CI only by cron

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,12 @@ env:
   NUM_CPUS: "2"
 
 linux_arm64_task:
+  # Run only when triggered manually or by cron.
+  #
+  # Note that the cron schedule is set from Cirrus CI web console (not in this file):
+  # See: https://cirrus-ci.org/guide/writing-tasks/#cron-builds
+  trigger_type: manual
+
   # Skip the whole task when this is a temporary branch for GitHub merge queue.
   skip: $CIRRUS_BRANCH =~ 'gh-readonly-queue/.*'
 


### PR DESCRIPTION
We use Cirrus CI for testing Moka on real Arm64 machine. However, it takes very long time (about 25 minutes) to complete.

Change Cirrus CI job to be manually triggered, and set up a cron schedule for it. (I hope a manually triggered job can be automatically triggered by cron, but it is not clear on [the doc](https://cirrus-ci.org/guide/writing-tasks/#cron-builds))