### PR TITLE
Fix typos in the docs about the release date of Rust 1.70.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,8 +465,8 @@ Moka's minimum supported Rust versions (MSRV) are the followings:
 
 | Feature  | MSRV                       |
 |:---------|:--------------------------:|
-| `future` | Rust 1.70.0 (June 3, 2022) |
-| `sync`   | Rust 1.70.0 (June 3, 2022) |
+| `future` | Rust 1.70.0 (June 1, 2023) |
+| `sync`   | Rust 1.70.0 (June 1, 2023) |
 
 It will keep a rolling MSRV policy of at least 6 months. If the default features with
 a mandatory features (`future` or `sync`) are enabled, MSRV will be updated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,8 @@
 //!
 //! | Feature  | MSRV                       |
 //! |:---------|:--------------------------:|
-//! | `future` | Rust 1.70.0 (June 3, 2022) |
-//! | `sync`   | Rust 1.70.0 (June 3, 2022) |
+//! | `future` | Rust 1.70.0 (June 1, 2023) |
+//! | `sync`   | Rust 1.70.0 (June 1, 2023) |
 //!
 //! It will keep a rolling MSRV policy of at least 6 months. If the default features
 //! with a mandatory features (`future` or `sync`) are enabled, MSRV will be updated


### PR DESCRIPTION

The release date of Rust 1.70.0: https://releases.rs/docs/1.70.0/