### PR TITLE
Prepare for `v0.12.9` release (1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,26 @@
 
 ## Version 0.12.9
 
-Bumped the minimum supported Rust version (MSRV) to 1.70 (June 1, 2023).
-([#474][gh-pull-0474])
+Bumped the minimum supported Rust version (MSRV) to 1.70 (June 1, 2023)
+([#474][gh-pull-0474]).
+
+### Added
+
+- Added `and_try_compute_if_nobody_else` method to `future::Cache`'s `entry` API.
+  ([#460][gh-pull-0460], by [@xuehaonan27][gh-xuehaonan27])
+
+### Removed
+
+- Removed needless traits along with `async-trait` usage. ([#445][gh-pull-0445], by
+  [@Swatinem][gh-Swatinem])
+
+### Changed
+
+- Enable `atomic64` feature only when target supports `AtomicU64`.
+  ([#466][gh-pull-0466], by [@zonyitoo][gh-zonyitoo])
+- Made `once_cell` dependency optional ([#444][gh-pull-0444]).
+- Stopped creating references unnecessarily to compare pointers by-address.
+  ([#452][gh-pull-0452], by [@JoJoDeveloping][gh-JoJoDeveloping])
 
 
 ## Version 0.12.8
@@ -868,6 +886,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-barkanido]: https://github.com/barkanido
 [gh-ClSlaid]: https://github.com/ClSlaid
 [gh-eaufavor]: https://github.com/eaufavor
+[gh-JoJoDeveloping]: https://github.com/JoJoDeveloping
 [gh-LMJW]: https://github.com/LMJW
 [gh-messense]: https://github.com/messense
 [gh-Milo123459]: https://github.com/Milo123459
@@ -877,6 +896,8 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-saethlin]: https://github.com/saethlin
 [gh-Swatinem]: https://github.com/Swatinem
 [gh-tinou98]: https://github.com/tinou98
+[gh-xuehaonan27]: https://github.com/xuehaonan27
+[gh-zonyitoo]: https://github.com/zonyitoo
 
 [gh-issue-0412]: https://github.com/moka-rs/moka/issues/412/
 [gh-issue-0385]: https://github.com/moka-rs/moka/issues/385/
@@ -902,6 +923,11 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
 [gh-pull-0474]: https://github.com/moka-rs/moka/pull/474/
+[gh-pull-0466]: https://github.com/moka-rs/moka/pull/466/
+[gh-pull-0460]: https://github.com/moka-rs/moka/pull/460/
+[gh-pull-0452]: https://github.com/moka-rs/moka/pull/452/
+[gh-pull-0445]: https://github.com/moka-rs/moka/pull/445/
+[gh-pull-0444]: https://github.com/moka-rs/moka/pull/444/
 [gh-pull-0426]: https://github.com/moka-rs/moka/pull/426/
 [gh-pull-0421]: https://github.com/moka-rs/moka/pull/421/
 [gh-pull-0417]: https://github.com/moka-rs/moka/pull/417/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 # Rust 1.70 was released on June 1, 2023.
 rust-version = "1.70"
@@ -29,10 +29,9 @@ future = ["async-lock", "event-listener", "futures-util"]
 # callback closure.
 logging = ["log"]
 
-# This feature is enabled by default. Disable it when the target platform does not
-# support `std::sync::atomic::AtomicU64`. (e.g. `armv5te-unknown-linux-musleabi`
-# or `mips-unknown-linux-musl`)
-# https://github.com/moka-rs/moka#resolving-compile-errors-on-some-32-bit-platforms
+# This feature is enabled by default, but will be automatically disabled if the
+# target platform does not support `std::sync::atomic::AtomicU64`.
+# (e.g. `armv5te-unknown-linux-musleabi` or `mips-unknown-linux-musl`)
 atomic64 = []
 
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns

--- a/README.md
+++ b/README.md
@@ -486,10 +486,10 @@ In both cases, increasing MSRV is _not_ considered a semver-breaking change.
 
 ## Troubleshooting
 
-### Compile Errors on Some 32-bit Platforms
+### Compile Errors on Some 32-bit Platforms (Moka v0.12.8 or earlier)
 
 On some 32-bit target platforms including the followings, you may encounter compile
-errors:
+errors if you use Moka v0.12.8 or earlier:
 
 - `armv5te-unknown-linux-musleabi`
 - `mips-unknown-linux-musl`
@@ -508,19 +508,10 @@ error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 Such errors can occur because `std::sync::atomic::AtomicU64` is not provided on these
 platforms but Moka uses it.
 
-You can resolve the errors by disabling `atomic64` feature, which is one of the
-default features of Moka. Edit your Cargo.toml to add `default-features = false`
-to the dependency declaration.
-
-```toml:Cargo.toml
-[dependencies]
-moka = { version = "0.12", default-features = false, features = ["sync"] }
-# Or
-moka = { version = "0.12", default-features = false, features = ["future"] }
-```
-
-This will make Moka to switch to a fall-back implementation, so it will compile.
-
+You can avoid the errors by upgrading Moka to v0.12.9 or later. These versions should
+automatically disable the `atomic64` feature, which is one of the default features of
+Moka. Disabling the feature will cause Moka to switch to a fall-back implementation,
+so that it will compile.
 
 ## Developing Moka
 


### PR DESCRIPTION
- Bump the version to `v0.12.9`.
- Update the `CHANGELOG.md`.
- Update the `README.md` and some comments in the `Cargo.toml` for #466.
