### PR TITLE
Add set_max_capacity methods to change max capacity while running

### DIFF
--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -104,8 +104,12 @@ impl<K, V, S> BaseCache<K, V, S> {
         self.inner.weighted_size()
     }
 
+    pub(crate) fn set_max_capacity(&self, max_capacity: Option<u64>) {
+        self.inner.set_max_capacity(max_capacity);
+    }
+
     pub(crate) fn is_map_disabled(&self) -> bool {
-        self.inner.max_capacity == Some(0)
+        self.inner.max_capacity.load() == Some(0)
     }
 
     #[inline]
@@ -984,7 +988,7 @@ type CacheStore<K, V, S> = crate::cht::SegmentedHashMap<Arc<K>, MiniArc<ValueEnt
 
 pub(crate) struct Inner<K, V, S> {
     name: Option<String>,
-    max_capacity: Option<u64>,
+    max_capacity: AtomicCell<Option<u64>>,
     entry_count: AtomicCell<u64>,
     weighted_size: AtomicCell<u64>,
     pub(crate) cache: CacheStore<K, V, S>,
@@ -1032,7 +1036,12 @@ impl<K, V, S> Inner<K, V, S> {
 
     fn policy(&self) -> Policy {
         let exp = &self.expiration_policy;
-        Policy::new(self.max_capacity, 1, exp.time_to_live(), exp.time_to_idle())
+        Policy::new(
+            self.max_capacity.load(),
+            1,
+            exp.time_to_live(),
+            exp.time_to_idle(),
+        )
     }
 
     #[inline]
@@ -1043,6 +1052,10 @@ impl<K, V, S> Inner<K, V, S> {
     #[inline]
     fn weighted_size(&self) -> u64 {
         self.weighted_size.load()
+    }
+
+    fn set_max_capacity(&self, max_capacity: Option<u64>) {
+        self.max_capacity.store(max_capacity);
     }
 
     #[inline]
@@ -1178,7 +1191,7 @@ where
 
         Self {
             name,
-            max_capacity,
+            max_capacity: AtomicCell::new(max_capacity),
             entry_count: AtomicCell::default(),
             weighted_size: AtomicCell::default(),
             cache,
@@ -1294,7 +1307,7 @@ where
         max_log_sync_repeats: u32,
         eviction_batch_size: u32,
     ) -> bool {
-        if self.max_capacity == Some(0) {
+        if self.max_capacity.load() == Some(0) {
             return false;
         }
 
@@ -1453,20 +1466,21 @@ where
     S: BuildHasher + Clone + Send + Sync + 'static,
 {
     fn has_enough_capacity(&self, candidate_weight: u32, counters: &EvictionCounters) -> bool {
-        self.max_capacity.map_or(true, |limit| {
+        self.max_capacity.load().map_or(true, |limit| {
             counters.weighted_size + candidate_weight as u64 <= limit
         })
     }
 
     fn weights_to_evict(&self, counters: &EvictionCounters) -> u64 {
         self.max_capacity
+            .load()
             .map(|limit| counters.weighted_size.saturating_sub(limit))
             .unwrap_or_default()
     }
 
     #[inline]
     fn should_enable_frequency_sketch(&self, counters: &EvictionCounters) -> bool {
-        match self.max_capacity {
+        match self.max_capacity.load() {
             None | Some(0) => false,
             Some(max_cap) => {
                 if self.frequency_sketch_enabled.load(Ordering::Acquire) {
@@ -1480,7 +1494,7 @@ where
 
     #[inline]
     async fn enable_frequency_sketch(&self, counters: &EvictionCounters) {
-        if let Some(max_cap) = self.max_capacity {
+        if let Some(max_cap) = self.max_capacity.load() {
             let c = counters;
             let cap = if self.weigher.is_none() {
                 max_cap
@@ -1493,7 +1507,7 @@ where
 
     #[cfg(test)]
     async fn enable_frequency_sketch_for_testing(&self) {
-        if let Some(max_cap) = self.max_capacity {
+        if let Some(max_cap) = self.max_capacity.load() {
             self.do_enable_frequency_sketch(max_cap).await;
         }
     }
@@ -1626,7 +1640,7 @@ where
             }
         }
 
-        if let Some(max) = self.max_capacity {
+        if let Some(max) = self.max_capacity.load() {
             if new_weight as u64 > max {
                 // The candidate is too big to fit in the cache. Reject it.
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -705,6 +705,11 @@ impl<K, V, S> Cache<K, V, S> {
         self.base.policy()
     }
 
+    /// Sets or clears a new value for the cache's maximum capacity.
+    pub fn set_max_capacity(&self, max_capacity: Option<u64>) {
+        self.base.set_max_capacity(max_capacity);
+    }
+
     /// Returns an approximate number of entries in this cache.
     ///
     /// The value returned is _an estimate_; the actual count may differ if there are
@@ -2207,6 +2212,28 @@ mod tests {
         assert!(!cache.contains_key(&0));
         assert!(cache.get(&0).await.is_none());
         assert_eq!(cache.entry_count(), 0)
+    }
+
+    #[tokio::test]
+    async fn max_capacity_shrink() {
+        const COUNT: u64 = 10;
+
+        let mut cache = Cache::new(COUNT);
+        cache.reconfigure_for_testing().await;
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        for i in 0..COUNT {
+            cache.insert(i, ()).await;
+        }
+
+        assert_eq!(cache.iter().count(), COUNT as _);
+
+        let small = COUNT / 2;
+        cache.set_max_capacity(Some(small));
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.iter().count(), small as _);
     }
 
     #[tokio::test]

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -140,6 +140,11 @@ impl<K, V, S> SegmentedCache<K, V, S> {
         policy
     }
 
+    /// Sets or clears a new value for the cache's maximum capacity.
+    pub fn set_max_capacity(&self, max_capacity: Option<u64>) {
+        self.inner.set_max_capacity(max_capacity);
+    }
+
     /// Returns an approximate number of entries in this cache.
     ///
     /// The value returned is _an estimate_; the actual count may differ if there are
@@ -692,6 +697,19 @@ struct Inner<K, V, S> {
     segment_shift: u32,
 }
 
+impl<K, V, S> Inner<K, V, S> {
+    fn compute_seg_max_capacity(segments: usize, max_capacity: Option<u64>) -> Option<u64> {
+        max_capacity.map(|n| (n as f64 / segments as f64).ceil() as u64)
+    }
+
+    fn set_max_capacity(&self, max_capacity: Option<u64>) {
+        let seg_max_capacity = Self::compute_seg_max_capacity(self.segments.len(), max_capacity);
+        for segment in self.segments.iter() {
+            segment.set_max_capacity(seg_max_capacity);
+        }
+    }
+}
+
 impl<K, V, S> Inner<K, V, S>
 where
     K: Hash + Eq + Send + Sync + 'static,
@@ -720,8 +738,7 @@ where
 
         let actual_num_segments = num_segments.next_power_of_two();
         let segment_shift = 64 - actual_num_segments.trailing_zeros();
-        let seg_max_capacity =
-            max_capacity.map(|n| (n as f64 / actual_num_segments as f64).ceil() as u64);
+        let seg_max_capacity = Self::compute_seg_max_capacity(actual_num_segments, max_capacity);
         let seg_init_capacity =
             initial_capacity.map(|cap| (cap as f64 / actual_num_segments as f64).ceil() as usize);
         // NOTE: We cannot initialize the segments as `vec![cache; actual_num_segments]`
@@ -801,6 +818,28 @@ mod tests {
         assert!(!cache.contains_key(&0));
         assert!(cache.get(&0).is_none());
         assert_eq!(cache.entry_count(), 0)
+    }
+
+    #[test]
+    fn max_capacity_shrink() {
+        const COUNT: u64 = 16;
+
+        let mut cache = SegmentedCache::new(COUNT, 4);
+        cache.reconfigure_for_testing();
+
+        // Make the cache exterior immutable.
+        let cache = cache;
+
+        for i in 0..COUNT {
+            cache.insert(i, ());
+        }
+
+        assert_eq!(cache.iter().count(), COUNT as _);
+
+        let small = COUNT / 2;
+        cache.set_max_capacity(Some(small));
+        cache.run_pending_tasks();
+        assert!(cache.iter().count() <= small as _);
     }
 
     #[test]


### PR DESCRIPTION
I didn't want to make this complex and try to drive usage down to the new limit if the max decreases, so I'm just relying on the already extant mechanisms to bring memory usage down eventually.

Fixes: #540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `set_max_capacity()` method to cache types, enabling runtime adjustment of maximum cache capacity without recreation.
  * Cache automatically evicts entries when capacity is reduced, maintaining consistency.

* **Tests**
  * Added tests validating capacity shrinking behavior and entry eviction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->