### PR TITLE
Upgrade thiserror to 2.0 and disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ parking_lot = "0.12"
 portable-atomic = "1.6"
 smallvec = "1.8"
 tagptr = "0.2"
-thiserror = "2.0"
+thiserror = { version = "2.0", default-features = false }
 uuid = { version = "1.1", features = ["v4"] }
 
 # Optional dependencies (quanta)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ parking_lot = "0.12"
 portable-atomic = "1.6"
 smallvec = "1.8"
 tagptr = "0.2"
-thiserror = "1.0"
+thiserror = "2.0"
 uuid = { version = "1.1", features = ["v4"] }
 
 # Optional dependencies (quanta)


### PR DESCRIPTION
Disable default-features on thiserror

We're barely using thiserror at all in moka, and we don't require any of
thiserror's features.

We might also want to consider not using thiserror at all and pruning
that whole dependency tree.

Upgrade thiserror to 2.0

Thiserror has had a 2.0 release that does include breaking changes but
does not appear to impact moka's use of thiserror.

By upgrading, we can stay closer to the latest version of thiserror and
avoid needing to compile multiple versions of thiserror in consumers who
are themselves using a newer version of thiserror.