### PR TITLE
Fix use-after-free in timer wheel

### DIFF
--- a/src/common/timer_wheel.rs
+++ b/src/common/timer_wheel.rs
@@ -398,7 +398,11 @@ impl<K> TimerWheel<K> {
             }
         }
 
-        deque.pop_front()
+        let mut popped = deque.pop_front();
+        if let Some(node) = &mut popped {
+            node.element.unset_position();
+        }
+        popped
     }
 
     /// Reset the positions of the nodes in the queue at the given level and index.
@@ -610,6 +614,8 @@ impl<K> Iterator for TimerEventsIter<'_, K> {
                             return Some(TimerEvent::Descheduled);
                         }
                     }
+                } else {
+                    node.as_ref().element.unset_timer_node_in_deq_nodes();
                 }
             } else {
                 // Done with the current queue. Move to the next index

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -1884,8 +1884,11 @@ where
         entry: &MiniArc<ValueEntry<K, V>>,
         timer_wheel: &mut TimerWheel<K>,
     ) {
+        // `expiration_time` is loaded here, and consistently used for
+        // all decisions about the timer wheel update.
+        let expiration_time = entry.entry_info().expiration_time();
         // Enable the timer wheel if needed.
-        if entry.entry_info().expiration_time().is_some() && !timer_wheel.is_enabled() {
+        if expiration_time.is_some() && !timer_wheel.is_enabled() {
             timer_wheel.enable();
         }
 
@@ -1894,7 +1897,7 @@ where
         let current_expiry_gen = entry.entry_info().expiry_gen();
 
         // Update the timer wheel.
-        match (entry.entry_info().expiration_time().is_some(), timer_node) {
+        match (expiration_time.is_some(), timer_node) {
             // Do nothing; the cache entry has no expiration time and not registered
             // to the timer wheel.
             (false, None) => (),

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -1712,8 +1712,11 @@ where
         entry: &MiniArc<ValueEntry<K, V>>,
         timer_wheel: &mut TimerWheel<K>,
     ) {
+        // `expiration_time` is loaded here, and consistently used for
+        // all decisions about the timer wheel update.
+        let expiration_time = entry.entry_info().expiration_time();
         // Enable the timer wheel if needed.
-        if entry.entry_info().expiration_time().is_some() && !timer_wheel.is_enabled() {
+        if expiration_time.is_some() && !timer_wheel.is_enabled() {
             timer_wheel.enable();
         }
 
@@ -1722,7 +1725,7 @@ where
         let current_expiry_gen = entry.entry_info().expiry_gen();
 
         // Update the timer wheel.
-        match (entry.entry_info().expiration_time().is_some(), timer_node) {
+        match (expiration_time.is_some(), timer_node) {
             // Do nothing; the cache entry has no expiration time and not registered
             // to the timer wheel.
             (false, None) => (),


### PR DESCRIPTION
Fixes #565 ([comment](https://github.com/moka-rs/moka/issues/565#issuecomment-3747272705))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced redundant expiration checks by caching expiration value, improving timer decision efficiency.
* **Bug Fixes**
  * Ensured timer entries are fully detached and positions cleared when removed, improving state cleanup and preventing stale timer state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->