### PR TITLE
CI: Fix the CI for the MSRV 1.65

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -5,3 +5,4 @@ set -eux
 # Pin some dependencies to specific versions for the MSRV.
 # cargo update -p <crate> --precise <version>
 cargo update -p actix-rt --precise 2.9.0
+cargo update -p cc --precise 1.0.105


### PR DESCRIPTION
- Pin `cc` to `v1.0.105` when testing the MSRV.