### PR TITLE
Fix `sync` cache to clear expiration when `expire_after_update` returns `None`

### DIFF
--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -678,8 +678,11 @@ impl<K, V, S> BaseCache<K, V, S> {
         let current_time = clock.to_std_instant(ts);
         let ei = &value_entry.entry_info();
 
+        // Track the current per-entry expiration time.
+        let current_per_entry_exp_time = ei.expiration_time();
+
         let exp_time = IntoIterator::into_iter([
-            ei.expiration_time(),
+            current_per_entry_exp_time,
             ttl.and_then(|dur| ei.last_modified().map(|ts| ts.saturating_add(dur))),
             tti.and_then(|dur| ei.last_accessed().map(|ts| ts.saturating_add(dur))),
         ])
@@ -699,6 +702,10 @@ impl<K, V, S> BaseCache<K, V, S> {
                 .entry_info()
                 .set_expiration_time(expiration_time);
             // The `expiration_time` has changed from `None` to `Some` or vice versa.
+            true
+        } else if duration.is_none() && current_per_entry_exp_time.is_some() {
+            // Clear the expired per-entry expiration time.
+            value_entry.entry_info().set_expiration_time(None);
             true
         } else {
             false


### PR DESCRIPTION
Port the fix from PR #549 to the sync cache implementation. Previously, when a custom `Expiry`'s `expire_after_update` callback returned `None` (meaning "no expiration"), the sync cache did not clear the existing per-entry expiration time, leaving expired entries inaccessible.

This fix ensures that:

1. The current per-entry expiration time is captured before modifications
2. When the expiry callback returns `None` and there was a previous per-entry expiration, that expiration is properly cleared

Also add `expire_after_update_none_on_expired_entry` test to the sync cache to verify the fix and prevent regressions.

Fixes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache expiration handling to more accurately compute and store per-entry expiration times. Ensures proper cleanup of expiration metadata when expiration durations become unassigned, improving cache reliability.

* **Tests**
  * Added new test to verify correct per-entry cache expiration behavior during dynamic expiration updates. Ensures entries are properly accessible when expiration is cleared and verifies expiration state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->