### PR TITLE
Fix CI 2024-12 (v0.12)

### DIFF
--- a/.ci_extras/pin-crate-vers-kani.sh
+++ b/.ci_extras/pin-crate-vers-kani.sh
@@ -4,4 +4,4 @@ set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain
 # used by Kani verifier.
-# cargo update -p crate-name --precise x.y.z
+# cargo update crate-name --precise x.y.z

--- a/.ci_extras/pin-crate-vers-kani.sh
+++ b/.ci_extras/pin-crate-vers-kani.sh
@@ -4,4 +4,4 @@ set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain
 # used by Kani verifier.
-# cargo update crate-name --precise x.y.z
+# cargo update -p crate-name --precise x.y.z

--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -3,8 +3,9 @@
 set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
-# cargo update -p <crate> --precise <version>
-cargo update -p actix-rt --precise 2.9.0
-cargo update -p cc --precise 1.0.105
-cargo update -p tokio-util --precise 0.7.11
-cargo update -p tokio --precise 1.38.1
+# cargo update <crate> --precise <version>
+cargo update actix-rt --precise 2.9.0
+cargo update cc --precise 1.0.105
+cargo update tokio-util --precise 0.7.11
+cargo update tokio --precise 1.38.1
+cargo update url --precise 2.5.2

--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -3,9 +3,9 @@
 set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
-# cargo update <crate> --precise <version>
-cargo update actix-rt --precise 2.9.0
-cargo update cc --precise 1.0.105
-cargo update tokio-util --precise 0.7.11
-cargo update tokio --precise 1.38.1
-cargo update url --precise 2.5.2
+# cargo update -p <crate> --precise <version>
+cargo update -p actix-rt --precise 2.9.0
+cargo update -p cc --precise 1.0.105
+cargo update -p tokio-util --precise 0.7.11
+cargo update -p tokio --precise 1.38.1
+cargo update -p url --precise 2.5.2

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -3,6 +3,6 @@
 set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain.
-# cargo update <crate> --precise <version>
+# cargo update -p <crate> --precise <version>
 # https://github.com/tkaitchuck/aHash/issues/200
-cargo update ahash --precise 0.8.7
+cargo update -p ahash --precise 0.8.7

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -3,5 +3,6 @@
 set -eux
 
 # Pin some dependencies to specific versions for the nightly toolchain.
+# cargo update <crate> --precise <version>
 # https://github.com/tkaitchuck/aHash/issues/200
-cargo update -p ahash --precise 0.8.7
+cargo update ahash --precise 0.8.7

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -565,13 +565,13 @@ where
         (ins_op, ts)
     }
 
-    async fn do_post_update_steps<'a>(
+    async fn do_post_update_steps(
         &self,
         ts: Instant,
         key: Arc<K>,
         old_info: OldEntryInfo<K, V>,
         upd_op: WriteOp<K, V>,
-        interrupted_op_ch: &'a Sender<InterruptedOp<K, V>>,
+        interrupted_op_ch: &Sender<InterruptedOp<K, V>>,
     ) -> (WriteOp<K, V>, Instant) {
         use futures_util::FutureExt;
 


### PR DESCRIPTION
- Fix the CI for the MSRV 1.65
    - Pin `url` to `v2.5.2` when testing the MSRV.
- Fix a Clippy warning
    - `clippy 0.1.84 (202008a1b8 2024-12-07)`