### PR TITLE
Switch loom to a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ tokio = { version = "1.19", features = ["fs", "io-util", "macros", "rt-multi-thr
 
 # We cannot use `cfg(loom)` here because an indirect dependency `concurrent-queue`
 # uses it.
-[target.'cfg(moka_loom)'.dependencies]
+[target.'cfg(moka_loom)'.dev-dependencies]
 loom = "0.7"
 
 [target.'cfg(trybuild)'.dev-dependencies]


### PR DESCRIPTION
The `loom` dependency is only used for testing and should therefore be a `dev-dependency`. At present, this pulls in an old version `windows` for us which I'd like to get rid of in our dependency tree:

```
❯ cargo tree -i -p windows@0.58.0 --target all
windows v0.58.0
└── generator v0.8.4
    └── loom v0.7.2
        └── moka v0.12.10
            └── firezone-gateway v1.4.7 (/home/thomas/src/github.com/firezone/firezone/rust/gateway)
```

Resolves: #501