### PR TITLE
Make `once_cell` dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,13 +38,12 @@ atomic64 = []
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns
 # counters of internal object construction and destruction. It will have some
 # performance impacts and is intended for debugging.
-unstable-debug-counters = ["future"]
+unstable-debug-counters = ["future", "once_cell"]
 
 [dependencies]
 crossbeam-channel = "0.5.5"
 crossbeam-epoch = "0.9.9"
 crossbeam-utils = "0.8"
-once_cell = "1.7"
 parking_lot = "0.12"
 smallvec = "1.8"
 tagptr = "0.2"
@@ -68,6 +67,9 @@ futures-util = { version = "0.3.17", optional = true }
 # Optional dependencies (logging)
 log = { version = "0.4", optional = true }
 
+# Optional dependencies (unstable-debug-counters)
+once_cell = { version = "1.7", optional = true }
+
 [dev-dependencies]
 actix-rt = "2.8"
 ahash = "0.8.3"
@@ -75,6 +77,7 @@ anyhow = "1.0.19"
 async-std = { version = "1.12", features = ["attributes"] }
 env_logger = "0.10.0"
 getrandom = "0.2"
+once_cell = "1.7"
 paste = "1.0.9"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls"] }
 tokio = { version = "1.19", features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time" ] }


### PR DESCRIPTION
Fixes #427.

This pull request changes `once_cell` crate optional. After applying this change, `once_cell` is used by `moka` only when the followings:

- development build (e.g. `cargo test`).
- `unstable-debug-counters` feature is enabled.

```console
## `once_cell` is used in [dev-dependency], and indirectly via `quanta`.

$ cargo tree -i once_cell -F future,sync
once_cell v1.19.0
├── ahash v0.8.11
│   [dev-dependencies]
│   └── moka v0.12.8 ( ... /moka)
├── async-global-executor v2.4.1
│   └── async-std v1.12.0
│       [dev-dependencies]
│       └── moka v0.12.8 ( ... /moka)
├── async-std v1.12.0 (*)
├── quanta v0.12.3
│   └── moka v0.12.8 ( ... /moka)
├── reqwest v0.11.27
│   [dev-dependencies]
│   └── moka v0.12.8 ( ... /moka)
└── tracing-core v0.1.32
    └── tracing v0.1.40
        ├── async-io v2.3.3
        │   └── async-global-executor v2.4.1 (*)
        ├── h2 v0.3.26
        │   ├── hyper v0.14.30
        │   │   ├── hyper-rustls v0.24.2
        │   │   │   └── reqwest v0.11.27 (*)
        │   │   └── reqwest v0.11.27 (*)
        │   └── reqwest v0.11.27 (*)
        ├── hyper v0.14.30 (*)
        └── polling v3.7.2
            └── async-io v2.3.3 (*)
[dev-dependencies]
└── moka v0.12.8 ( ... /moka)

## If the default features is disabled, `once_cell` appears only under [dev-dependency].

cargo tree -i once_cell --no-default-features -F future,sync
once_cell v1.19.0
├── ahash v0.8.11
│   [dev-dependencies]
│   └── moka v0.12.8 ( ... /moka)
├── async-global-executor v2.4.1
│   └── async-std v1.12.0
│       [dev-dependencies]
│       └── moka v0.12.8 ( ... /moka)
├── async-std v1.12.0 (*)
├── reqwest v0.11.27
│   [dev-dependencies]
│   └── moka v0.12.8 ( ... /moka)
└── tracing-core v0.1.32
    └── tracing v0.1.40
        ├── async-io v2.3.3
        │   └── async-global-executor v2.4.1 (*)
        ├── h2 v0.3.26
        │   ├── hyper v0.14.30
        │   │   ├── hyper-rustls v0.24.2
        │   │   │   └── reqwest v0.11.27 (*)
        │   │   └── reqwest v0.11.27 (*)
        │   └── reqwest v0.11.27 (*)
        ├── hyper v0.14.30 (*)
        └── polling v3.7.2
            └── async-io v2.3.3 (*)
[dev-dependencies]
└── moka v0.12.8 ( ... /moka)
```