### PR TITLE
Fix the CI: 2024-09-15 v0.12.x

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -6,4 +6,5 @@ set -eux
 # cargo update -p <crate> --precise <version>
 cargo update -p actix-rt --precise 2.9.0
 cargo update -p cc --precise 1.0.105
+cargo update -p tokio-util --precise 0.7.11
 cargo update -p tokio --precise 1.38.1

--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -53,3 +53,5 @@ jobs:
         uses: model-checking/kani-github-action@v1.0
         with:
           args: --features 'sync, future'
+          # Workaround for https://github.com/moka-rs/moka/issues/457
+          kani-version: '0.54.0'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,17 @@ trybuild = "1.0"
 [target.'cfg(rustver)'.build-dependencies]
 rustc_version = "0.4.0"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    "cfg(armv5te)",
+    "cfg(beta_clippy)",
+    "cfg(kani)",
+    "cfg(mips)",
+    "cfg(rustver)",
+    "cfg(skip_large_mem_tests)",
+    "cfg(trybuild)",
+] }
+
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]
 # Build the doc at docs.rs with some features enabled.

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,3 @@
-#![allow(unexpected_cfgs)] // for `#[cfg(rustver)]` in this build.rs.
-
-const ALLOWED_CFG_NAMES: &[&str] = &[
-    "armv5te",
-    "beta_clippy",
-    "kani",
-    "mips",
-    "rustver",
-    "skip_large_mem_tests",
-    "trybuild",
-];
-
 #[cfg(rustver)]
 fn main() {
     use rustc_version::version;
@@ -18,18 +6,7 @@ fn main() {
         "cargo:rustc-env=RUSTC_SEMVER={}.{}",
         version.major, version.minor
     );
-
-    allow_cfgs(ALLOWED_CFG_NAMES);
 }
 
 #[cfg(not(rustver))]
-fn main() {
-    allow_cfgs(ALLOWED_CFG_NAMES);
-}
-
-/// Tells `rustc` to allow `#[cfg(...)]` with the given names.
-fn allow_cfgs(names: &[&str]) {
-    for name in names.iter() {
-        println!("cargo:rustc-check-cfg=cfg({name})");
-    }
-}
+fn main() {}


### PR DESCRIPTION
- Pin Kani verifier to `v0.54.0` to avoid out of memory errors with `v0.55.0`.
- Pin `tokio-util` version to `0.7.11` to fix the CI for the MSRV `1.65.0`.
- Move the `check-cfg` lint stuff from the build script to `Cargo.toml`.