### PR TITLE
Add `portable-atomic` crate for the platforms where `AtomicU64` is not available

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,7 +101,7 @@ jobs:
         run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
 
       - name: Run tests (future feature, but no sync feature)
-        run: cargo test --no-default-features --features 'future, atomic64, quanta'
+        run: cargo test --features future
 
       - name: Run tests (future, sync and logging features)
         run: cargo test --features 'future, sync, logging'

--- a/.github/workflows/CIArm64.yml
+++ b/.github/workflows/CIArm64.yml
@@ -56,7 +56,7 @@ jobs:
         run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
 
       - name: Run tests (future feature, but no sync feature)
-        run: cargo test --no-default-features --features 'future, atomic64, quanta'
+        run: cargo test --features future
         env:
           RUSTFLAGS: '--cfg skip_large_mem_tests'
 

--- a/.github/workflows/CIQuantaDisabled.yml
+++ b/.github/workflows/CIQuantaDisabled.yml
@@ -68,20 +68,20 @@ jobs:
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Run tests (debug, but no quanta feature)
-        run: cargo test --no-default-features --features 'sync, atomic64'
+        run: cargo test --no-default-features --features sync
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (release, but no quanta feature)
-        run: cargo test --release --no-default-features --features 'sync, atomic64'
+        run: cargo test --release --no-default-features --features sync
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (future feature, but no quanta and sync features)
-        run: cargo test --no-default-features --features 'future, atomic64'
+        run: cargo test --no-default-features --features future
 
       - name: Run tests (future, sync and logging features, but no quanta feature)
-        run: cargo test --no-default-features --features 'sync, future, atomic64, logging'
+        run: cargo test --no-default-features --features 'sync, future, logging'
 
       - name: Run tests (sync feature, but no quanta feature, drop cache)
         run: cargo test --release --lib --no-default-features --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -29,7 +29,7 @@ jobs:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (no quanta feature)
-        run: cargo llvm-cov --no-report --no-default-features --features 'sync, future, atomic64'
+        run: cargo llvm-cov --no-report --no-default-features --features 'sync, future'
         env:
           RUSTFLAGS: '--cfg rustver'
 

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -47,14 +47,11 @@ jobs:
             rust-version: stable
           # Platforms without AtomicU64 support.
           - target: armv5te-unknown-linux-musleabi
-            cargo-opts: "--no-default-features"  # Disable atomic64 and quanta features.
             rust-version: stable
           - target: mips-unknown-linux-musl
-            cargo-opts: "--no-default-features"  # Disable atomic64 and quanta features.
             rust-version: "1.72.1"
             cargo-version: "+1.72.1"
           - target: mipsel-unknown-linux-musl
-            cargo-opts: "--no-default-features"  # Disable atomic64 and quanta features.
             rust-version: "1.72.1"
             cargo-version: "+1.72.1"
 
@@ -86,17 +83,17 @@ jobs:
       - name: Run tests (sync feature)
         run: |
           cross ${{ matrix.platform.carge-version }} test --release -F sync \
-            --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+            --target ${{ matrix.platform.target }}
         env:
           RUSTFLAGS: '--cfg rustver'
 
       - name: Run tests (future feature)
         run: |
           cross ${{ matrix.platform.cargo-version }} test --release -F future \
-            --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }}
+            --target ${{ matrix.platform.target }}
 
       - name: Run tests (sync feature, drop cache)
         run: |
           cross ${{ matrix.platform.cargo-version }} test --release -F sync \
-            --target ${{ matrix.platform.target }} ${{ matrix.platform.cargo-opts }} \
+            --target ${{ matrix.platform.target }} \
             --lib sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.10
+
+### Changed
+
+- Switched to `AtomicU64` of `portable-atomic` crate for the platforms where
+  `AtomicU64` is not available in `std`. ([#480][gh-pull-0480])
+    - `moka`'s `atomic64` feature no longer has any effect on the build as
+      `AtomicU64` is now always used. But the feature is kept for backward
+      compatibility.
+
+
 ## Version 0.12.9
 
 Bumped the minimum supported Rust version (MSRV) to 1.70 (June 1, 2023)
@@ -937,6 +948,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0480]: https://github.com/moka-rs/moka/pull/480/
 [gh-pull-0474]: https://github.com/moka-rs/moka/pull/474/
 [gh-pull-0466]: https://github.com/moka-rs/moka/pull/466/
 [gh-pull-0460]: https://github.com/moka-rs/moka/pull/460/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ crossbeam-channel = "0.5.5"
 crossbeam-epoch = "0.9.9"
 crossbeam-utils = "0.8"
 parking_lot = "0.12"
-portable-atomic = { version = "1.6", default-features = false }
+portable-atomic = "1.6"
 smallvec = "1.8"
 tagptr = "0.2"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 build = "build.rs"
 
 [features]
-default = ["atomic64", "quanta"]
+default = ["quanta"]
 
 # Enable this feature to use `moka::sync::{Cache, SegmentedCache}`
 sync = []
@@ -29,9 +29,12 @@ future = ["async-lock", "event-listener", "futures-util"]
 # callback closure.
 logging = ["log"]
 
-# This feature is enabled by default, but will be automatically disabled if the
-# target platform does not support `std::sync::atomic::AtomicU64`.
-# (e.g. `armv5te-unknown-linux-musleabi` or `mips-unknown-linux-musl`)
+# This feature is enabled by default. It will slightly speed up some cache operations
+# by using the `quanta` crate to measure time.
+quanta = ["dep:quanta"]
+
+# This is an old feature and has no effect in v0.12.10 or newer. It is kept for
+# backward compatibility and will be removed in v0.13.0.
 atomic64 = []
 
 # This unstable feature adds `GlobalDebugCounters::current` function, which returns
@@ -44,6 +47,7 @@ crossbeam-channel = "0.5.5"
 crossbeam-epoch = "0.9.9"
 crossbeam-utils = "0.8"
 parking_lot = "0.12"
+portable-atomic = { version = "1.6", default-features = false }
 smallvec = "1.8"
 tagptr = "0.2"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.9"
+version = "0.12.10"
 edition = "2021"
 # Rust 1.70 was released on June 1, 2023.
 rust-version = "1.70"

--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ routers. Here are some highlights:
     - [Size Aware Eviction](#example-size-aware-eviction)
 - [Expiration Policies](#expiration-policies)
 - [Minimum Supported Rust Versions](#minimum-supported-rust-versions)
-- Troubleshooting
-    - [Compile Errors on Some 32-bit Platforms](#compile-errors-on-some-32-bit-platforms)
 - [Developing Moka](#developing-moka)
 - [Road Map](#road-map)
 - [About the Name](#about-the-name)
@@ -482,36 +480,6 @@ In both cases, increasing MSRV is _not_ considered a semver-breaking change.
 <!--
 - quanta v0.12.4 requires 1.70.0.
 -->
-
-
-## Troubleshooting
-
-### Compile Errors on Some 32-bit Platforms (Moka v0.12.8 or earlier)
-
-On some 32-bit target platforms including the followings, you may encounter compile
-errors if you use Moka v0.12.8 or earlier:
-
-- `armv5te-unknown-linux-musleabi`
-- `mips-unknown-linux-musl`
-- `mipsel-unknown-linux-musl`
-
-```console
-error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
-  --> ... /moka-0.5.3/src/sync.rs:10:30
-   |
-10 |         atomic::{AtomicBool, AtomicU64, Ordering},
-   |                              ^^^^^^^^^
-   |                              |
-   |                              no `AtomicU64` in `sync::atomic`
-```
-
-Such errors can occur because `std::sync::atomic::AtomicU64` is not provided on these
-platforms but Moka uses it.
-
-You can avoid the errors by upgrading Moka to v0.12.9 or later. These versions should
-automatically disable the `atomic64` feature, which is one of the default features of
-Moka. Disabling the feature will cause Moka to switch to a fall-back implementation,
-so that it will compile.
 
 ## Developing Moka
 

--- a/src/common/concurrent.rs
+++ b/src/common/concurrent.rs
@@ -12,12 +12,9 @@ pub(crate) mod entry_info;
 #[cfg(feature = "sync")]
 pub(crate) mod housekeeper;
 
+#[cfg_attr(feature = "quanta", path = "concurrent/atomic_time/atomic_time.rs")]
 #[cfg_attr(
-    all(feature = "atomic64", feature = "quanta", target_has_atomic = "64"),
-    path = "concurrent/atomic_time/atomic_time.rs"
-)]
-#[cfg_attr(
-    not(all(feature = "atomic64", feature = "quanta")),
+    not(feature = "quanta"),
     path = "concurrent/atomic_time/atomic_time_compat.rs"
 )]
 pub(crate) mod atomic_time;

--- a/src/common/concurrent/atomic_time/atomic_time.rs
+++ b/src/common/concurrent/atomic_time/atomic_time.rs
@@ -1,9 +1,8 @@
 use crate::common::time::{clock::Instant as ClockInstant, Instant};
 
-use std::{
-    any::TypeId,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::{any::TypeId, sync::atomic::Ordering};
+
+use portable_atomic::AtomicU64;
 
 #[derive(Debug)]
 pub(crate) struct AtomicInstant {

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -215,9 +215,8 @@ mod test {
         };
 
         let expected_sizes = match (arch, is_quanta_enabled) {
-            (Linux64 | Linux32Arm, true) => vec![("1.51", 56)],
+            (Linux64 | Linux32Arm | Linux32Mips, true) => vec![("1.51", 56)],
             (Linux32X86, true) => vec![("1.51", 48)],
-            (Linux32Mips, true) => unimplemented!(),
             (MacOS64, true) => vec![("1.62", 56)],
             (Linux64, false) => vec![("1.66", 104), ("1.60", 128)],
             (Linux32X86, false) => unimplemented!(),


### PR DESCRIPTION
Fixes #462, #41.

- Add `portable-atomic` crate for the platforms where `AtomicU64` is not available.
- The crate feature `atomic64` no longer has any effect but we will keep it for now for backward compatibility.
    - It will be removed in `v0.13.0` release.