### PR TITLE
Avoid panic in an internal `base_cache::Clocks::to_std_instant` method

### DIFF
--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -1027,7 +1027,20 @@ impl Clocks {
         } else {
             (self.origin, self.origin_std)
         };
-        origin_std + (time.checked_duration_since(origin).unwrap())
+
+        // `checked_duration_since` should always succeed here because the `origin`
+        // is set when this `Cache` is created, and the `time` is either the last
+        // modified or last accessed time of a cached entry. So `time` should always
+        // be greater than or equal to `origin`.
+        //
+        // However, this is not always true when `quanta::Instant` is used as the
+        // time source? https://github.com/moka-rs/moka/issues/472
+        //
+        // (Or do we set zero Instant to last modified/accessed time somewhere?)
+        //
+        // As a workaround, let's use zero duration when `checked_duration_since`
+        // fails.
+        origin_std + (time.checked_duration_since(origin).unwrap_or_default())
     }
 
     #[cfg(test)]

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -896,7 +896,20 @@ impl Clocks {
         } else {
             (self.origin, self.origin_std)
         };
-        origin_std + (time.checked_duration_since(origin).unwrap())
+
+        // `checked_duration_since` should always succeed here because the `origin`
+        // is set when this `Cache` is created, and the `time` is either the last
+        // modified or last accessed time of a cached entry. So `time` should always
+        // be greater than or equal to `origin`.
+        //
+        // However, this is not always true when `quanta::Instant` is used as the
+        // time source? https://github.com/moka-rs/moka/issues/472
+        //
+        // (Or do we set zero Instant to last modified/accessed time somewhere?)
+        //
+        // As a workaround, let's use zero duration when `checked_duration_since`
+        // fails.
+        origin_std + (time.checked_duration_since(origin).unwrap_or_default())
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Fixes #472.

This PR should avoid occasional panic in an internal `base_cache::Clocks::to_std_instant` method by using zero `Duration` if `checked_duration_since` method fails.

I could not figure out why the specific call of `checked_duration_since` method can fail. I might have overlooked something in `moka`'s code, or maybe `quanta::Instant` can return not a monotonically increasing time on some CPUs?