### PR TITLE
chore: remove clippy ignore that no longer applies

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -638,8 +638,6 @@ pub struct Cache<K, V, S = RandomState> {
     schedule_write_op_should_block: AtomicBool,
 }
 
-// TODO: https://github.com/moka-rs/moka/issues/54
-#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<K, V, S> Send for Cache<K, V, S>
 where
     K: Send + Sync,

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -573,8 +573,6 @@ pub struct Cache<K, V, S = RandomState> {
     value_initializer: Arc<ValueInitializer<K, V, S>>,
 }
 
-// TODO: https://github.com/moka-rs/moka/issues/54
-#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<K, V, S> Send for Cache<K, V, S>
 where
     K: Send + Sync,

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -34,8 +34,6 @@ pub struct SegmentedCache<K, V, S = RandomState> {
     inner: Arc<Inner<K, V, S>>,
 }
 
-// TODO: https://github.com/moka-rs/moka/issues/54
-#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<K, V, S> Send for SegmentedCache<K, V, S>
 where
     K: Send + Sync,


### PR DESCRIPTION
Just randomly ran into the todo comment and I realized the clippy warning is no longer there as soon as I wanted to investigate its safety. So maybe time to remove it and close #54?