### PR TITLE
Support `Equivalent` trait for the cache key type `K`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Moka Cache &mdash; Change Log
 
+## Version 0.12.11
+
+### Added
+
+- Support `Equivalent` trait for the key type `K` of the caches.
+  ([#492][gh-pull-0492])
+
+
 ## Version 0.12.10
 
 ### Changed
@@ -959,6 +967,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0492]: https://github.com/moka-rs/moka/pull/492/
 [gh-pull-0482]: https://github.com/moka-rs/moka/pull/482/
 [gh-pull-0481]: https://github.com/moka-rs/moka/pull/481/
 [gh-pull-0480]: https://github.com/moka-rs/moka/pull/480/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 # Rust 1.70 was released on June 1, 2023.
 rust-version = "1.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ unstable-debug-counters = ["future", "once_cell"]
 crossbeam-channel = "0.5.5"
 crossbeam-epoch = "0.9.9"
 crossbeam-utils = "0.8"
+equivalent = "1.0"
 parking_lot = "0.12"
 portable-atomic = "1.6"
 smallvec = "1.8"
@@ -55,7 +56,7 @@ tagptr = "0.2"
 thiserror = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
-# Optional dependencies (enabled by default)
+# Optional dependencies (quanta)
 quanta = { version = "0.12.2", optional = true }
 
 # Optional dependencies (future)

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -38,13 +38,13 @@ use crate::cht::map::{
 use super::iter::{Iter, ScanningGet};
 
 use std::{
-    borrow::Borrow,
     hash::{BuildHasher, Hash},
     ptr,
     sync::atomic::{self, AtomicUsize, Ordering},
 };
 
 use crossbeam_epoch::Atomic;
+use equivalent::Equivalent;
 
 /// A lock-free hash map implemented with segmented bucket pointer arrays, open
 /// addressing, and linear probing.
@@ -500,8 +500,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     #[inline]
     pub(crate) fn hash<Q>(&self, key: &Q) -> u64
     where
-        Q: Hash + Eq + ?Sized,
-        K: Borrow<Q>,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         bucket::hash(&self.build_hasher, key)
     }

--- a/src/future/entry_selector.rs
+++ b/src/future/entry_selector.rs
@@ -1,9 +1,10 @@
+use equivalent::Equivalent;
+
 use crate::{ops::compute, Entry};
 
 use super::Cache;
 
 use std::{
-    borrow::Borrow,
     future::Future,
     hash::{BuildHasher, Hash},
     sync::Arc,
@@ -681,8 +682,8 @@ where
 
 impl<'a, K, Q, V, S> RefKeyEntrySelector<'a, K, Q, V, S>
 where
-    K: Borrow<Q> + Hash + Eq + Send + Sync + 'static,
-    Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+    K: Hash + Eq + Send + Sync + 'static,
+    Q: Equivalent<K> + ToOwned<Owned = K> + Hash + ?Sized,
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -223,7 +223,7 @@ where
         // Check if the value has already been inserted by other thread.
         if let Some(value) = cache
             .base
-            .get_with_hash(c_key, c_hash, ignore_if.as_mut(), false, false)
+            .get_with_hash(&**c_key, c_hash, ignore_if.as_mut(), false, false)
             .await
             .map(Entry::into_value)
         {
@@ -321,7 +321,7 @@ where
         let ignore_if = None as Option<&mut fn(&V) -> bool>;
         let maybe_entry = cache
             .base
-            .get_with_hash(&c_key, c_hash, ignore_if, true, true)
+            .get_with_hash(&*c_key, c_hash, ignore_if, true, true)
             .await;
         let maybe_value = if allow_nop {
             maybe_entry.as_ref().map(|ent| ent.value().clone())
@@ -384,7 +384,7 @@ where
                 }
             }
             Op::Remove => {
-                let maybe_prev_v = cache.invalidate_with_hash(&c_key, c_hash, true).await;
+                let maybe_prev_v = cache.invalidate_with_hash(&*c_key, c_hash, true).await;
                 if let Some(prev_v) = maybe_prev_v {
                     crossbeam_epoch::pin().flush();
                     let entry = Entry::new(Some(c_key), prev_v, false, false);
@@ -430,7 +430,7 @@ where
             let ignore_if = None as Option<&mut fn(&V) -> bool>;
             let maybe_entry = cache
                 .base
-                .get_with_hash(&c_key, c_hash, ignore_if, true, true)
+                .get_with_hash(&*c_key, c_hash, ignore_if, true, true)
                 .await;
             let maybe_value = maybe_entry.as_ref().map(|ent| ent.value().clone());
 
@@ -460,7 +460,7 @@ where
         let ignore_if = None as Option<&mut fn(&V) -> bool>;
         let maybe_entry = cache
             .base
-            .get_with_hash(&c_key, c_hash, ignore_if, true, true)
+            .get_with_hash(&*c_key, c_hash, ignore_if, true, true)
             .await;
         let maybe_value = if allow_nop {
             maybe_entry.as_ref().map(|ent| ent.value().clone())
@@ -522,7 +522,7 @@ where
                 }
             }
             Op::Remove => {
-                let maybe_prev_v = cache.invalidate_with_hash(&c_key, c_hash, true).await;
+                let maybe_prev_v = cache.invalidate_with_hash(&*c_key, c_hash, true).await;
                 if let Some(prev_v) = maybe_prev_v {
                     crossbeam_epoch::pin().flush();
                     let entry = Entry::new(Some(c_key), prev_v, false, false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,9 @@ compile_error!(
     `moka` crate. Please update your dependencies in Cargo.toml"
 );
 
+// Reexport(s)
+pub use equivalent;
+
 #[cfg(feature = "future")]
 #[cfg_attr(docsrs, doc(cfg(feature = "future")))]
 pub mod future;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ compile_error!(
 );
 
 // Reexport(s)
-pub use equivalent;
+pub use equivalent::Equivalent;
 
 #[cfg(feature = "future")]
 #[cfg_attr(docsrs, doc(cfg(feature = "future")))]

--- a/src/sync/entry_selector.rs
+++ b/src/sync/entry_selector.rs
@@ -1,9 +1,10 @@
+use equivalent::Equivalent;
+
 use crate::{ops::compute, Entry};
 
 use super::Cache;
 
 use std::{
-    borrow::Borrow,
     hash::{BuildHasher, Hash},
     sync::Arc,
 };
@@ -567,8 +568,8 @@ where
 
 impl<'a, K, Q, V, S> RefKeyEntrySelector<'a, K, Q, V, S>
 where
-    K: Borrow<Q> + Hash + Eq + Send + Sync + 'static,
-    Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+    K: Hash + Eq + Send + Sync + 'static,
+    Q: Equivalent<K> + ToOwned<Owned = K> + Hash + ?Sized,
     V: Clone + Send + Sync + 'static,
     S: BuildHasher + Clone + Send + Sync + 'static,
 {

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1,3 +1,5 @@
+use equivalent::Equivalent;
+
 use super::{cache::Cache, CacheBuilder, OwnedKeyEntrySelector, RefKeyEntrySelector};
 use crate::common::concurrent::Weigher;
 use crate::common::time::Clock;
@@ -10,7 +12,6 @@ use crate::{
 };
 
 use std::{
-    borrow::Borrow,
     collections::hash_map::RandomState,
     fmt,
     hash::{BuildHasher, Hash, Hasher},
@@ -248,8 +249,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         self.inner.select(hash).contains_key_with_hash(key, hash)
@@ -267,8 +267,7 @@ where
     /// [rustdoc-std-arc]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
     pub fn get<Q>(&self, key: &Q) -> Option<V>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + Eq + ?Sized,
     {
         let hash = self.inner.hash(key);
         self.inner
@@ -288,8 +287,7 @@ where
 
     pub fn entry_by_ref<'a, Q>(&'a self, key: &'a Q) -> RefKeyEntrySelector<'a, K, Q, V, S>
     where
-        K: Borrow<Q>,
-        Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+        Q: Equivalent<K> + ToOwned<Owned = K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         let cache = self.inner.select(hash);
@@ -340,8 +338,7 @@ where
     /// cache, the key will be cloned to create new entry in the cache.
     pub fn get_with_by_ref<Q>(&self, key: &Q, init: impl FnOnce() -> V) -> V
     where
-        K: Borrow<Q>,
-        Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+        Q: Equivalent<K> + ToOwned<Owned = K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         let replace_if = None as Option<fn(&V) -> bool>;
@@ -405,8 +402,7 @@ where
     pub fn optionally_get_with_by_ref<F, Q>(&self, key: &Q, init: F) -> Option<V>
     where
         F: FnOnce() -> Option<V>,
-        K: Borrow<Q>,
-        Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+        Q: Equivalent<K> + ToOwned<Owned = K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         self.inner
@@ -451,8 +447,7 @@ where
     where
         F: FnOnce() -> Result<V, E>,
         E: Send + Sync + 'static,
-        K: Borrow<Q>,
-        Q: ToOwned<Owned = K> + Hash + Eq + ?Sized,
+        Q: Equivalent<K> + ToOwned<Owned = K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         self.inner
@@ -479,8 +474,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn invalidate<Q>(&self, key: &Q)
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         self.inner
@@ -497,8 +491,7 @@ where
     /// on the borrowed form _must_ match those for the key type.
     pub fn remove<Q>(&self, key: &Q) -> Option<V>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         let hash = self.inner.hash(key);
         self.inner
@@ -762,8 +755,7 @@ where
     #[inline]
     fn hash<Q>(&self, key: &Q) -> u64
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         let mut hasher = self.build_hasher.build_hasher();
         key.hash(&mut hasher);

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -228,7 +228,7 @@ where
         let ignore_if = None as Option<&mut fn(&V) -> bool>;
         let maybe_entry = cache
             .base
-            .get_with_hash_and_ignore_if(&c_key, c_hash, ignore_if, true);
+            .get_with_hash_and_ignore_if(&*c_key, c_hash, ignore_if, true);
         let maybe_value = if allow_nop {
             maybe_entry.as_ref().map(|ent| ent.value().clone())
         } else {
@@ -286,7 +286,7 @@ where
                 }
             }
             Op::Remove => {
-                let maybe_prev_v = cache.invalidate_with_hash(&c_key, c_hash, true);
+                let maybe_prev_v = cache.invalidate_with_hash(&*c_key, c_hash, true);
                 if let Some(prev_v) = maybe_prev_v {
                     crossbeam_epoch::pin().flush();
                     let entry = Entry::new(Some(c_key), prev_v, false, false);

--- a/src/sync_base/base_cache.rs
+++ b/src/sync_base/base_cache.rs
@@ -32,6 +32,7 @@ use crate::{
 
 use crossbeam_channel::{Receiver, Sender, TrySendError};
 use crossbeam_utils::atomic::AtomicCell;
+use equivalent::Equivalent;
 use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
 use std::{
@@ -189,16 +190,14 @@ where
     #[inline]
     pub(crate) fn hash<Q>(&self, key: &Q) -> u64
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.inner.hash(key)
     }
 
     pub(crate) fn contains_key_with_hash<Q>(&self, key: &Q, hash: u64) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         // TODO: Maybe we can just call ScanningGet::scanning_get.
         self.inner
@@ -217,8 +216,7 @@ where
 
     pub(crate) fn get_with_hash<Q>(&self, key: &Q, hash: u64, need_key: bool) -> Option<Entry<K, V>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         // Define a closure to record a read op.
         let record = |op, now| {
@@ -237,8 +235,7 @@ where
         need_key: bool,
     ) -> Option<Entry<K, V>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
         I: FnMut(&V) -> bool,
     {
         // Define a closure to record a read op.
@@ -256,8 +253,7 @@ where
         ignore_if: Option<&mut I>,
     ) -> Option<V>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
         I: FnMut(&V) -> bool,
     {
         // Define a closure that skips to record a read op.
@@ -275,8 +271,7 @@ where
         need_key: bool,
     ) -> Option<Entry<K, V>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
         R: Fn(ReadOp<K, V>, Instant),
         I: FnMut(&V) -> bool,
     {
@@ -376,8 +371,7 @@ where
 
     pub(crate) fn get_key_with_hash<Q>(&self, key: &Q, hash: u64) -> Option<Arc<K>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.inner
             .get_key_value_and(key, hash, |k, _entry| Arc::clone(k))
@@ -386,8 +380,7 @@ where
     #[inline]
     pub(crate) fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<KvEntry<K, V>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.inner.remove_entry(key, hash)
     }
@@ -436,8 +429,8 @@ where
     }
 
     fn scanning_get(&self, key: &Arc<K>) -> Option<V> {
-        let hash = self.hash(key);
-        self.inner.get_key_value_and_then(key, hash, |k, entry| {
+        let hash = self.hash(&**key);
+        self.inner.get_key_value_and_then(&**key, hash, |k, entry| {
             let i = &self.inner;
             let (ttl, tti, va) = (&i.time_to_live(), &i.time_to_idle(), &i.valid_after());
             let now = self.current_time();
@@ -1067,8 +1060,7 @@ where
     #[inline]
     fn hash<Q>(&self, key: &Q) -> u64
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         let mut hasher = self.build_hasher.build_hasher();
         key.hash(&mut hasher);
@@ -1078,33 +1070,30 @@ where
     #[inline]
     fn get_key_value_and<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
         F: FnOnce(&Arc<K>, &MiniArc<ValueEntry<K, V>>) -> T,
     {
         self.cache
-            .get_key_value_and(hash, |k| (k as &K).borrow() == key, with_entry)
+            .get_key_value_and(hash, |k| key.equivalent(k as &K), with_entry)
     }
 
     #[inline]
     fn get_key_value_and_then<Q, F, T>(&self, key: &Q, hash: u64, with_entry: F) -> Option<T>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
         F: FnOnce(&Arc<K>, &MiniArc<ValueEntry<K, V>>) -> Option<T>,
     {
         self.cache
-            .get_key_value_and_then(hash, |k| (k as &K).borrow() == key, with_entry)
+            .get_key_value_and_then(hash, |k| key.equivalent(k as &K), with_entry)
     }
 
     #[inline]
     fn remove_entry<Q>(&self, key: &Q, hash: u64) -> Option<KvEntry<K, V>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.cache
-            .remove_entry(hash, |k| (k as &K).borrow() == key)
+            .remove_entry(hash, |k| key.equivalent(k as &K))
             .map(|(key, entry)| KvEntry::new(key, entry))
     }
 
@@ -2168,7 +2157,7 @@ where
                     if !kd.is_dirty() {
                         if let Some(ts) = kd.last_modified() {
                             let key = kd.key();
-                            let hash = self.hash(key);
+                            let hash = self.hash(&**key);
                             candidates.push(KeyDateLite::new(key, hash, ts));
                             len += 1;
                         }


### PR DESCRIPTION
## Summary

Support the `Equivalent` trait from the [equivalent crate](https://crates.io/crates/equivalent) for the cache key type `K`. Replace all usages of the trait bound `K: Borrow<Q>` with `Q: Equivalent<K>`.

For example,

**Before**

```rust
pub fn get<Q>(&self, key: &Q) -> Option<V>
where
    K: Borrow<Q>,
    Q: Hash + Eq + ?Sized,
```

**After**

```rust
pub fn get<Q>(&self, key: &Q) -> Option<V>
where
    Q: Equivalent<K> + Hash + ?Sized,
```

https://github.com/indexmap-rs/equivalent/blob/master/README.md

> These traits are not used by the maps in the standard library, but they may add more flexibility in third-party map implementations, especially in situations where a strict `K: Borrow<Q>` relationship is not available.

## Changes

- Add the [equivalent crate](https://crates.io/crates/equivalent) to the dependencies.
- Reexport the `equivalent` module.
- Replace all trait bound `K: Borrow<Q>` with `Q: Equivalent<K>`.

Relates to #166
