### PR TITLE
Remove Tier 3 MIPS tests from CI

### DIFF
--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -48,14 +48,6 @@ jobs:
           # Platforms without AtomicU64 support.
           - target: armv5te-unknown-linux-musleabi
             rust-version: stable
-          - target: mips-unknown-linux-musl
-            rust-version: "1.72.1"
-            cargo-version: "+1.72.1"
-            remove-reqwest: true
-          - target: mipsel-unknown-linux-musl
-            rust-version: "1.72.1"
-            cargo-version: "+1.72.1"
-            remove-reqwest: true
 
     steps:
       - name: Checkout Moka
@@ -78,24 +70,20 @@ jobs:
           cargo remove --dev actix-rt
           cat Cargo.toml
 
-      - name: Remove reqwest dependency (for some platforms)
-        if: ${{ matrix.platform.remove-reqwest == true }}
-        run: cargo remove --dev reqwest
-
       - run: cargo clean
 
       - name: Run tests (sync feature)
         run: |
-          cross ${{ matrix.platform.cargo-version }} test --release -F sync \
+          cross test --release -F sync \
             --target ${{ matrix.platform.target }}
 
       - name: Run tests (future feature)
         run: |
-          cross ${{ matrix.platform.cargo-version }} test --release -F future \
+          cross test --release -F future \
             --target ${{ matrix.platform.target }}
 
       - name: Run tests (sync feature, drop cache)
         run: |
-          cross ${{ matrix.platform.cargo-version }} test --release -F sync \
+          cross test --release -F sync \
             --target ${{ matrix.platform.target }} \
             --lib sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored


### PR DESCRIPTION
Relates to #333.

Remove the MIPS tests from the CI. Here are the reasons:

- The following targets were demoted from Tier 2 to Tier 3 in Rust 1.73.0, released almost two years ago:
  - `mips-unknown-linux-musl`
  - `mipsel-unknown-linux-musl`
- We have been using Rust 1.72.1, the last version supporting Tier 2 MIPS targets, to run the MIPS tests in the CI.
- However,  it is getting meaningless to test targets with not a recent stable Rust versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified cross-compilation testing workflow by removing MIPS platform targets and streamlining test invocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->