### PR TITLE
Adjust license expression: some code is just `Apache-2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # Rust 1.70 was released on June 1, 2023.
 rust-version = "1.70"
 description = "A fast and concurrent cache library inspired by Java Caffeine"
-license = "MIT OR Apache-2.0"
+license = "(MIT OR Apache-2.0) AND Apache-2.0"
 # homepage = "https://"
 documentation = "https://docs.rs/moka/"
 repository = "https://github.com/moka-rs/moka"


### PR DESCRIPTION
Some code copied from Caffeine was only licensed `Apache-2.0`. Adjust the overall license expression from `MIT OR Apache-2.0` to `(MIT OR Apache-2.0) AND Apache-2.0` to reflect the fact that not all of the source code is available under MIT license terms.

https://github.com/moka-rs/moka/blob/8dbc8e5c6ee804470b1144960f4065959658232a/src/common/frequency_sketch.rs#L1-L12

https://github.com/moka-rs/moka/blob/8dbc8e5c6ee804470b1144960f4065959658232a/src/common/timer_wheel.rs#L1-L12