### PR TITLE
Add `and_try_compute_if_nobody_else` to `future::OwnedKeyEntrySelector`

### DIFF
--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -238,6 +238,21 @@ where
             .await
     }
 
+    pub async fn and_try_compute_if_nobody_else<F, Fut, E>(
+        self,
+        f: F,
+    ) -> Result<compute::CompResult<K, V>, E>
+    where
+        F: FnOnce(Option<Entry<K, V>>) -> Fut,
+        Fut: Future<Output = Result<compute::Op<V>, E>>,
+        E: Send + Sync + 'static,
+    {
+        let key = Arc::new(self.owned_key);
+        self.cache
+            .try_compute_if_nobody_else_with_hash_and_fun(key, self.hash, f)
+            .await
+    }
+
     /// Performs an upsert of an [`Entry`] by using the given closure `f`. The word
     /// "upsert" here means "update" or "insert".
     ///


### PR DESCRIPTION
This is for following up #460:

- `#460` added `and_try_compute_if_nobody_else` method to `moka::future::RefKeyEntrySelector`.
- This PR adds the same method to `moka::future::OwnedKeyEntrySelector`.