### PR TITLE
Fix use-after-free panic in timer wheel when Expiry returns None

### DIFF
--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -1719,11 +1719,12 @@ where
             timer_wheel.enable();
         }
 
+        // Get timer_node with its expiry generation to detect stale pointers.
+        let (timer_node, expected_expiry_gen) = entry.timer_node_with_expiry_gen();
+        let current_expiry_gen = entry.entry_info().expiry_gen();
+
         // Update the timer wheel.
-        match (
-            entry.entry_info().expiration_time().is_some(),
-            entry.timer_node(),
-        ) {
+        match (entry.entry_info().expiration_time().is_some(), timer_node) {
             // Do nothing; the cache entry has no expiration time and not registered
             // to the timer wheel.
             (false, None) => (),
@@ -1733,26 +1734,39 @@ where
                 let timer = timer_wheel.schedule(
                     MiniArc::clone(entry.entry_info()),
                     MiniArc::clone(entry.deq_nodes()),
+                    current_expiry_gen,
                 );
                 entry.set_timer_node(timer);
             }
             // Reschedule the cache entry in the timer wheel; the cache entry has an
             // expiration time and already registered to the timer wheel.
             (true, Some(tn)) => {
-                let result = timer_wheel.reschedule(tn);
-                if let ReschedulingResult::Removed(removed_tn) = result {
-                    // The timer node was removed from the timer wheel because the
-                    // expiration time has been unset by other thread after we
-                    // checked.
-                    entry.set_timer_node(None);
-                    drop(removed_tn);
+                // Reschedule with generation validation to prevent use-after-free
+                match timer_wheel.reschedule(tn, expected_expiry_gen) {
+                    Some(ReschedulingResult::Removed(removed_tn)) => {
+                        // The timer node was removed from the timer wheel because the
+                        // expiration time has been unset by other thread after we
+                        // checked.
+                        entry.set_timer_node(None);
+                        drop(removed_tn);
+                    }
+                    Some(ReschedulingResult::Rescheduled) => {
+                        // Successfully rescheduled, nothing to do.
+                    }
+                    None => {
+                        // The timer node was invalid (stale - expiry gen mismatch).
+                        // Clear the timer_node to prevent further issues.
+                        entry.set_timer_node(None);
+                    }
                 }
             }
             // Unregister the cache entry from the timer wheel; the cache entry has
             // no expiration time but registered to the timer wheel.
             (false, Some(tn)) => {
                 entry.set_timer_node(None);
-                timer_wheel.deschedule(tn);
+                // Returns false if the node was stale, but we've already
+                // cleared timer_node above, so we can ignore the return value.
+                let _ = timer_wheel.deschedule(tn, expected_expiry_gen);
             }
         }
     }
@@ -1764,8 +1778,12 @@ where
         gen: Option<u16>,
         counters: &mut EvictionCounters,
     ) {
-        if let Some(timer_node) = entry.take_timer_node() {
-            timer_wheel.deschedule(timer_node);
+        // Take the timer node along with its stored expiry generation for validation.
+        let (timer_node, expiry_gen) = entry.take_timer_node();
+        if let Some(tn) = timer_node {
+            // Returns false if the node was stale, but we've already
+            // taken (cleared) the timer_node, so we can ignore the return value.
+            let _ = timer_wheel.deschedule(tn, expiry_gen);
         }
         Self::handle_remove_without_timer_wheel(deqs, entry, gen, counters);
     }
@@ -1798,8 +1816,13 @@ where
         entry: MiniArc<ValueEntry<K, V>>,
         counters: &mut EvictionCounters,
     ) {
-        if let Some(timer) = entry.take_timer_node() {
-            timer_wheel.deschedule(timer);
+        // Take the timer node along with its stored expiry generation for validation.
+        let (timer_node, expiry_gen) = entry.take_timer_node();
+        if let Some(timer) = timer_node {
+            // Deschedule with generation validation to prevent use-after-free.
+            // Returns false if the node was stale, but we've already
+            // taken (cleared) the timer_node, so we can ignore the return value.
+            let _ = timer_wheel.deschedule(timer, expiry_gen);
         }
         if entry.is_admitted() {
             entry.set_admitted(false);

--- a/tests/timer_wheel_panic_test.rs
+++ b/tests/timer_wheel_panic_test.rs
@@ -1,0 +1,297 @@
+//! This test reproduces a race condition where returning `None` from `Expiry`
+//! methods (to unset expiration) can cause a use-after-free panic in the timer wheel.
+//!
+//! The bug occurs because:
+//! 1. `expiration_time` is set atomically (immediately) when `Expiry` returns `None`
+//! 2. `timer_node` is only updated during housekeeping (later)
+//! 3. This creates a window where `expiration_time` is `None` but `timer_node` still
+//!    points to a freed/invalid timer node
+//!
+//! Pattern that triggers the bug:
+//! - Insert with `Err` value → gets TTL (timer node created)
+//! - Update to `Ok` value → `Expiry` returns `None` (should remove timer node)
+//! - Concurrent `get` or housekeeping reads stale `timer_node` pointer
+
+#![cfg(feature = "sync")]
+
+use moka::sync::Cache;
+use moka::Expiry;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+type HandleResult<T> = Result<T, String>;
+
+struct CustomExpiry {
+    error_ttl: Duration,
+}
+
+impl Default for CustomExpiry {
+    fn default() -> Self {
+        Self {
+            error_ttl: Duration::from_millis(100),
+        }
+    }
+}
+
+impl<K, V> Expiry<K, HandleResult<V>> for CustomExpiry {
+    fn expire_after_create(&self, _: &K, value: &HandleResult<V>, _: Instant) -> Option<Duration> {
+        match value {
+            Ok(_) => None,
+            Err(_) => Some(self.error_ttl),
+        }
+    }
+
+    fn expire_after_update(
+        &self,
+        _: &K,
+        value: &HandleResult<V>,
+        _: Instant,
+        _: Option<Duration>,
+    ) -> Option<Duration> {
+        match value {
+            Ok(_) => None,
+            Err(_) => Some(self.error_ttl),
+        }
+    }
+}
+
+/// This test runs for a short duration (5 seconds by default) to catch the race condition.
+/// In production, the bug was observed within 2 months of operation, but with aggressive
+/// concurrent operations, it can be triggered much faster.
+///
+/// The test pattern:
+/// 1. Insert threads: repeatedly insert `Err` then `Ok` values (triggers timer node create/remove)
+/// 2. Get threads: continuously read entries (triggers `expire_after_read` and housekeeping)
+/// 3. Housekeeping thread: explicitly runs `run_pending_tasks()` to process timer wheel operations
+#[test]
+fn test_timer_wheel_panic() {
+    // Use shorter duration for CI, increase for more thorough testing
+    let test_duration = Duration::from_secs(5);
+
+    let panics = Arc::new(AtomicUsize::new(0));
+
+    let cache: Cache<u64, HandleResult<u64>> = Cache::builder()
+        .name("test_cache")
+        .expire_after(CustomExpiry::default())
+        .time_to_idle(Duration::from_secs(240))
+        .max_capacity(10000)
+        .build();
+
+    let cache = Arc::new(cache);
+    let start = Instant::now();
+
+    // Insert threads: Err -> Ok pattern
+    let insert_handles: Vec<_> = (0..4)
+        .map(|tid| {
+            let cache = Arc::clone(&cache);
+            let panics = Arc::clone(&panics);
+            let duration = test_duration;
+            thread::spawn(move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut ops = 0u64;
+                    while start.elapsed() < duration {
+                        for key in 0..100u64 {
+                            let key = key + (tid as u64 * 10000);
+                            // Insert error first (creates timer node with TTL)
+                            cache.insert(key, Err("error".into()));
+                            // Update to success (Expiry returns None - removes TTL)
+                            cache.insert(key, Ok(ops));
+                            // Sometimes go back to error
+                            if ops % 3 == 0 {
+                                cache.insert(key, Err("retry".into()));
+                            }
+                            ops += 1;
+                        }
+                    }
+                    println!("[Insert {}] done: {} ops", tid, ops);
+                }))
+                .unwrap_or_else(|_| {
+                    panics.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("[Insert {}] PANICKED!", tid);
+                });
+            })
+        })
+        .collect();
+
+    // Get threads - trigger expire_after_read and housekeeping
+    let get_handles: Vec<_> = (0..4)
+        .map(|tid| {
+            let cache = Arc::clone(&cache);
+            let panics = Arc::clone(&panics);
+            let duration = test_duration;
+            thread::spawn(move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut ops = 0u64;
+                    while start.elapsed() < duration {
+                        for key in 0..100u64 {
+                            // Read from different thread's key space to increase contention
+                            let key = key + ((ops % 4) * 10000);
+                            let _ = cache.get(&key);
+                            ops += 1;
+                        }
+                    }
+                    println!("[Get {}] done: {} ops", tid, ops);
+                }))
+                .unwrap_or_else(|_| {
+                    panics.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("[Get {}] PANICKED!", tid);
+                });
+            })
+        })
+        .collect();
+
+    let cache_hk = Arc::clone(&cache);
+    let panics_hk = Arc::clone(&panics);
+    let hk = thread::spawn(move || {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            while start.elapsed() < test_duration {
+                cache_hk.run_pending_tasks();
+                thread::sleep(Duration::from_millis(50));
+            }
+        }))
+        .unwrap_or_else(|_| {
+            panics_hk.fetch_add(1, Ordering::Relaxed);
+            eprintln!("[HK] PANICKED!");
+        });
+    });
+
+    for h in insert_handles {
+        let _ = h.join();
+    }
+    for h in get_handles {
+        let _ = h.join();
+    }
+    let _ = hk.join();
+
+    let total_panics = panics.load(Ordering::Relaxed);
+    assert_eq!(
+        total_panics, 0,
+        "Timer wheel panic detected! {} threads panicked",
+        total_panics
+    );
+}
+
+/// Extended stress test - runs longer for more thorough testing.
+///
+/// Use `cargo test --release -p moka --test timer_wheel_panic_test stress -- --ignored`
+/// to run this test.
+#[test]
+#[ignore]
+fn stress_test_timer_wheel_panic() {
+    let test_duration = Duration::from_secs(60);
+
+    let panics = Arc::new(AtomicUsize::new(0));
+
+    let cache: Cache<u64, HandleResult<u64>> = Cache::builder()
+        .name("stress_test_cache")
+        .expire_after(CustomExpiry::default())
+        .time_to_idle(Duration::from_secs(240))
+        .max_capacity(10000)
+        .build();
+
+    let cache = Arc::new(cache);
+    let start = Instant::now();
+
+    // More aggressive thread count for stress testing
+    let num_insert_threads = 8;
+    let num_get_threads = 8;
+
+    // Insert threads
+    let insert_handles: Vec<_> = (0..num_insert_threads)
+        .map(|tid| {
+            let cache = Arc::clone(&cache);
+            let panics = Arc::clone(&panics);
+            let duration = test_duration;
+            thread::spawn(move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut ops = 0u64;
+                    while start.elapsed() < duration {
+                        for key in 0..200u64 {
+                            let key = key + (tid as u64 * 10000);
+                            cache.insert(key, Err("error".into()));
+                            cache.insert(key, Ok(ops));
+                            if ops % 3 == 0 {
+                                cache.insert(key, Err("retry".into()));
+                            }
+                            if ops % 7 == 0 {
+                                cache.invalidate(&key);
+                            }
+                            ops += 1;
+                        }
+                    }
+                    println!("[Insert {}] done: {} ops", tid, ops);
+                }))
+                .unwrap_or_else(|e| {
+                    panics.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("[Insert {}] PANICKED: {:?}", tid, e);
+                });
+            })
+        })
+        .collect();
+
+    // Get threads
+    let get_handles: Vec<_> = (0..num_get_threads)
+        .map(|tid| {
+            let cache = Arc::clone(&cache);
+            let panics = Arc::clone(&panics);
+            let duration = test_duration;
+            thread::spawn(move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut ops = 0u64;
+                    while start.elapsed() < duration {
+                        for key in 0..200u64 {
+                            let key = key + ((ops % num_get_threads as u64) * 10000);
+                            let _ = cache.get(&key);
+                            ops += 1;
+                        }
+                    }
+                    println!("[Get {}] done: {} ops", tid, ops);
+                }))
+                .unwrap_or_else(|e| {
+                    panics.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("[Get {}] PANICKED: {:?}", tid, e);
+                });
+            })
+        })
+        .collect();
+
+    let hk_handles: Vec<_> = (0..2)
+        .map(|tid| {
+            let cache = Arc::clone(&cache);
+            let panics = Arc::clone(&panics);
+            let duration = test_duration;
+            thread::spawn(move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    while start.elapsed() < duration {
+                        cache.run_pending_tasks();
+                        thread::sleep(Duration::from_millis(25));
+                    }
+                }))
+                .unwrap_or_else(|e| {
+                    panics.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("[HK {}] PANICKED: {:?}", tid, e);
+                });
+            })
+        })
+        .collect();
+
+    // Wait for all threads
+    for h in insert_handles {
+        let _ = h.join();
+    }
+    for h in get_handles {
+        let _ = h.join();
+    }
+    for h in hk_handles {
+        let _ = h.join();
+    }
+
+    let total_panics = panics.load(Ordering::Relaxed);
+    assert_eq!(
+        total_panics, 0,
+        "Timer wheel panic detected! {} threads panicked during stress test.",
+        total_panics
+    );
+}


### PR DESCRIPTION
Problem:
A race condition exists when using custom Expiry implementations that return None to unset per-entry expiration. expiration_time in EntryInfo is modified atomically when Expiry returns None, but timer_node in DeqNodes is only updated during housekeeping. This creates a window where the expiration time indicates "no expiration" but the timer node pointer still references freed memory.

Solution:
Add a generation counter expiry_gen to EntryInfo.
Counter incremented each time expiration changes
and skip operations on stale nodes instead of panicking (best effort). Long term solution would be apply the set_expiration_time() changes during housekeeping or use arena-based allocation, but it changes external behavior and I consider this as bigger architectural change.

This PR also adds a two tests to catch a such panic and reproduce the issue.

Fixes https://github.com/moka-rs/moka/issues/527 and https://github.com/moka-rs/moka/issues/524.