### PR TITLE
Disable flaky GC-dependent tests by default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,16 @@ jobs:
         env:
           RUSTFLAGS: '--cfg run_flaky_tests'
 
+      - name: Run tests (future feature, drop value after eviction for future::Cache)
+        run: cargo test --release --lib --features future future::cache::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future feature, drop cache for future::Cache)
+        run: cargo test --release --lib --features future future::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
       - name: Run tests (future feature, but no sync feature)
         run: cargo test --features future
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,16 +85,24 @@ jobs:
         run: cargo test --release --features sync
 
       - name: Run tests (sync feature, key lock test for notification)
-        run: cargo test --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop value after eviction for sync::Cache)
-        run: cargo test --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop value after eviction for sync::SegmentedCache)
-        run: cargo test --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop cache)
-        run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (future feature, but no sync feature)
         run: cargo test --features future

--- a/.github/workflows/CIArm64.yml
+++ b/.github/workflows/CIArm64.yml
@@ -63,6 +63,16 @@ jobs:
         env:
           RUSTFLAGS: '--cfg run_flaky_tests'
 
+      - name: Run tests (future feature, drop value after eviction for future::Cache)
+        run: cargo test --release --lib --features future future::cache::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future feature, drop cache for future::Cache)
+        run: cargo test --release --lib --features future future::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
       - name: Run tests (future feature)
         run: cargo test --features future
         env:

--- a/.github/workflows/CIArm64.yml
+++ b/.github/workflows/CIArm64.yml
@@ -44,16 +44,24 @@ jobs:
           RUSTFLAGS: '--cfg skip_large_mem_tests'
 
       - name: Run tests (sync feature, key lock test for notification)
-        run: cargo test --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop value after eviction for sync::Cache)
-        run: cargo test --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop value after eviction for sync::SegmentedCache)
-        run: cargo test --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::segment::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop cache)
-        run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+        run: cargo test --release --lib --features sync sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (future feature)
         run: cargo test --features future

--- a/.github/workflows/CIQuantaEnabled.yml
+++ b/.github/workflows/CIQuantaEnabled.yml
@@ -89,3 +89,13 @@ jobs:
         run: cargo test --release --lib --features 'sync, quanta' sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
         env:
           RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future, quanta features, drop value after eviction for future::Cache)
+        run: cargo test --release --lib --features 'future, quanta' future::cache::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future, quanta features, drop cache for future::Cache)
+        run: cargo test --release --lib --features 'future, quanta' future::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'

--- a/.github/workflows/CIQuantaEnabled.yml
+++ b/.github/workflows/CIQuantaEnabled.yml
@@ -86,4 +86,6 @@ jobs:
         run: cargo test --features 'sync, future, quanta, logging'
 
       - name: Run tests (sync, quanta features, drop cache)
-        run: cargo test --release --lib --features 'sync, quanta' sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+        run: cargo test --release --lib --features 'sync, quanta' sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -33,25 +33,33 @@ jobs:
         run: |
           cargo llvm-cov --no-report --lib --features sync \
             -- sync::cache::tests::test_key_lock_used_by_immediate_removal_notifications \
-            --exact --ignored
+            --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop value after eviction for sync::Cache)
         run: |
           cargo llvm-cov --no-report --lib --features sync \
             -- sync::cache::tests::drop_value_immediately_after_eviction \
-            --exact --ignored
+            --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop value after eviction for sync::SegmentedCache)
         run: |
           cargo llvm-cov --no-report --lib --features sync \
             -- sync::segment::tests::drop_value_immediately_after_eviction \
-            --exact --ignored
+            --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Run tests (sync feature, drop cache)
         run: |
           cargo llvm-cov --no-report --lib --features sync \
             -- sync::cache::tests::ensure_gc_runs_when_dropping_cache \
-            --exact --ignored
+            --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
 
       - name: Generate coverage report
         run: cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -61,6 +61,22 @@ jobs:
         env:
           RUSTFLAGS: '--cfg run_flaky_tests'
 
+      - name: Run tests (future feature, drop value after eviction for future::Cache)
+        run: |
+          cargo llvm-cov --no-report --lib --features future \
+            -- future::cache::tests::drop_value_immediately_after_eviction \
+            --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future feature, drop cache for future::Cache)
+        run: |
+          cargo llvm-cov --no-report --lib --features future \
+            -- future::cache::tests::ensure_gc_runs_when_dropping_cache \
+            --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
       - name: Generate coverage report
         run: cargo llvm-cov report --lcov --output-path lcov.info
 

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -86,4 +86,6 @@ jobs:
         run: |
           cross test --release -F sync \
             --target ${{ matrix.platform.target }} \
-            --lib sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact --ignored
+            --lib sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'

--- a/.github/workflows/LinuxCrossCompileTest.yml
+++ b/.github/workflows/LinuxCrossCompileTest.yml
@@ -89,3 +89,19 @@ jobs:
             --lib sync::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
         env:
           RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future feature, drop value after eviction for future::Cache)
+        run: |
+          cross test --release -F future \
+            --target ${{ matrix.platform.target }} \
+            --lib future::cache::tests::drop_value_immediately_after_eviction -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'
+
+      - name: Run tests (future feature, drop cache for future::Cache)
+        run: |
+          cross test --release -F future \
+            --target ${{ matrix.platform.target }} \
+            --lib future::cache::tests::ensure_gc_runs_when_dropping_cache -- --exact
+        env:
+          RUSTFLAGS: '--cfg run_flaky_tests'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     "cfg(kani)",
     "cfg(moka_loom)",
     "cfg(mips)",
+    "cfg(run_flaky_tests)",
     "cfg(skip_large_mem_tests)",
     "cfg(trybuild)",
 ] }

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -5596,7 +5596,10 @@ mod tests {
         cache.invalidate(key_s).await;
     }
 
+    // Ignored by default. This test becomes unstable when run in parallel with
+    // other tests.
     #[tokio::test]
+    #[cfg_attr(not(run_flaky_tests), ignore)]
     async fn drop_value_immediately_after_eviction() {
         use crate::common::test_utils::{Counters, Value};
 
@@ -5696,7 +5699,11 @@ mod tests {
     }
 
     // https://github.com/moka-rs/moka/issues/383
+    //
+    // Ignored by default. This test becomes unstable when run in parallel with
+    // other tests.
     #[tokio::test]
+    #[cfg_attr(not(run_flaky_tests), ignore)]
     async fn ensure_gc_runs_when_dropping_cache() {
         let cache = Cache::builder().build();
         let val = Arc::new(0);

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -4845,7 +4845,7 @@ mod tests {
     // This test is ignored by default. It becomes unstable when run in parallel
     // with other tests.
     #[test]
-    #[ignore]
+    #[cfg_attr(not(run_flaky_tests), ignore)]
     fn test_key_lock_used_by_immediate_removal_notifications() {
         use std::thread::{sleep, spawn};
 
@@ -5203,7 +5203,7 @@ mod tests {
     // Ignored by default. This test becomes unstable when run in parallel with
     // other tests.
     #[test]
-    #[ignore]
+    #[cfg_attr(not(run_flaky_tests), ignore)]
     fn drop_value_immediately_after_eviction() {
         use crate::common::test_utils::{Counters, Value};
 
@@ -5265,7 +5265,7 @@ mod tests {
     // Ignored by default. This test becomes unstable when run in parallel with
     // other tests.
     #[test]
-    #[ignore]
+    #[cfg_attr(not(run_flaky_tests), ignore)]
     fn ensure_gc_runs_when_dropping_cache() {
         let cache = Cache::builder().build();
         let val = Arc::new(0);

--- a/src/sync/segment.rs
+++ b/src/sync/segment.rs
@@ -1851,7 +1851,7 @@ mod tests {
     // Ignored by default. This test becomes unstable when run in parallel with
     // other tests.
     #[test]
-    #[ignore]
+    #[cfg_attr(not(run_flaky_tests), ignore)]
     fn drop_value_immediately_after_eviction() {
         use crate::common::test_utils::{Counters, Value};
 


### PR DESCRIPTION
## Summary

Disable flaky GC-dependent tests by default using `run_flaky_tests` cfg. These tests rely on epoch-based GC (`crossbeam-epoch`) timing that is not guaranteed, causing intermittent failures in downstream projects.

Fixes #539 and #580.

## Problem

- **The following GH Issues**: `future::cache::tests::ensure_gc_runs_when_dropping_cache` fails intermittently.
    - #539
    - #580
- The `sync` version had `#[ignore]`, but the **future version did not** &mdash; it ran by default.
- Downstream projects (Fedora, Debian) experienced flaky test failures.

## Solution

Use `#[cfg_attr(not(run_flaky_tests), ignore)]` to conditionally ignore tests:
- **Default behavior**: Tests are ignored. (won't run with `cargo test`.)
- **moka CI**: Sets `RUSTFLAGS='--cfg run_flaky_tests'` to enable tests.
- **Downstream projects**: Tests are ignored by default.

## Affected Tests

| Test | Location |
|------|----------|
| `ensure_gc_runs_when_dropping_cache` | sync/cache, future/cache |
| `drop_value_immediately_after_eviction` | sync/cache, sync/segment, future/cache |
| `test_key_lock_used_by_immediate_removal_notifications` | sync/cache |

## Changes

- Add `run_flaky_tests` to `unexpected_cfgs` in `Cargo.toml`.
- Add `#[cfg_attr(not(run_flaky_tests), ignore)]` to six tests.
- Update 5 CI workflows with `RUSTFLAGS` env var.

## Testing

```bash
# Tests are ignored by default
cargo test --features sync
# -> sync::cache::tests::ensure_gc_runs_when_dropping_cache ... ignored

# Tests run when cfg is set
RUSTFLAGS='--cfg run_flaky_tests' cargo test --features sync
# -> sync::cache::tests::ensure_gc_runs_when_dropping_cache ... ok
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moka-rs/moka/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Previously skipped cache tests (eviction behavior, immediate-drop, lock notifications, GC-on-drop) can now run under a conditional test mode, increasing coverage for sync and async cache implementations.

* **Chores**
  * CI workflows updated to run those conditional tests when enabled and a compile-time flag added to control flaky-test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->