### PR TITLE
Bump the MSRV to 1.71.1 (2023-08-03)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.70.0  # MSRV
+          - 1.71.1  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -68,11 +68,11 @@ jobs:
         run: ./.ci_extras/pin-crate-vers-nightly.sh
 
       - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.70.0' }}
+        if: ${{ matrix.rust == '1.71.1' }}
         run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Remove some examples (MSRV only)
-        if: ${{ matrix.rust == '1.70.0' }}
+        if: ${{ matrix.rust == '1.71.1' }}
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Show cargo tree

--- a/.github/workflows/CIQuantaEnabled.yml
+++ b/.github/workflows/CIQuantaEnabled.yml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.70.0  # MSRV
+          - 1.71.1  # MSRV
           - nightly # For checking minimum version dependencies.
 
     steps:
@@ -60,11 +60,11 @@ jobs:
         run: ./.ci_extras/pin-crate-vers-nightly.sh
 
       - name: Pin some dependencies to specific versions (MSRV only)
-        if: ${{ matrix.rust == '1.70.0' }}
+        if: ${{ matrix.rust == '1.71.1' }}
         run: ./.ci_extras/pin-crate-vers-msrv.sh
 
       - name: Remove some examples (MSRV only)
-        if: ${{ matrix.rust == '1.70.0' }}
+        if: ${{ matrix.rust == '1.71.1' }}
         run: ./.ci_extras/remove-examples-msrv.sh
 
       - name: Show cargo tree

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ section ([`sync::Cache`][doc-sync-cache-expiration],
 Moka's minimum supported Rust versions (MSRV) are the followings:
 
 | Feature  | MSRV                       |
-|:---------|:--------------------------:|
-| `future` | Rust 1.70.0 (June 1, 2023) |
-| `sync`   | Rust 1.70.0 (June 1, 2023) |
+|:---------|:-----------------------------:|
+| `future` | Rust 1.71.1 (August 3, 2023) |
+| `sync`   | Rust 1.71.1 (August 3, 2023) |
 
 It will keep a rolling MSRV policy of at least 6 months. If the default features with
 a mandatory features (`future` or `sync`) are enabled, MSRV will be updated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,9 +130,9 @@
 //! This crate's minimum supported Rust versions (MSRV) are the followings:
 //!
 //! | Feature  | MSRV                       |
-//! |:---------|:--------------------------:|
-//! | `future` | Rust 1.70.0 (June 1, 2023) |
-//! | `sync`   | Rust 1.70.0 (June 1, 2023) |
+//! |:---------|:-----------------------------:|
+//! | `future` | Rust 1.71.1 (August 3, 2023) |
+//! | `sync`   | Rust 1.71.1 (August 3, 2023) |
 //!
 //! It will keep a rolling MSRV policy of at least 6 months. If the default features
 //! with a mandatory features (`future` or `sync`) are enabled, MSRV will be updated


### PR DESCRIPTION
## Summary

Bump the MSRV from `1.70.0` (2023-06-01) to `1.71.1` (2023-08-03) for the following reasons:

- Avoid read-after-free issues with the timer wheels occurring ONLY on Rust 1.70.0 with Linux targets.
  - https://github.com/moka-rs/moka/pull/553#issuecomment-3662997890
- Avoid 1.71.0 or erlier for security vulnerability in Cargo: CVE-2023-38497
  - https://github.com/rust-lang/cargo/security/advisories/GHSA-j3xp-wfr4-hx87
 
## Updated files:

- `Cargo.toml`: Updated rust-version field and comment
- `README.md`: Updated MSRV documentation
- `src/lib.rs`: Updated MSRV documentation
- GitHub Actions workflows: Updated MSRV references in `CI.yml` and `CIQuantaEnabled.yml`

## Summary by CodeRabbit

- Chores
  - Updated CI workflows to reflect new minimum supported Rust version (MSRV) of 1.71.1, previously 1.70.0.

- Documentation
  - Updated MSRV tables and documentation to version 1.71.1.
  - Clarified MSRV policy to note that using additional features may require newer Rust versions.
