### PR TITLE
Fix flaky test `cht::segment::tests::drop_many_values_concurrent` on many-core machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
           so `Expiry::expire_after_create` is called instead.
         - This may change the expiration time of re-inserted entries, depending on
           your `Expiry` trait implementation.
+- Fixed a flaky test `cht::segment::tests::drop_many_values_concurrent` that was
+  failing on high-core-count machines ([#586][gh-pull-0586]):
+    - The test was using a CPU-dependent segment count, causing inconsistent
+      bucket array shrinking behavior of the internal segmented hash map across
+      different machines.
+    - Changed the test to use a fixed segment count (4) for consistent results.
 
 ### Changed
 
@@ -1139,6 +1145,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0586]: https://github.com/moka-rs/moka/pull/586/
 [gh-pull-0584]: https://github.com/moka-rs/moka/pull/584/
 [gh-pull-0582]: https://github.com/moka-rs/moka/pull/582/
 [gh-pull-0581]: https://github.com/moka-rs/moka/pull/581/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,13 @@
           so `Expiry::expire_after_create` is called instead.
         - This may change the expiration time of re-inserted entries, depending on
           your `Expiry` trait implementation.
-- Fixed a flaky test `cht::segment::tests::drop_many_values_concurrent` that was
-  failing on high-core-count machines ([#586][gh-pull-0586]):
-    - The test was using a CPU-dependent segment count, causing inconsistent
+- Fixed flaky tests `cht::segment::tests::drop_many_values` and
+  `drop_many_values_concurrent` that were failing on high-core-count machines
+  ([#586][gh-pull-0586]):
+    - These tests were using a CPU-dependent segment count, causing inconsistent
       bucket array shrinking behavior of the internal segmented hash map across
       different machines.
-    - Changed the test to use a fixed segment count (4) for consistent results.
+    - Changed these tests to use a fixed segment count (4) for consistent results.
 
 ### Changed
 

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -1435,7 +1435,11 @@ mod tests {
         );
 
         {
-            let map = Arc::new(HashMap::with_capacity(0));
+            let map = Arc::new(HashMap::with_num_segments_capacity_and_hasher(
+                4,
+                0,
+                DefaultHashBuilder::default(),
+            ));
             assert!(map.is_empty());
             assert_eq!(map.len(), 0);
 

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -1333,7 +1333,11 @@ mod tests {
             .collect();
 
         {
-            let map = HashMap::with_capacity(0);
+            let map = HashMap::with_num_segments_capacity_and_hasher(
+                4,
+                0,
+                DefaultHashBuilder::default(),
+            );
             assert!(map.is_empty());
             assert_eq!(map.len(), 0);
 

--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -1333,11 +1333,8 @@ mod tests {
             .collect();
 
         {
-            let map = HashMap::with_num_segments_capacity_and_hasher(
-                4,
-                0,
-                DefaultHashBuilder::default(),
-            );
+            let map =
+                HashMap::with_num_segments_capacity_and_hasher(4, 0, DefaultHashBuilder::default());
             assert!(map.is_empty());
             assert_eq!(map.len(), 0);
 


### PR DESCRIPTION
## Problem

The test `cht::segment::tests::drop_many_values_concurrent` was flaky on high-core-count machines (e.g., Fedora's 192-core builders), failing with:

```
assertion `left == right` failed
  left: 65792
 right: 131072
```

https://github.com/moka-rs/moka/pull/584#issuecomment-4097437328

Fixes #539.

## Root Cause

The test creates an internal `moka::cht` segmented `HashMap` using `HashMap::with_capacity(0)`, which uses a segment count based on CPU cores (`available_parallelism() * 2`). On a 192-core machine, this created 512 segments.

The assertion expected all segments to shrink to minimum bucket array size (256 buckets) after removing all entries. However, with 512 segments:

- Each segment only had ~64 entries on average.
- Tombstone accumulation during concurrent removals was non-uniform.
- Not all segments triggered enough shrink cycles to reach minimum size, causing the test to fail.

## Solution

Changed the test to use a fixed number of segments (`4`) instead of CPU-dependent segment count.

```rust
// Before
let map = Arc::new(HashMap::with_capacity(0));

// After
let map = Arc::new(HashMap::with_num_segments_capacity_and_hasher(
    4,
    0,
    DefaultHashBuilder::default(),
));
```

With four segments, each has ~8,192 entries, providing sufficient tombstone accumulation to ensure consistent shrinking behavior across all machines.

## Testing

- Verified the test passes locally

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moka-rs/moka/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixed flaky concurrent map tests by initializing with a fixed segment configuration to ensure consistent behavior on high-core-count machines.
* **Changelog**
  * Added an entry documenting the test fixes and included a link to the related pull request.

Note: This change affects internal tests only and does not modify public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->