### PR TITLE
CI: Fix Kani and Clippy tests

### DIFF
--- a/.github/workflows/Kani.yml
+++ b/.github/workflows/Kani.yml
@@ -32,7 +32,7 @@ jobs:
   run-kani:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Moka
         uses: actions/checkout@v4

--- a/src/common/concurrent/arc.rs
+++ b/src/common/concurrent/arc.rs
@@ -102,7 +102,8 @@ impl<T: ?Sized> MiniArc<T> {
     /// coercion by using the `unsize` crate. `MiniArc` does not have such a
     /// feature, so we are safe for now.
     #[inline]
-    #[allow(ambiguous_wide_pointer_comparisons)] // Remove when MSRV is 1.76 or newer.
+    #[allow(ambiguous_wide_pointer_comparisons)] // Remove this when we make the MSRV is 1.76 or newer.
+    #[allow(clippy::ptr_eq)] // Remove this when we make the MSRV is 1.76 or newer.
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
         // `addr_eq` requires Rust 1.76 or newer.
         // ptr::addr_eq(this.ptr.as_ptr(), other.ptr.as_ptr())

--- a/src/common/concurrent/arc.rs
+++ b/src/common/concurrent/arc.rs
@@ -102,8 +102,8 @@ impl<T: ?Sized> MiniArc<T> {
     /// coercion by using the `unsize` crate. `MiniArc` does not have such a
     /// feature, so we are safe for now.
     #[inline]
-    #[allow(ambiguous_wide_pointer_comparisons)] // Remove this when we make the MSRV is 1.76 or newer.
-    #[allow(clippy::ptr_eq)] // Remove this when we make the MSRV is 1.76 or newer.
+    #[allow(ambiguous_wide_pointer_comparisons)] // Remove this when MSRV is 1.76 or newer.
+    #[allow(clippy::ptr_eq)] // Remove this when MSRV is 1.76 or newer.
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
         // `addr_eq` requires Rust 1.76 or newer.
         // ptr::addr_eq(this.ptr.as_ptr(), other.ptr.as_ptr())


### PR DESCRIPTION
- Fix Kani test by upgrading Ubuntu from 20.04 to the latest LTS
- Fix a Clippy warning (Rust 1.87 beta)
    - `clippy 0.1.87 (af91af44eb 2025-05-07)`