### PR TITLE
Fix Clippy warnings and fix the CI for the minimal crate versions

### DIFF
--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -3,6 +3,5 @@
 set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain.
-cargo update -p proc-macro2 --precise 1.0.63
 # https://github.com/tkaitchuck/aHash/issues/200
 cargo update -p ahash --precise 0.8.7

--- a/src/cht/iter.rs
+++ b/src/cht/iter.rs
@@ -35,7 +35,7 @@ impl<'i, K, V> Iter<'i, K, V> {
     }
 }
 
-impl<'i, K, V> Iterator for Iter<'i, K, V>
+impl<K, V> Iterator for Iter<'_, K, V>
 where
     K: Eq + Hash + Clone + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
@@ -58,7 +58,7 @@ where
     }
 }
 
-impl<'i, K, V> Iter<'i, K, V>
+impl<K, V> Iter<'_, K, V>
 where
     K: Eq + Hash + Clone + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,

--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -369,7 +369,7 @@ struct Probe<'b, 'g, K: 'g, V: 'g> {
     reload: bool,
 }
 
-impl<'b, 'g, K: 'g, V: 'g> Probe<'b, 'g, K, V> {
+impl<'g, K: 'g, V: 'g> Probe<'_, 'g, K, V> {
     fn reload(&mut self) {
         self.reload = true;
     }

--- a/src/cht/map/bucket_array_ref.rs
+++ b/src/cht/map/bucket_array_ref.rs
@@ -13,7 +13,7 @@ pub(crate) struct BucketArrayRef<'a, K, V, S> {
     pub(crate) len: &'a AtomicUsize,
 }
 
-impl<'a, K, V, S> BucketArrayRef<'a, K, V, S>
+impl<K, V, S> BucketArrayRef<'_, K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
@@ -293,7 +293,7 @@ where
     }
 }
 
-impl<'a, 'g, K, V, S> BucketArrayRef<'a, K, V, S> {
+impl<'g, K, V, S> BucketArrayRef<'_, K, V, S> {
     fn get(&self, guard: &'g Guard) -> &'g BucketArray<K, V> {
         let mut maybe_new_bucket_array = None;
 

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -83,7 +83,7 @@ impl<T> Drop for Deque<T> {
     fn drop(&mut self) {
         struct DropGuard<'a, T>(&'a mut Deque<T>);
 
-        impl<'a, T> Drop for DropGuard<'a, T> {
+        impl<T> Drop for DropGuard<'_, T> {
             fn drop(&mut self) {
                 // Continue the same loop we do below. This only runs when a destructor has
                 // panicked. If another one panics this will abort.

--- a/src/common/timer_wheel.rs
+++ b/src/common/timer_wheel.rs
@@ -440,7 +440,7 @@ impl<'iter, K> TimerEventsIter<'iter, K> {
     }
 }
 
-impl<'iter, K> Drop for TimerEventsIter<'iter, K> {
+impl<K> Drop for TimerEventsIter<'_, K> {
     fn drop(&mut self) {
         if !self.is_done {
             // This iterator was dropped before consuming all events. Reset the
@@ -451,7 +451,7 @@ impl<'iter, K> Drop for TimerEventsIter<'iter, K> {
     }
 }
 
-impl<'iter, K> Iterator for TimerEventsIter<'iter, K> {
+impl<K> Iterator for TimerEventsIter<'_, K> {
     type Item = TimerEvent<K>;
 
     /// NOTE: When necessary, this iterator will unset the timer node pointer in the

--- a/src/future.rs
+++ b/src/future.rs
@@ -63,7 +63,7 @@ impl<'i, K, V> Iter<'i, K, V> {
     }
 }
 
-impl<'i, K, V> Iterator for Iter<'i, K, V>
+impl<K, V> Iterator for Iter<'_, K, V>
 where
     K: Eq + Hash + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
@@ -131,7 +131,7 @@ impl<'a, K, V> CancelGuard<'a, K, V> {
     }
 }
 
-impl<'a, K, V> Drop for CancelGuard<'a, K, V> {
+impl<K, V> Drop for CancelGuard<'_, K, V> {
     fn drop(&mut self) {
         let interrupted_op = match (self.future.take(), self.op.take()) {
             (Some(future), Some(op)) => InterruptedOp::CallEvictionListener {

--- a/src/future/key_lock.rs
+++ b/src/future/key_lock.rs
@@ -24,7 +24,7 @@ where
     lock: TrioArc<Mutex<()>>,
 }
 
-impl<'a, K, S> Drop for KeyLock<'a, K, S>
+impl<K, S> Drop for KeyLock<'_, K, S>
 where
     K: Eq + Hash,
     S: BuildHasher,

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -94,7 +94,7 @@ where
     }
 }
 
-impl<'a, K, V, S> Drop for WaiterGuard<'a, K, V, S>
+impl<K, V, S> Drop for WaiterGuard<'_, K, V, S>
 where
     K: Eq + Hash,
     V: Clone,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -570,7 +570,6 @@ use std::{
 ///
 /// [builder-name-method]: ./struct.CacheBuilder.html#method.name
 ///
-
 pub struct Cache<K, V, S = RandomState> {
     pub(crate) base: BaseCache<K, V, S>,
     value_initializer: Arc<ValueInitializer<K, V, S>>,

--- a/src/sync_base/iter.rs
+++ b/src/sync_base/iter.rs
@@ -59,7 +59,7 @@ impl<'i, K, V> Iter<'i, K, V> {
     }
 }
 
-impl<'i, K, V> Iterator for Iter<'i, K, V>
+impl<K, V> Iterator for Iter<'_, K, V>
 where
     K: Eq + Hash + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
@@ -124,14 +124,24 @@ where
     }
 }
 
-unsafe impl<'a, 'i, K, V> Send for Iter<'i, K, V>
+// Clippy beta 0.1.83 (f41c7ed9889 2024-10-31) warns about unused lifetimes on 'a.
+// This seems a false positive. The lifetimes are used in the Send and Sync impls.
+// Let's suppress the warning.
+// https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
+#[allow(clippy::extra_unused_lifetimes)]
+unsafe impl<'a, K, V> Send for Iter<'_, K, V>
 where
     K: 'a + Eq + Hash + Send,
     V: 'a + Send,
 {
 }
 
-unsafe impl<'a, 'i, K, V> Sync for Iter<'i, K, V>
+// Clippy beta 0.1.83 (f41c7ed9889 2024-10-31) warns about unused lifetimes on 'a.
+// This seems a false positive. The lifetimes are used in the Send and Sync impls.
+// Let's suppress the warning.
+// https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
+#[allow(clippy::extra_unused_lifetimes)]
+unsafe impl<'a, K, V> Sync for Iter<'_, K, V>
 where
     K: 'a + Eq + Hash + Sync,
     V: 'a + Sync,

--- a/src/sync_base/key_lock.rs
+++ b/src/sync_base/key_lock.rs
@@ -24,7 +24,7 @@ where
     lock: TrioArc<Mutex<()>>,
 }
 
-impl<'a, K, S> Drop for KeyLock<'a, K, S>
+impl<K, S> Drop for KeyLock<'_, K, S>
 where
     K: Eq + Hash,
     S: BuildHasher,


### PR DESCRIPTION
- Fix beta Clippy warnings
    - clippy 0.1.83 (f41c7ed9889 2024-10-31)
- Fix the CI for nightly + minimal crate versions
    - Unpin the `proc-macro2` version.
    - This fixes #461