### PR TITLE
Fix Clippy warnings (after upgrading the MSRV 1.71.1)

### DIFF
--- a/src/cht/map/bucket.rs
+++ b/src/cht/map/bucket.rs
@@ -1,5 +1,5 @@
 use std::{
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     mem::{self, MaybeUninit},
     ptr,
     sync::{
@@ -660,10 +660,7 @@ where
     K: ?Sized + Hash,
     H: BuildHasher,
 {
-    let mut hasher = build_hasher.build_hasher();
-    key.hash(&mut hasher);
-
-    hasher.finish()
+    build_hasher.hash_one(key)
 }
 
 pub(crate) enum InsertionResult<'g, K, V> {

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -207,7 +207,7 @@ impl FrequencySketch {
 mod tests {
     use super::FrequencySketch;
     use once_cell::sync::Lazy;
-    use std::hash::{BuildHasher, Hash, Hasher};
+    use std::hash::{BuildHasher, Hash};
 
     static ITEM: Lazy<u32> = Lazy::new(|| {
         let mut buf = [0; 4];
@@ -322,11 +322,7 @@ mod tests {
 
     fn hasher<K: Hash>() -> impl Fn(K) -> u64 {
         let build_hasher = std::collections::hash_map::RandomState::default();
-        move |key| {
-            let mut hasher = build_hasher.build_hasher();
-            key.hash(&mut hasher);
-            hasher.finish()
-        }
+        move |key| build_hasher.hash_one(&key)
     }
 }
 

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -44,7 +44,7 @@ use smallvec::SmallVec;
 use std::{
     borrow::Borrow,
     collections::hash_map::RandomState,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     sync::{
         atomic::{AtomicBool, AtomicU8, Ordering},
         Arc,
@@ -1206,9 +1206,7 @@ where
     where
         Q: Equivalent<K> + Hash + ?Sized,
     {
-        let mut hasher = self.build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish()
+        self.build_hasher.hash_one(key)
     }
 
     #[inline]

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -38,7 +38,7 @@ use smallvec::SmallVec;
 use std::{
     borrow::Borrow,
     collections::hash_map::RandomState,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicU8, Ordering},
@@ -1062,9 +1062,7 @@ where
     where
         Q: Equivalent<K> + Hash + ?Sized,
     {
-        let mut hasher = self.build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish()
+        self.build_hasher.hash_one(key)
     }
 
     #[inline]

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -16,7 +16,7 @@ use crate::{
 use std::{
     collections::hash_map::RandomState,
     fmt,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     sync::Arc,
 };
 
@@ -757,9 +757,7 @@ where
     where
         Q: Equivalent<K> + Hash + ?Sized,
     {
-        let mut hasher = self.build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish()
+        self.build_hasher.hash_one(key)
     }
 
     #[inline]


### PR DESCRIPTION
Upgrading the `rust-version` in `Cargo.toml` enabled a lint:

- https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#manual_hash_one

This PR follows the lint and use the convenient method for `Hasher` added to Rust 1.71.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized hash computation routines across core caching modules for improved code efficiency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->