### PR TITLE
Remove several unneeded files from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/moka-rs/moka"
 keywords = ["cache", "concurrent"]
 categories = ["caching", "concurrency"]
 readme = "README.md"
-exclude = [".devcontainer", ".github", ".gitpod.yml", ".vscode"]
+exclude = [".devcontainer", ".github", ".gitpod.yml", ".vscode", "tests/compile_tests/", ".ci_extras/", ".codecov.yml", "MIGRATION-GUIDE.md", "CHANGELOG.md", "examples", ".gitignore"]
 build = "build.rs"
 
 [features]


### PR DESCRIPTION
During a dependency review I noticed that moka includes the output of it's compile tests, several test scripts and some other unneeded files in the published package. These files are not required for building moka. For the dev scripts they are executable scripts that might run at compile time and prevent us from denying interpreted scripts via cargo deny.

This commit extends the existing `exclude` directive in the `Cargo.toml` file to exclude any file that's not useful for building the crate downstream and that's not releated to documentation and licensing. Overall this reduces the size of the published crate from 97 files, 1.4MiB (251.5KiB compressed) to 66 files, 1.3MiB (224.1KiB compressed) which would result in a 87GB/month traffic reduction on crates.io assuming the current 3.3 millions of downloads per month. For me personally the reduction in the number of included files and the removal of the scripts is more important.