### PR TITLE
CI: Run `miri` using tree borrows in addition to the existing stacked borrows

### DIFF
--- a/.github/workflows/Miri.yml
+++ b/.github/workflows/Miri.yml
@@ -47,8 +47,18 @@ jobs:
 
       - run: cargo miri setup
 
-      - name: Run Miri test (deque)
+      - name: Run Miri test on deque module using tree borrows
+        run: cargo miri test deque --features 'sync, future'
+        env:
+          MIRIFLAGS: '-Zmiri-tree-borrows'
+
+      - name: Run Miri test on timer_wheel module using tree borrows
+        run: cargo miri test timer_wheel --features 'sync, future'
+        env:
+          MIRIFLAGS: '-Zmiri-tree-borrows'
+
+      - name: Run Miri test on deque module using stacked borrows
         run: cargo miri test deque --features 'sync, future'
 
-      - name: Run Miri test (timer_wheel)
+      - name: Run Miri test on timer_wheel module using stacked borrows
         run: cargo miri test timer_wheel --features 'sync, future'


### PR DESCRIPTION
Our CI runs `miri` on the following internal modules, which contain a bunch of `unsafe` codes.

- `deque`
- `timer_wheel`

And we have only used `miri`'s stacked borrows model to detect pointer aliasing violations.

This pull request adds `miri` tests using tree borrows model so that our CI will detect the problems like the one reported by #452.

https://github.com/moka-rs/moka/actions/runs/10545853093/job/29216602204
![miri-tree-borrows](https://github.com/user-attachments/assets/a645f37a-4ae3-49b9-9320-d39ae1e53caa)
