### PR TITLE
Remove needless traits along with `async-trait` usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["atomic64", "quanta"]
 sync = []
 
 # Enable this feature to use `moka::future::Cache`.
-future = ["async-lock", "async-trait", "event-listener", "futures-util"]
+future = ["async-lock", "event-listener", "futures-util"]
 
 # Enable this feature to activate optional logging from caches.
 # Currently cache will emit log only when it encounters a panic in user provided
@@ -60,7 +60,6 @@ quanta = { version = "0.12.2", optional = true }
 
 # Optional dependencies (future)
 async-lock = { version = "3.3", optional = true }
-async-trait = { version = "0.1.58", optional = true }
 event-listener = { version = "5.3", optional = true }
 futures-util = { version = "0.3.17", optional = true }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1,5 +1,5 @@
 use super::{
-    value_initializer::{GetOrInsert, InitResult, ValueInitializer},
+    value_initializer::{InitResult, ValueInitializer},
     CacheBuilder, OwnedKeyEntrySelector, RefKeyEntrySelector,
 };
 use crate::{
@@ -572,7 +572,7 @@ use std::{
 ///
 
 pub struct Cache<K, V, S = RandomState> {
-    base: BaseCache<K, V, S>,
+    pub(crate) base: BaseCache<K, V, S>,
     value_initializer: Arc<ValueInitializer<K, V, S>>,
 }
 
@@ -1845,27 +1845,6 @@ where
             }
         }
         Ok(())
-    }
-}
-
-impl<K, V, S> GetOrInsert<K, V> for Cache<K, V, S>
-where
-    K: Hash + Eq + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-    S: BuildHasher + Clone + Send + Sync + 'static,
-{
-    fn get_entry(&self, key: &Arc<K>, hash: u64) -> Option<Entry<K, V>> {
-        let ignore_if = None as Option<&mut fn(&V) -> bool>;
-        self.base
-            .get_with_hash_and_ignore_if(key, hash, ignore_if, true)
-    }
-
-    fn insert(&self, key: Arc<K>, hash: u64, value: V) {
-        self.insert_with_hash(key.clone(), hash, value);
-    }
-
-    fn remove(&self, key: &Arc<K>, hash: u64) -> Option<V> {
-        self.invalidate_with_hash(key, hash, true)
     }
 }
 


### PR DESCRIPTION
I originally just found a redundant `Arc::clone` within `GetOrInsert::insert`.
But then I discovered that `GetOrInsert` only has a single implementor and is thus unnecessary indirection.

The similar thing was true for `GetOrRemoveEntry` and `InnerSync`, so I removed those as well. One reason they might have existed was using a trait for code encapsulation, as removing them resulted in a bit more `pub(crate)` visibility, and a bunch more trait bounds all over the place.

However, in particular `#[async_trait]` usage was allocating `Box<dyn Future>` and using dynamic dispatch at runtime. Now that overhead is avoided and the compiler should be able to produce better code.