### PR TITLE
Disable the `quanta` feature by default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,5 +103,8 @@ jobs:
       - name: Run tests (future feature, but no sync feature)
         run: cargo test --features future
 
+      - name: Run tests (release, future feature, but no sync feature)
+        run: cargo test --release --features future
+
       - name: Run tests (future, sync and logging features)
         run: cargo test --features 'future, sync, logging'

--- a/.github/workflows/CIArm64.yml
+++ b/.github/workflows/CIArm64.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tests (sync feature, drop cache)
         run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
 
-      - name: Run tests (future feature, but no sync feature)
+      - name: Run tests (future feature)
         run: cargo test --features future
         env:
           RUSTFLAGS: '--cfg skip_large_mem_tests'

--- a/.github/workflows/CIQuantaEnabled.yml
+++ b/.github/workflows/CIQuantaEnabled.yml
@@ -1,4 +1,4 @@
-name: CI (Quanta disabled)
+name: CI (Quanta enabled)
 
 on:
   push:
@@ -67,21 +67,27 @@ jobs:
         if: ${{ matrix.rust == '1.70.0' }}
         run: ./.ci_extras/remove-examples-msrv.sh
 
-      - name: Run tests (debug, but no quanta feature)
-        run: cargo test --no-default-features --features sync
+      - name: Show cargo tree
+        run: cargo tree --features 'sync, future, quanta'
+
+      - name: Run tests (debug, sync, quanta features)
+        run: cargo test --features 'sync, quanta'
         env:
           RUSTFLAGS: '--cfg rustver'
 
-      - name: Run tests (release, but no quanta feature)
-        run: cargo test --release --no-default-features --features sync
+      - name: Run tests (release, sync, quanta features)
+        run: cargo test --release --features 'sync, quanta'
         env:
           RUSTFLAGS: '--cfg rustver'
 
-      - name: Run tests (future feature, but no quanta and sync features)
-        run: cargo test --no-default-features --features future
+      - name: Run tests (debug, future, quanta features)
+        run: cargo test --features 'future, quanta'
 
-      - name: Run tests (future, sync and logging features, but no quanta feature)
-        run: cargo test --no-default-features --features 'sync, future, logging'
+      - name: Run tests (release, future, quanta features)
+        run: cargo test --release --features 'future, quanta'
 
-      - name: Run tests (sync feature, but no quanta feature, drop cache)
-        run: cargo test --release --lib --no-default-features --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+      - name: Run tests (future, sync, logging, quanta features)
+        run: cargo test --features 'sync, future, quanta, logging'
+
+      - name: Run tests (sync, quanta features, drop cache)
+        run: cargo test --release --lib --features 'sync, quanta' sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -28,8 +28,8 @@ jobs:
         env:
           RUSTFLAGS: '--cfg rustver'
 
-      - name: Run tests (no quanta feature)
-        run: cargo llvm-cov --no-report --no-default-features --features 'sync, future'
+      - name: Run tests (with quanta feature)
+        run: cargo llvm-cov --no-report --features 'sync, future, quanta'
         env:
           RUSTFLAGS: '--cfg rustver'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,22 @@
 
 ### Changed
 
+- Disable the `quanta` feature by default. ([#482][gh-pull-0482])
 - Replaced most uses of `quanta::Instant` with `std::time::Instant` to increase the
-  accuracy of time measurements. ([#481][gh-pull-0481])
-- Switched to `AtomicU64` of `portable-atomic` crate for the platforms where
-  `AtomicU64` is not available in `std`. ([#480][gh-pull-0480])
+  accuracy of time measurements ([#481][gh-pull-0481]):
+    - When `quanta` feature is enabled, `quanta::Instant` is used for some
+      performance critical parts in the cache, and `std::time::Instant` is used for
+      the rest of the parts.
+    - However, as of this version, enabling the `quanta` feature will not make any
+      noticeable difference in the performance.
+    - When `quanta` feature is disabled (default), `std::time::Instant` is used for
+      all time measurements.
+- Switched to `AtomicU64` of the `portable-atomic` crate, which provides fallback
+  implementations for platforms where `std` `AtomicU64` is not available
+  ([#480][gh-pull-0480]):
     - `moka`'s `atomic64` feature no longer has any effect on the build as
-      `AtomicU64` is now always used. But the feature is kept for backward
-      compatibility.
+      `AtomicU64` is now always available on all platforms. But we keep the
+      `atomic64` feature in `Cargo.toml` for backward compatibility.
 
 
 ## Version 0.12.9
@@ -950,6 +959,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0482]: https://github.com/moka-rs/moka/pull/482/
 [gh-pull-0481]: https://github.com/moka-rs/moka/pull/481/
 [gh-pull-0480]: https://github.com/moka-rs/moka/pull/480/
 [gh-pull-0474]: https://github.com/moka-rs/moka/pull/474/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ future = ["async-lock", "event-listener", "futures-util"]
 # callback closure.
 logging = ["log"]
 
-# Enable this feature to use `quanta::Instant` in some performance critical
+# Enable this feature to use `quanta::Instant` for some performance critical
 # operations in the cache instead of `std::time::Instant`. As of v0.12.10, this
 # feature will not make any noticeable performance difference, but in the future
 # when cache metrics are added, it will be useful to have this feature enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 build = "build.rs"
 
 [features]
-default = ["quanta"]
+default = []
 
 # Enable this feature to use `moka::sync::{Cache, SegmentedCache}`
 sync = []
@@ -29,8 +29,10 @@ future = ["async-lock", "event-listener", "futures-util"]
 # callback closure.
 logging = ["log"]
 
-# This feature is enabled by default. It will slightly speed up some cache operations
-# by using the `quanta` crate to measure time.
+# Enable this feature to use `quanta::Instant` in some performance critical
+# operations in the cache instead of `std::time::Instant`. As of v0.12.10, this
+# feature will not make any noticeable performance difference, but in the future
+# when cache metrics are added, it will be useful to have this feature enabled.
 quanta = ["dep:quanta"]
 
 # This is an old feature and has no effect in v0.12.10 or newer. It is kept for


### PR DESCRIPTION
This PR _disables_ the `quanta` feature by default.

If it is manually enabled, `quanta::Instant` will be used for some performance critical operations in the cache instead of `std::time::Instant`.

The `quanta` crate is a high performance time measurement library and will be great for some use cases such as collecting performance metrics. `moka` used to use `quanta::Instant` all over the place by default. However, `quanta` is not very good for tracking cache entry expiration times because the time measurement can drift over time and it may not be monotonic on some specific hardware (#472). Therefore, using `std::time::Instant` is more appropriate for tracking enty expiration times.

As of `v0.12.10`, the `quanta` feature will not make any noticeable performance difference, but in the future when cache metrics are added, it will be useful to have this feature enabled.