### PR TITLE
Add try_get_with_entry to have access to whether an entry is fresh or not 

### DIFF
--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1328,7 +1328,7 @@ where
         futures_util::pin_mut!(init);
         let hash = self.base.hash(&key);
         let key = Arc::new(key);
-        self.get_or_try_insert_with_hash_and_fun(key, hash, init, false)
+        self.get_or_try_insert_with_hash_and_fun(key, hash, init, true)
             .await
     }
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1315,6 +1315,28 @@ where
             .map(Entry::into_value)
     }
 
+    /// Similar to [`try_get_with`](#method.try_get_with), but returns an [`Entry`]
+    /// instead of just the value. The [`Entry::is_fresh`] method returns `true` if
+    /// the value was not cached and was freshly computed (cache miss), or `false` if
+    /// it was already present in the cache (cache hit).
+    ///
+    /// This is useful when callers need to distinguish between a cache hit and a miss
+    /// without performing a separate `get` call before `try_get_with`.
+    ///
+    /// Like `try_get_with`, concurrent calls for the same key are coalesced: only one
+    /// `init` future runs; the rest wait and receive the same result.
+    pub async fn try_get_with_entry<F, E>(&self, key: K, init: F) -> Result<Entry<K, V>, Arc<E>>
+    where
+        F: Future<Output = Result<V, E>>,
+        E: Send + Sync + 'static,
+    {
+        futures_util::pin_mut!(init);
+        let hash = self.base.hash(&key);
+        let key = Arc::new(key);
+        self.get_or_try_insert_with_hash_and_fun(key, hash, init, false)
+            .await
+    }
+
     /// Similar to [`try_get_with`](#method.try_get_with), but instead of passing an
     /// owned key, you can pass a reference to the key. If the key does not exist in
     /// the cache, the key will be cloned to create new entry in the cache.

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1307,12 +1307,7 @@ where
         F: Future<Output = Result<V, E>>,
         E: Send + Sync + 'static,
     {
-        futures_util::pin_mut!(init);
-        let hash = self.base.hash(&key);
-        let key = Arc::new(key);
-        self.get_or_try_insert_with_hash_and_fun(key, hash, init, false)
-            .await
-            .map(Entry::into_value)
+        self.try_get_with_entry(key, init).await.map(Entry::into_value)
     }
 
     /// Similar to [`try_get_with`](#method.try_get_with), but returns an [`Entry`]


### PR DESCRIPTION
👋 I have some code that requires to know whether an entry is fresh from the cache or not.

I decided to expose that functionality in a new public function `try_get_with_entry`. I'll appreciate it if this code could make it back into upstream. I think it's pretty trivial to maintain since it's just the code in `try_get_with` without the `map` exposed in a public function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moka-rs/moka/pull/589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cache query that returns full entry objects (value plus metadata) for advanced caching scenarios.

* **Refactor**
  * Updated the existing value-only retrieval to delegate to the new entry-aware flow, simplifying control flow and making initialization and hashing paths consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->