### PR TITLE
CI: Fix the CI for the MSRV 1.65

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -9,3 +9,4 @@ cargo update -p cc --precise 1.0.105
 cargo update -p tokio-util --precise 0.7.11
 cargo update -p tokio --precise 1.38.1
 cargo update -p url --precise 2.5.2
+cargo update -p quanta --precise 0.12.2


### PR DESCRIPTION
- Pin `quanta` to `v0.12.2` when testing the MSRV.