### PR TITLE
Fix expire_after_update not clearing expiration time for expired entries (`future` cache)

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5758,4 +5758,96 @@ mod tests {
             break;
         }
     }
+
+    /// Test that returning `None` from `expire_after_update` properly clears
+    /// expiration for an already expired entry.
+    ///
+    /// Expected behavior: After `expire_after_update` returns `None`, the entry
+    /// should become accessible via `get()`.
+    #[tokio::test]
+    async fn expire_after_update_none_on_expired_entry() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // A flag to control whether the entry should expire immediately
+        let should_expire = Arc::new(AtomicBool::new(true));
+
+        struct TestExpiry {
+            should_expire: Arc<AtomicBool>,
+        }
+
+        impl Expiry<String, String> for TestExpiry {
+            fn expire_after_create(
+                &self,
+                _key: &String,
+                _value: &String,
+                _current_time: StdInstant,
+            ) -> Option<Duration> {
+                if self.should_expire.load(Ordering::SeqCst) {
+                    // Expire immediately
+                    Some(Duration::ZERO)
+                } else {
+                    // No expiration
+                    None
+                }
+            }
+
+            fn expire_after_update(
+                &self,
+                _key: &String,
+                _value: &String,
+                _current_time: StdInstant,
+                _duration_until_expiry: Option<Duration>,
+            ) -> Option<Duration> {
+                if self.should_expire.load(Ordering::SeqCst) {
+                    Some(Duration::ZERO)
+                } else {
+                    // According to docs, None means "no expiration"
+                    // This should make the entry accessible again
+                    None
+                }
+            }
+        }
+
+        let expiry = TestExpiry {
+            should_expire: Arc::clone(&should_expire),
+        };
+
+        let mut cache: Cache<String, String> = Cache::builder()
+            .max_capacity(100)
+            .expire_after(expiry)
+            .build();
+        cache.reconfigure_for_testing().await;
+
+        let key = "test_key".to_string();
+
+        // Insert entry that expires immediately
+        cache.insert(key.clone(), "first_value".to_string()).await;
+        cache.run_pending_tasks().await;
+
+        // Entry should exist but be expired
+        assert_eq!(cache.entry_count(), 1, "Entry should exist in cache");
+        assert_eq!(
+            cache.get(&key).await,
+            None,
+            "Entry should not be accessible (expired)"
+        );
+        cache.run_pending_tasks().await;
+
+        // Now update the entry to NOT expire (expire_after_update returns None)
+        should_expire.store(false, Ordering::SeqCst);
+        cache.insert(key.clone(), "second_value".to_string()).await;
+        cache.run_pending_tasks().await;
+
+        // The entry should now be accessible since we returned None
+        // (meaning "no expiration") from expire_after_update
+        assert_eq!(cache.entry_count(), 1, "Entry should exist in cache");
+
+        // Returning None from expire_after_update should clear the expiration.
+        let result = cache.get(&key).await;
+        assert_eq!(
+            result,
+            Some("second_value".to_string()),
+            "Entry should be accessible after clearing expiration"
+        );
+    }
 }


### PR DESCRIPTION
When an entry was already expired, returning None from expire_after_update did not clear the expiration time as expected. This happened because:

1. For expired entries, current_duration is None (can't compute positive duration from a past time)
2. User returns None to clear expiration
3. The check `duration != current_duration` evaluates to `None != None`, which is false
4. The expiration time was not updated, leaving the entry inaccessible

The fix tracks the current per-entry expiration time separately and adds a check: if the user returns None and there's a per-entry expiration time set (meaning the entry is expired, not "no expiration"), clear it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache expiration logic to optimize how expiration times are calculated and cached, with improved handling to clear per-entry expiration when necessary for better system performance.

* **Tests**
  * Added test case verifying cache behavior when per-entry expiration times are cleared, demonstrating that expired entries can transition back to a usable state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->