### PR TITLE
Support and_try_compute_if_nobody_else

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1879,6 +1879,23 @@ where
             .await
     }
 
+    pub(crate) async fn try_compute_if_nobody_else_with_hash_and_fun<F, Fut, E>(
+        &self,
+        key: Arc<K>,
+        hash: u64,
+        f: F,
+    ) -> Result<compute::CompResult<K, V>, E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let post_init = ValueInitializer::<K, V, S>::post_init_for_try_compute_with_if_nobody_else;
+        self.value_initializer
+            .try_compute_if_nobody_else(key, hash, self, f, post_init, true)
+            .await
+    }
+
     pub(crate) async fn upsert_with_hash_and_fun<F, Fut>(
         &self,
         key: Arc<K>,

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -878,6 +878,21 @@ where
             .await
     }
 
+    pub async fn and_try_compute_if_nobody_else<F, Fut, E>(
+        self,
+        f: F,
+    ) -> Result<compute::CompResult<K, V>, E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.ref_key.to_owned());
+        self.cache
+            .try_compute_if_nobody_else_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
     /// Performs an upsert of an [`Entry`] by using the given closure `f`. The word
     /// "upsert" here means "update" or "insert".
     ///


### PR DESCRIPTION
Issue: #433 
It will only evaluate one closure for a certain entry, and other closures will be canceled, returning `CompResult::Unchanged`.

Add `ValueInitializer::post_init_for_try_compute_with_if_nobody_else`. 
Add `Cache::try_compute_if_nobody_else_with_hash_and_fun`. 
Add `RefKeyEntrySelector::and_try_compute_if_nobody_else`.