### PR TITLE
Replace thiserror usage with manual impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ parking_lot = "0.12"
 portable-atomic = "1.6"
 smallvec = "1.8"
 tagptr = "0.2"
-thiserror = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
 # Optional dependencies (quanta)

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,8 +1,10 @@
+use std::{error::Error, fmt::Display};
+
 /// The error type for the functionalities around
 /// [`Cache::invalidate_entries_if`][invalidate-if] method.
 ///
 /// [invalidate-if]: ./sync/struct.Cache.html#method.invalidate_entries_if
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum PredicateError {
     /// This cache does not have a necessary configuration enabled to support
     /// invalidating entries with a closure.
@@ -12,10 +14,18 @@ pub enum PredicateError {
     /// method at the cache creation time.
     ///
     /// [support-invalidation-closures]: ./sync/struct.CacheBuilder.html#method.support_invalidation_closures
-    #[error(
-        "Support for invalidation closures is disabled in this cache. \
-    Please enable it by calling the support_invalidation_closures method \
-    of the builder at the cache creation time"
-    )]
     InvalidationClosuresDisabled,
 }
+
+impl Display for PredicateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Support for invalidation closures is disabled in this cache. \
+            Please enable it by calling the support_invalidation_closures \
+            method of the builder at the cache creation time",
+        )
+    }
+}
+
+impl Error for PredicateError {}

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -785,7 +785,7 @@ mod tests {
     use super::SegmentedCache;
     use crate::notification::RemovalCause;
     use parking_lot::Mutex;
-    use std::{sync::Arc, time::Duration};
+    use std::{error::Error, fmt::Display, sync::Arc, time::Duration};
 
     #[test]
     fn max_capacity_zero() {
@@ -1556,9 +1556,16 @@ mod tests {
             thread::{sleep, spawn},
         };
 
-        #[derive(thiserror::Error, Debug)]
-        #[error("{}", _0)]
+        #[derive(Debug)]
         pub struct MyError(String);
+
+        impl Display for MyError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl Error for MyError {}
 
         type MyResult<T> = Result<T, Arc<MyError>>;
 


### PR DESCRIPTION
We were only using thiserror in 2 places, and one of them was in tests. Our usage was also very minimal (no use of the #[from] directive, etc.), so I think it makes more sense to just manually implement Error for these limited uses.

It's hard to see the impact here because we also don't check-in Cargo.lock, but locally running a cargo tree, I see 5 fewer lines of dependencies.

I went down this path because while auditing an unrelated project I maintain, I noticed that we were pulling in 2 copies of thiserror because moka required version 1, but the other project was pulling in version 2. I opened #506 to address that, but that doesn't help any projects out there who are using version 1. Sometimes crates add dedicated version feature flags like thiserror_v1 and thiserror_v2 or something, but given our minimal usage I thought we could just remove it completely.

Closes https://github.com/moka-rs/moka/issues/511