### PR TITLE
Raise the MSRV from 1.70

### DIFF
--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -3,10 +3,4 @@
 set -eux
 
 # Pin some dependencies to specific versions for the MSRV.
-# cargo update -p <crate> --precise <version>
-cargo update -p actix-rt --precise 2.9.0
-cargo update -p cc --precise 1.0.105
-cargo update -p tokio-util --precise 0.7.11
-cargo update -p tokio --precise 1.38.1
 cargo update -p url --precise 2.5.2
-cargo update -p quanta --precise 0.12.2

--- a/.ci_extras/remove-examples-msrv.sh
+++ b/.ci_extras/remove-examples-msrv.sh
@@ -18,4 +18,4 @@ EOF
 }
 
 # `OnceLock` was introduced in 1.70.0.
-disable_example_sync reinsert_expired_entries_sync
+# disable_example_sync reinsert_expired_entries_sync

--- a/.devcontainer/ensure-rust-toolchains-installed.sh
+++ b/.devcontainer/ensure-rust-toolchains-installed.sh
@@ -4,5 +4,5 @@ set -eu
 
 rustup toolchain install stable -c clippy,rust-analysis,rust-src,rustfmt
 rustup toolchain install beta   -c clippy
-rustup toolchain install 1.65.0
+rustup toolchain install 1.70.0
 rustup default stable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.65.0  # MSRV
+          - 1.70.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -68,11 +68,11 @@ jobs:
         run: ./.ci_extras/pin-crate-vers-nightly.sh
 
       - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.65.0' }}
+        if: ${{ matrix.rust == '1.70.0' }}
         run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Remove some examples (MSRV only)
-        if: ${{ matrix.rust == '1.65.0' }}
+        if: ${{ matrix.rust == '1.70.0' }}
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Show cargo tree

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.65.0  # MSRV
+          - 1.70.0  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -60,11 +60,11 @@ jobs:
         run: ./.ci_extras/pin-crate-vers-nightly.sh
 
       - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.65.0' }}
+        if: ${{ matrix.rust == '1.70.0' }}
         run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Remove some examples (MSRV only)
-        if: ${{ matrix.rust == '1.65.0' }}
+        if: ${{ matrix.rust == '1.70.0' }}
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Run tests (debug, but no quanta feature)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.9
+
+Bumped the minimum supported Rust version (MSRV) to 1.70 (June 1, 2023).
+([#474][gh-pull-0474])
+
+
 ## Version 0.12.8
 
 ### Fixed
@@ -895,6 +901,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0474]: https://github.com/moka-rs/moka/pull/474/
 [gh-pull-0426]: https://github.com/moka-rs/moka/pull/426/
 [gh-pull-0421]: https://github.com/moka-rs/moka/pull/421/
 [gh-pull-0417]: https://github.com/moka-rs/moka/pull/417/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "moka"
 version = "0.12.8"
 edition = "2021"
-# Rust 1.65 was released on Nov 3, 2022.
-rust-version = "1.65"
+# Rust 1.70 was released on June 1, 2023.
+rust-version = "1.70"
 description = "A fast and concurrent cache library inspired by Java Caffeine"
 license = "MIT OR Apache-2.0"
 # homepage = "https://"

--- a/README.md
+++ b/README.md
@@ -467,18 +467,20 @@ section ([`sync::Cache`][doc-sync-cache-expiration],
 
 Moka's minimum supported Rust versions (MSRV) are the followings:
 
-| Feature          | MSRV                      |
-|:-----------------|:-------------------------:|
-| default features | Rust 1.65.0 (Nov 3, 2022) |
-| `future`         | Rust 1.65.0 (Nov 3, 2022) |
+| Feature  | MSRV                       |
+|:---------|:--------------------------:|
+| `future` | Rust 1.70.0 (June 3, 2022) |
+| `sync`   | Rust 1.70.0 (June 3, 2022) |
 
-It will keep a rolling MSRV policy of at least 6 months. If only the default features
-are enabled, MSRV will be updated conservatively. When using other features, like
-`future`, MSRV might be updated more frequently, up to the latest stable. In both
-cases, increasing MSRV is _not_ considered a semver-breaking change.
+It will keep a rolling MSRV policy of at least 6 months. If the default features with
+a mondatory features (`future` or `sync`) are enabled, MSRV will be updated
+conservatively. When using other features, MSRV might be updated more frequently, up
+to the latest stable.
+
+In both cases, increasing MSRV is _not_ considered a semver-breaking change.
 
 <!--
-- quanta v0.11.0 requires 1.60.
+- quanta v0.12.4 requires 1.70.0.
 -->
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,17 @@
 //!
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
-//! | Feature          | MSRV                      |
-//! |:-----------------|:-------------------------:|
-//! | default features | Rust 1.65.0 (Nov 3, 2022) |
-//! | `future`         | Rust 1.65.0 (Nov 3, 2022) |
+//! | Feature  | MSRV                       |
+//! |:---------|:--------------------------:|
+//! | `future` | Rust 1.70.0 (June 3, 2022) |
+//! | `sync`   | Rust 1.70.0 (June 3, 2022) |
 //!
-//! It will keep a rolling MSRV policy of at least 6 months. If only the default
-//! features are enabled, MSRV will be updated conservatively. When using other
-//! features, like `future`, MSRV might be updated more frequently, up to the latest
-//! stable. In both cases, increasing MSRV is _not_ considered a semver-breaking
-//! change.
+//! It will keep a rolling MSRV policy of at least 6 months. If the default features
+//! with a mondatory features (`future` or `sync`) are enabled, MSRV will be updated
+//! conservatively. When using other features, MSRV might be updated more frequently,
+//! up to the latest stable.
+//!
+//! In both cases, increasing MSRV is _not_ considered a semver-breaking change.
 
 #[cfg(not(any(feature = "sync", feature = "future")))]
 compile_error!(


### PR DESCRIPTION
Update the Minimum Supported Rust Version (MSRV) from 1.66 to 1.70. 

- Rust 1.70.0 was released on  June 1, 2023.
- `quanta@v0.12.4` requires Rust 1.70.0 or later.
