### PR TITLE
Fix CI: Fix a Clippy warning and pin tokio version for the MSRV

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -6,3 +6,4 @@ set -eux
 # cargo update -p <crate> --precise <version>
 cargo update -p actix-rt --precise 2.9.0
 cargo update -p cc --precise 1.0.105
+cargo update -p tokio --precise 1.38.1

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -101,7 +101,7 @@ impl FrequencySketch {
         }
 
         self.table = vec![0; table_size as usize].into_boxed_slice();
-        self.table_mask = 0.max(table_size - 1) as u64;
+        self.table_mask = table_size.saturating_sub(1) as u64;
         self.sample_size = if cap == 0 {
             10
         } else {


### PR DESCRIPTION
- Fix a Clippy warning
    - clippy 0.1.81 (6c199c89c72 2024-08-15)
- Fix the CI for the MSRV 1.65.0.
    - Pin `tokio` version to `1.38.1`.