### PR TITLE
Fix LRU eviction stall under concurrent key reuse

### DIFF
--- a/src/cht/segment.rs
+++ b/src/cht/segment.rs
@@ -337,6 +337,9 @@ impl<K: Hash + Eq, V, S: BuildHasher> HashMap<K, V, S> {
     /// Removes a key from the map, returning a clone of the key-value pair
     /// previously corresponding to the key.
     #[inline]
+    #[allow(dead_code)] // Kept for the CHT's public-ish API surface; current
+                        // moka call sites go through `remove_entry_if_and` so the
+                        // post-CAS callback can retire the `EntryInfo`.
     pub(crate) fn remove_entry(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<(K, V)>
     where
         K: Clone,

--- a/src/common/concurrent/entry_info.rs
+++ b/src/common/concurrent/entry_info.rs
@@ -10,7 +10,72 @@ pub(crate) struct EntryInfo<K> {
     /// `is_admitted` indicates that the entry has been admitted to the cache. When
     /// `false`, it means the entry is _temporary_ admitted to the cache or evicted
     /// from the cache (so it should not have LRU nodes).
+    ///
+    /// This is distinct from [`is_retired`](Self::is_retired): `is_admitted`
+    /// tracks deque membership, while `is_retired` tracks CHT membership. A
+    /// freshly inserted entry is **not retired** and **not admitted** until its
+    /// `WriteOp::Upsert` is drained; a retired entry may still be `is_admitted`
+    /// until `handle_remove*` unlinks it.
     is_admitted: AtomicBool,
+    /// CHT-membership flag: `false` while the entry is alive (still backed by
+    /// the concurrent hash table), `true` once the entry has been removed.
+    ///
+    /// The flag is set by `retire()` at the moment the entry is unlinked from
+    /// the CHT and is never cleared (`false → true`, monotonic). The
+    /// invariant it enforces is:
+    ///
+    /// > If `is_retired == true`, no policy-tier mutation may run against
+    /// > this `EntryInfo`.
+    ///
+    /// Examples of policy-tier mutations:
+    ///
+    /// - admitting the entry to an LRU deque,
+    /// - moving its deque node to the back,
+    /// - scheduling a timer-wheel node,
+    /// - incrementing `weighted_size`.
+    ///
+    /// ### Why we need it
+    ///
+    /// moka stores entries in a lock-free CHT (source of truth) and mirrors
+    /// their ordering into LRU deques updated asynchronously via a bounded
+    /// `WriteOp` channel. Without this flag, a `WriteOp::Upsert` can sit in the
+    /// channel long enough that the backing CHT entry is evicted before the op
+    /// is drained; the drain then pushes an "orphan" deque node that the
+    /// eviction loop cannot reach, blocking progress and stalling eviction
+    /// indefinitely (see <https://github.com/moka-rs/moka/issues/590>). The
+    /// retire store is performed inside the CHT's post-success
+    /// `with_previous_entry` callback so the transition linearises with the
+    /// bucket-pointer CAS that physically unlinked the entry; any consumer
+    /// draining a stale op thereafter observes `is_retired == true` and
+    /// declines to touch policy state.
+    ///
+    /// ### Why a single bit suffices (no `Dead` state)
+    ///
+    /// Caffeine encodes a three-state lifecycle (`Alive → Retired → Dead`)
+    /// because its `makeDead()` can be called twice for the same node: once
+    /// inline from `evictEntry()` during admission, and again later from
+    /// `RemovalTask.run()` draining the write buffer. The `isDead()` guard at
+    /// the top of `makeDead` prevents double-subtraction of `weightedSize`.
+    ///
+    /// moka has no such double-enter path: every CHT removal site gates its
+    /// `handle_remove_*` call on `if let Some(entry) = …`; i.e. on winning
+    /// the CHT bucket CAS. So `handle_remove_*` runs exactly once per
+    /// retirement, structurally.
+    ///
+    /// ### When a third state would become necessary
+    ///
+    /// A third state (`Dead`) earns its keep when there are **multiple
+    /// finalization paths** that may both target the same entry. Currently,
+    /// moka has one at the CAS-gated inline `handle_remove_*`.
+    ///
+    /// If moka ever grows a second finalization path that runs alongside the
+    /// `WriteOp::Remove` drain (e.g., an inline emergency-evict, an
+    /// async load-completion that touches policy state, or any code that
+    /// can re-enter `handle_remove_*` for an already-retired entry), the
+    /// idempotency requirement returns and a third state (or an equivalent
+    /// "weight already subtracted" marker) becomes necessary. Until then, a
+    /// single bit is sufficient.
+    is_retired: AtomicBool,
     /// `entry_gen` (entry generation) is incremented every time the entry is updated
     /// in the concurrent hash table.
     entry_gen: AtomicU16,
@@ -46,6 +111,7 @@ impl<K> EntryInfo<K> {
         Self {
             key_hash,
             is_admitted: AtomicBool::default(),
+            is_retired: AtomicBool::default(),
             // `entry_gen` starts at 1 and `policy_gen` start at 0.
             entry_gen: AtomicU16::new(1),
             policy_gen: AtomicU16::new(0),
@@ -70,6 +136,41 @@ impl<K> EntryInfo<K> {
     #[inline]
     pub(crate) fn set_admitted(&self, value: bool) {
         self.is_admitted.store(value, Ordering::Release);
+    }
+
+    /// Returns `true` iff the entry has been retired (removed from the CHT).
+    #[inline]
+    pub(crate) fn is_retired(&self) -> bool {
+        self.is_retired.load(Ordering::Acquire)
+    }
+
+    /// Returns `true` iff the entry is still alive (not yet retired).
+    /// Consumers of buffered operations (`WriteOp::Upsert`, `ReadOp::Hit`,
+    /// TinyLFU inline victim scans) MUST check this before mutating policy
+    /// state; see the `is_retired` field docs.
+    #[inline]
+    pub(crate) fn is_alive(&self) -> bool {
+        !self.is_retired()
+    }
+
+    /// Transitions the entry to the retired state. Must be called inside the
+    /// post-CAS `with_previous_entry` callback of `cht::remove_entry_if_and`
+    /// (or an equivalent linearisation point) so the transition is atomic
+    /// with the CHT unlink.
+    ///
+    /// The callsite is exclusive: the `with_previous_entry` closure fires at
+    /// most once per `EntryInfo` (it only runs for the thread that won the
+    /// bucket-pointer CAS), so no other thread can be transitioning the same
+    /// field in parallel. A plain `Release` store is therefore sufficient
+    /// (no RMW needed) and matches the `is_admitted` pattern. Double-retire
+    /// would indicate a broken invariant (caught by a debug-mode assertion).
+    #[inline]
+    pub(crate) fn retire(&self) {
+        debug_assert!(
+            !self.is_retired.load(Ordering::Acquire),
+            "retire() called on already-retired entry; lifecycle invariant broken",
+        );
+        self.is_retired.store(true, Ordering::Release);
     }
 
     /// Returns `true` if the `ValueEntry` having this `EntryInfo` is dirty.
@@ -229,5 +330,42 @@ impl<K> AccessTime for EntryInfo<K> {
     #[inline]
     fn set_last_modified(&self, timestamp: Instant) {
         self.last_modified.set_instant(timestamp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EntryInfo, KeyHash};
+    use crate::common::time::Instant;
+    use std::sync::Arc;
+
+    fn make_entry_info() -> EntryInfo<u64> {
+        let kh = KeyHash::new(Arc::new(42u64), 0xdead_beef);
+        EntryInfo::new(kh, Instant::from_nanos(0), 1)
+    }
+
+    #[test]
+    fn lifecycle_initial_is_alive() {
+        let info = make_entry_info();
+        assert!(info.is_alive());
+        assert!(!info.is_retired());
+    }
+
+    #[test]
+    fn lifecycle_retire_transitions_to_retired() {
+        let info = make_entry_info();
+        info.retire();
+        assert!(!info.is_alive());
+        assert!(info.is_retired());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "retire() called on already-retired entry")]
+    fn lifecycle_double_retire_debug() {
+        let info = make_entry_info();
+        info.retire();
+        // Second retire violates the exclusive-call invariant; debug-asserted.
+        info.retire();
     }
 }

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -1251,9 +1251,17 @@ where
     where
         Q: Equivalent<K> + Hash + ?Sized,
     {
-        self.cache
-            .remove_entry(hash, |k| key.equivalent(k as &K))
-            .map(|(key, entry)| KvEntry::new(key, entry))
+        // Linearise the CHT unlink with the retire transition via the
+        // post-CAS `with_previous_entry` callback. See `EntryInfo::is_retired`.
+        self.cache.remove_entry_if_and(
+            hash,
+            |k| key.equivalent(k as &K),
+            |_, _| true,
+            |k, v| {
+                v.entry_info().retire();
+                KvEntry::new(Arc::clone(k), MiniArc::clone(v))
+            },
+        )
     }
 
     fn keys(&self, cht_segment: usize) -> Option<Vec<Arc<K>>> {
@@ -1540,6 +1548,13 @@ where
                 }) => {
                     let kh = value_entry.entry_info().key_hash();
                     freq.increment(kh.hash);
+                    if !value_entry.entry_info().is_alive() {
+                        // Stale ReadOp: the backing CHT entry has been
+                        // retired since the Get was recorded. Policy-tier
+                        // mutations (timer-wheel reschedule, deque move-to-
+                        // back) must not run against a non-Alive entry.
+                        continue;
+                    }
                     if is_expiry_modified {
                         self.update_timer_wheel(&value_entry, timer_wheel);
                     }
@@ -1603,6 +1618,24 @@ where
         }
     }
 
+    /// Removes an entry from the CHT if `condition` is satisfied, flipping
+    /// its `is_retired` flag atomically with the unlink.
+    ///
+    /// See the sync variant of this helper and `EntryInfo::is_retired` for
+    /// the full rationale.
+    fn cht_remove_if_and_retire(
+        &self,
+        hash: u64,
+        eq: impl FnMut(&Arc<K>) -> bool,
+        condition: impl FnMut(&Arc<K>, &MiniArc<ValueEntry<K, V>>) -> bool,
+    ) -> Option<MiniArc<ValueEntry<K, V>>> {
+        self.cache
+            .remove_entry_if_and(hash, eq, condition, |_k, v| {
+                v.entry_info().retire();
+                MiniArc::clone(v)
+            })
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn handle_upsert(
         &self,
@@ -1618,6 +1651,17 @@ where
     ) where
         V: Clone,
     {
+        // If the entry has been retired (its CHT slot was unlinked while this
+        // `WriteOp` sat in the channel), admitting it would create an orphan
+        // deque node that the eviction loop cannot reach, stalling eviction
+        // indefinitely. Update `policy_gen` so `is_dirty()` stops firing and
+        // bail. See `EntryInfo::is_retired` and
+        // <https://github.com/moka-rs/moka/issues/590>.
+        if !entry.entry_info().is_alive() {
+            entry.entry_info().set_policy_gen(gen);
+            return;
+        }
+
         {
             let counters = &mut eviction_state.counters;
 
@@ -1653,7 +1697,7 @@ where
                     None
                 };
 
-                let removed = self.cache.remove_if(
+                let removed = self.cht_remove_if_and_retire(
                     kh.hash,
                     |k| k == &kh.key,
                     |_, current_entry| {
@@ -1709,7 +1753,10 @@ where
                         vic_hash,
                         |k| k == &vic_key,
                         |_, entry| entry.entry_info().last_accessed() == vic_la,
-                        |k, v| (k.clone(), v.clone()),
+                        |k, v| {
+                            v.entry_info().retire();
+                            (k.clone(), v.clone())
+                        },
                     ) {
                         if eviction_state.is_notifier_enabled() {
                             eviction_state
@@ -1758,7 +1805,7 @@ where
                 // Remove the candidate from the cache (hash map) if the entry
                 // generation matches.
                 let key = Arc::clone(&kh.key);
-                let removed = self.cache.remove_if(
+                let removed = self.cht_remove_if_and_retire(
                     kh.hash,
                     |k| k == &key,
                     |_, current_entry| {
@@ -1827,8 +1874,11 @@ where
             next_victim = DeqNode::next_node_ptr(victim);
 
             let vic_elem = &unsafe { victim.as_ref() }.element;
-            if vic_elem.is_dirty() {
-                // Skip this node as its ValueEntry have been updated or invalidated.
+            if vic_elem.is_dirty() || !vic_elem.entry_info().is_alive() {
+                // Skip this node: its `ValueEntry` was updated / invalidated
+                // (dirty) or retired (non-Alive). Retired entries are being
+                // torn down; admitting them would re-link a node that is
+                // about to be unlinked.
                 unsafe { deq.move_to_back(victim) };
                 retries += 1;
                 continue;
@@ -1872,6 +1922,20 @@ where
         timer_wheel: &mut TimerWheel<K>,
         counters: &mut EvictionCounters,
     ) {
+        // Precondition: admission only applies to Alive, not-yet-admitted
+        // entries. Violations indicate a caller failed to guard with
+        // `is_alive()` / `!is_admitted()`. Admitting a retired entry would
+        // produce an orphan deque node unreachable from the CHT, stalling
+        // eviction indefinitely (moka-rs/moka#590).
+        debug_assert!(
+            entry.entry_info().is_alive(),
+            "handle_admit called on non-Alive entry",
+        );
+        debug_assert!(
+            !entry.is_admitted(),
+            "handle_admit called on already-admitted entry",
+        );
+
         counters.saturating_add(1, policy_weight);
 
         self.update_timer_wheel(entry, timer_wheel);
@@ -1975,6 +2039,14 @@ where
         gen: Option<u16>,
         counters: &mut EvictionCounters,
     ) {
+        // Precondition: the caller has already retired the entry (removed it
+        // from the CHT via `cht_remove_if_and_retire` or produced a
+        // `WriteOp::Remove` from `Inner::remove_entry`, which retires).
+        debug_assert!(
+            entry.entry_info().is_retired(),
+            "handle_remove_without_timer_wheel called on an Alive entry",
+        );
+
         if entry.is_admitted() {
             entry.set_admitted(false);
             counters.saturating_sub(1, entry.policy_weight());
@@ -1997,6 +2069,12 @@ where
         entry: MiniArc<ValueEntry<K, V>>,
         counters: &mut EvictionCounters,
     ) {
+        // Precondition: the caller has already retired the entry.
+        debug_assert!(
+            entry.entry_info().is_retired(),
+            "handle_remove_with_deques called on an Alive entry",
+        );
+
         // Take the timer node along with its stored expiry generation for validation.
         let (timer_node, expiry_gen) = entry.take_timer_node();
         if let Some(timer) = timer_node {
@@ -2070,7 +2148,7 @@ where
             };
 
             // Remove the key from the map only when the entry is really expired.
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| is_expired_by_per_entry_ttl(v.entry_info(), now),
@@ -2198,7 +2276,7 @@ where
             // expired. This check is needed because it is possible that the entry in
             // the map has been updated or deleted but its deque node we checked
             // above has not been updated yet.
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| is_expired_entry_ao(tti, va, v, now),
@@ -2339,7 +2417,7 @@ where
                 None
             };
 
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| is_expired_entry_wo(ttl, va, v, now),
@@ -2489,7 +2567,7 @@ where
                 None
             };
 
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| {

--- a/src/future/invalidator.rs
+++ b/src/future/invalidator.rs
@@ -308,7 +308,9 @@ where
             None
         };
 
-        let maybe_entry = cache.cache.remove_if(
+        // Retire the entry inside the post-CAS callback so the
+        // `Alive → Retired` transition linearises with the CHT unlink.
+        let maybe_entry = cache.cache.remove_entry_if_and(
             hash,
             |k| k == key,
             |_, v| {
@@ -317,6 +319,10 @@ where
                 } else {
                     false
                 }
+            },
+            |_k, v| {
+                v.entry_info().retire();
+                MiniArc::clone(v)
             },
         );
         if let Some(entry) = &maybe_entry {

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -1107,9 +1107,18 @@ where
     where
         Q: Equivalent<K> + Hash + ?Sized,
     {
-        self.cache
-            .remove_entry(hash, |k| key.equivalent(k as &K))
-            .map(|(key, entry)| KvEntry::new(key, entry))
+        // Linearise the CHT unlink with the retire transition via the
+        // post-CAS `with_previous_entry` callback. See `EntryInfo::is_retired`
+        // for why the transition must happen here and not in the caller.
+        self.cache.remove_entry_if_and(
+            hash,
+            |k| key.equivalent(k as &K),
+            |_, _| true,
+            |k, v| {
+                v.entry_info().retire();
+                KvEntry::new(Arc::clone(k), MiniArc::clone(v))
+            },
+        )
     }
 
     fn keys(&self, cht_segment: usize) -> Option<Vec<Arc<K>>> {
@@ -1392,6 +1401,13 @@ where
                 }) => {
                     let kh = value_entry.entry_info().key_hash();
                     freq.increment(kh.hash);
+                    if !value_entry.entry_info().is_alive() {
+                        // Stale ReadOp: the backing CHT entry has been
+                        // retired since the Get was recorded. Policy-tier
+                        // mutations (timer-wheel reschedule, deque move-to-
+                        // back) must not run against a non-Alive entry.
+                        continue;
+                    }
                     if is_expiry_modified {
                         self.update_timer_wheel(&value_entry, timer_wheel);
                     }
@@ -1452,6 +1468,29 @@ where
         }
     }
 
+    /// Removes an entry from the CHT if `condition` is satisfied, flipping its
+    /// `is_retired` flag atomically with the unlink.
+    ///
+    /// This is moka's analogue of Caffeine's `synchronized(node); retire()`
+    /// pattern inside the CHM mutation callback: the `retire()` store runs in
+    /// the post-success `with_previous_entry` closure of
+    /// `cht::remove_entry_if_and`, which fires exactly once after the CHT's
+    /// bucket-pointer CAS has succeeded. Consumers draining a stale `WriteOp`
+    /// for the same entry therefore observe `is_retired == true` via
+    /// `is_alive()` returning `false`, and decline to touch policy state.
+    fn cht_remove_if_and_retire(
+        &self,
+        hash: u64,
+        eq: impl FnMut(&Arc<K>) -> bool,
+        condition: impl FnMut(&Arc<K>, &MiniArc<ValueEntry<K, V>>) -> bool,
+    ) -> Option<MiniArc<ValueEntry<K, V>>> {
+        self.cache
+            .remove_entry_if_and(hash, eq, condition, |_k, v| {
+                v.entry_info().retire();
+                MiniArc::clone(v)
+            })
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn handle_upsert(
         &self,
@@ -1467,6 +1506,17 @@ where
     ) where
         V: Clone,
     {
+        // If the entry has been retired (its CHT slot was unlinked while this
+        // `WriteOp` sat in the channel), admitting it would create an orphan
+        // deque node that the eviction loop cannot reach, stalling eviction
+        // indefinitely. Update `policy_gen` so `is_dirty()` stops firing and
+        // bail. See `EntryInfo::is_retired` and
+        // <https://github.com/moka-rs/moka/issues/590>.
+        if !entry.entry_info().is_alive() {
+            entry.entry_info().set_policy_gen(gen);
+            return;
+        }
+
         {
             let counters = &mut eviction_state.counters;
 
@@ -1498,7 +1548,7 @@ where
                 let kl = self.maybe_key_lock(&kh.key);
                 let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-                let removed = self.cache.remove_if(
+                let removed = self.cht_remove_if_and_retire(
                     kh.hash,
                     |k| k == &kh.key,
                     |_, current_entry| {
@@ -1548,7 +1598,10 @@ where
                         vic_hash,
                         |k| k == &vic_key,
                         |_, entry| entry.entry_info().last_accessed() == vic_la,
-                        |k, v| (k.clone(), v.clone()),
+                        |k, v| {
+                            v.entry_info().retire();
+                            (k.clone(), v.clone())
+                        },
                     ) {
                         if eviction_state.is_notifier_enabled() {
                             eviction_state.notify_entry_removal(
@@ -1595,7 +1648,7 @@ where
                 // Remove the candidate from the cache (hash map) if the entry
                 // generation matches.
                 let key = Arc::clone(&kh.key);
-                let removed = self.cache.remove_if(
+                let removed = self.cht_remove_if_and_retire(
                     kh.hash,
                     |k| k == &key,
                     |_, current_entry| {
@@ -1662,8 +1715,11 @@ where
             next_victim = DeqNode::next_node_ptr(victim);
 
             let vic_elem = &unsafe { victim.as_ref() }.element;
-            if vic_elem.is_dirty() {
-                // Skip this node as its ValueEntry have been updated or invalidated.
+            if vic_elem.is_dirty() || !vic_elem.entry_info().is_alive() {
+                // Skip this node: its `ValueEntry` was updated / invalidated
+                // (dirty) or retired (non-Alive). Retired entries are being
+                // torn down; admitting them would re-link a node that is
+                // about to be unlinked.
                 unsafe { deq.move_to_back(victim) };
                 retries += 1;
                 continue;
@@ -1707,6 +1763,20 @@ where
         timer_wheel: &mut TimerWheel<K>,
         counters: &mut EvictionCounters,
     ) {
+        // Precondition: admission only applies to Alive, not-yet-admitted
+        // entries. Violations indicate a caller failed to guard with
+        // `is_alive()` / `!is_admitted()`. Admitting a retired entry would
+        // produce an orphan deque node unreachable from the CHT, stalling
+        // eviction indefinitely (moka-rs/moka#590).
+        debug_assert!(
+            entry.entry_info().is_alive(),
+            "handle_admit called on non-Alive entry",
+        );
+        debug_assert!(
+            !entry.is_admitted(),
+            "handle_admit called on already-admitted entry",
+        );
+
         counters.saturating_add(1, policy_weight);
 
         self.update_timer_wheel(entry, timer_wheel);
@@ -1811,6 +1881,14 @@ where
         gen: Option<u16>,
         counters: &mut EvictionCounters,
     ) {
+        // Precondition: the caller has already retired the entry (removed it
+        // from the CHT via `cht_remove_if_and_retire` or produced a
+        // `WriteOp::Remove` from `Inner::remove_entry`, which retires).
+        debug_assert!(
+            entry.entry_info().is_retired(),
+            "handle_remove_without_timer_wheel called on an Alive entry",
+        );
+
         if entry.is_admitted() {
             entry.set_admitted(false);
             counters.saturating_sub(1, entry.policy_weight());
@@ -1833,6 +1911,12 @@ where
         entry: MiniArc<ValueEntry<K, V>>,
         counters: &mut EvictionCounters,
     ) {
+        // Precondition: the caller has already retired the entry.
+        debug_assert!(
+            entry.entry_info().is_retired(),
+            "handle_remove_with_deques called on an Alive entry",
+        );
+
         // Take the timer node along with its stored expiry generation for validation.
         let (timer_node, expiry_gen) = entry.take_timer_node();
         if let Some(timer) = timer_node {
@@ -1897,7 +1981,7 @@ where
                 let _klg = &kl.as_ref().map(|kl| kl.lock());
 
                 // Remove the key from the map only when the entry is really expired.
-                let maybe_entry = self.cache.remove_if(
+                let maybe_entry = self.cht_remove_if_and_retire(
                     hash,
                     |k| k == key,
                     |_, v| is_expired_by_per_entry_ttl(v.entry_info(), now),
@@ -2017,7 +2101,7 @@ where
             // expired. This check is needed because it is possible that the entry in
             // the map has been updated or deleted but its deque node we checked
             // above has not been updated yet.
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| is_expired_entry_ao(tti, va, v, now),
@@ -2144,7 +2228,7 @@ where
             let kl = self.maybe_key_lock(&key);
             let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| is_expired_entry_wo(ttl, va, v, now),
@@ -2287,7 +2371,7 @@ where
             let kl = self.maybe_key_lock(&key);
             let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-            let maybe_entry = self.cache.remove_if(
+            let maybe_entry = self.cht_remove_if_and_retire(
                 hash,
                 |k| k == &key,
                 |_, v| {

--- a/src/sync/invalidator.rs
+++ b/src/sync/invalidator.rs
@@ -304,7 +304,9 @@ where
         let kl = cache.maybe_key_lock(key);
         let _klg = &kl.as_ref().map(|kl| kl.lock());
 
-        let maybe_entry = cache.cache.remove_if(
+        // Retire the entry inside the post-CAS callback so the
+        // `Alive → Retired` transition linearises with the CHT unlink.
+        let maybe_entry = cache.cache.remove_entry_if_and(
             hash,
             |k| k == key,
             |_, v| {
@@ -313,6 +315,10 @@ where
                 } else {
                     false
                 }
+            },
+            |_k, v| {
+                v.entry_info().retire();
+                MiniArc::clone(v)
             },
         );
         if let Some(entry) = &maybe_entry {

--- a/tests/eviction_stall_future.rs
+++ b/tests/eviction_stall_future.rs
@@ -1,0 +1,120 @@
+#![cfg(all(test, feature = "future"))]
+
+use moka::{future::Cache, policy::EvictionPolicy};
+use std::sync::Arc;
+
+/// Regression test for the unbounded-`weighted_size` bug in moka's LRU
+/// admission path, future variant
+/// (<https://github.com/moka-rs/moka/issues/590>). See
+/// `tests/eviction_stall_sync.rs` for the sync variant.
+///
+/// ## What the pre-fix bug looked like
+///
+/// Under LRU admission with concurrent writers that mix repeatedly-reinserted
+/// keys with unique keys, a stale `WriteOp::Upsert` could be drained for an
+/// entry whose backing CHT slot had already been evicted. The stale op pushed
+/// a deque node that was not reachable from the CHT — an orphan at the LRU
+/// front. `evict_lru_entries` would then make no further progress and the
+/// cache's `weighted_size` would grow without bound.
+///
+/// With the `is_retired` lifecycle fix on `EntryInfo`, every drained
+/// `WriteOp` whose entry has been retired is short-circuited before
+/// `handle_admit` runs, so the post-drain `weighted_size` always converges
+/// to `<= max_capacity`.
+///
+/// ## Why this shape of workload
+///
+/// - **Repeated-key writers** drive the re-insertion pattern. When a reused
+///   key is evicted while a stale `WriteOp` for its prior generation is still
+///   sitting in the channel, the stale op will try to re-admit on drain —
+///   that's the window the bug exploited.
+/// - **Unique-key writers** keep the cache above capacity so eviction runs
+///   frequently and the race window is repeatedly entered.
+/// - **10 MiB capacity, 64 KiB values** keeps the working set at ~160 entries:
+///   small enough that the LRU eviction fires often, large enough to exercise
+///   multi-segment bookkeeping.
+///
+/// ## Determinism
+///
+/// The test uses a fixed insertion count per writer (not a wall-clock
+/// duration), so its input is deterministic. The writer thread interleaving
+/// is still non-deterministic, which is what the test depends on to exercise
+/// the race. The pass/fail property — convergence after the post-hoc drain —
+/// is invariant of the interleaving. Related flakiness notes:
+/// <https://github.com/moka-rs/moka/issues/591>.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn eviction_converges_under_concurrent_key_reuse() {
+    const MAX_CAPACITY: u64 = 10 * 1024 * 1024;
+    const VALUE_SIZE: usize = 64 * 1024;
+    const WRITERS_PER_GROUP: usize = 10;
+    const INSERTS_PER_WRITER: u64 = 1_000;
+    const REUSED_KEY_POOL: u64 = 500;
+    const DRAIN_ROUNDS: usize = 64;
+
+    let cache: Cache<u64, Vec<u8>> = Cache::builder()
+        .max_capacity(MAX_CAPACITY)
+        .weigher(|_k, v: &Vec<u8>| v.len() as u32)
+        .eviction_policy(EvictionPolicy::lru())
+        .build();
+
+    let barrier = Arc::new(tokio::sync::Barrier::new(WRITERS_PER_GROUP * 2));
+    let mut handles = Vec::with_capacity(WRITERS_PER_GROUP * 2);
+
+    // Group A: cycle through a small pool of reused keys. Each cycle an
+    // entry is (re-)inserted, potentially while a prior-generation
+    // `WriteOp` is still in the channel — this is the race.
+    for _ in 0..WRITERS_PER_GROUP {
+        let cache = cache.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for i in 0..INSERTS_PER_WRITER {
+                let key = i % REUSED_KEY_POOL;
+                cache.insert(key, vec![0u8; VALUE_SIZE]).await;
+            }
+        }));
+    }
+
+    // Group B: fresh, never-repeated keys. These supply eviction pressure so
+    // the reused keys are forced out of the cache between reinsertions.
+    for writer_id in 0..WRITERS_PER_GROUP {
+        let cache = cache.clone();
+        let barrier = Arc::clone(&barrier);
+        let base = (writer_id as u64 + 1) * 1_000_000_000;
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for i in 0..INSERTS_PER_WRITER {
+                cache.insert(base + i, vec![0u8; VALUE_SIZE]).await;
+            }
+        }));
+    }
+
+    for h in handles {
+        h.await.expect("writer task panicked");
+    }
+
+    // Drain: let housekeeping catch up. Pre-fix this loop made no progress
+    // once a zombie reached the LRU front; post-fix convergence is immediate.
+    for _ in 0..DRAIN_ROUNDS {
+        cache.run_pending_tasks().await;
+    }
+
+    let ws = cache.weighted_size();
+    let ec = cache.entry_count();
+    let max_entries = MAX_CAPACITY / VALUE_SIZE as u64;
+
+    assert!(
+        ws <= MAX_CAPACITY,
+        "eviction stalled: weighted_size {:.1} MiB > max_capacity {:.1} MiB \
+         after {} rounds of run_pending_tasks()",
+        ws as f64 / (1024.0 * 1024.0),
+        MAX_CAPACITY as f64 / (1024.0 * 1024.0),
+        DRAIN_ROUNDS,
+    );
+    assert!(
+        ec <= max_entries,
+        "eviction stalled: entry_count {ec} > {max_entries} (the number of \
+         {VALUE_SIZE}-byte entries that fit in {MAX_CAPACITY} bytes) after \
+         {DRAIN_ROUNDS} rounds of run_pending_tasks()",
+    );
+}

--- a/tests/eviction_stall_sync.rs
+++ b/tests/eviction_stall_sync.rs
@@ -1,0 +1,121 @@
+#![cfg(all(test, feature = "sync"))]
+
+use moka::{policy::EvictionPolicy, sync::Cache};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+/// Regression test for the unbounded-`weighted_size` bug in moka's LRU
+/// admission path, sync variant
+/// (<https://github.com/moka-rs/moka/issues/590>). See
+/// `tests/eviction_stall_future.rs` for the future variant.
+///
+/// ## What the pre-fix bug looked like
+///
+/// Under LRU admission with concurrent writers that mix repeatedly-reinserted
+/// keys with unique keys, a stale `WriteOp::Upsert` could be drained for an
+/// entry whose backing CHT slot had already been evicted. The stale op pushed
+/// a deque node that was not reachable from the CHT — an orphan at the LRU
+/// front. `evict_lru_entries` would then make no further progress and the
+/// cache's `weighted_size` would grow without bound.
+///
+/// With the `is_retired` lifecycle fix on `EntryInfo`, every drained
+/// `WriteOp` whose entry has been retired is short-circuited before
+/// `handle_admit` runs, so the post-drain `weighted_size` always converges
+/// to `<= max_capacity`.
+///
+/// ## Why this shape of workload
+///
+/// - **Repeated-key writers** drive the re-insertion pattern. When a reused
+///   key is evicted while a stale `WriteOp` for its prior generation is still
+///   sitting in the channel, the stale op will try to re-admit on drain —
+///   that's the window the bug exploited.
+/// - **Unique-key writers** keep the cache above capacity so eviction runs
+///   frequently and the race window is repeatedly entered.
+/// - **10 MiB capacity, 64 KiB values** keeps the working set at ~160 entries:
+///   small enough that the LRU eviction fires often, large enough to exercise
+///   multi-segment bookkeeping.
+///
+/// ## Determinism
+///
+/// The test uses a fixed insertion count per writer (not a wall-clock
+/// duration), so its input is deterministic. The writer thread interleaving
+/// is still non-deterministic, which is what the test depends on to exercise
+/// the race. The pass/fail property — convergence after the post-hoc drain —
+/// is invariant of the interleaving. Related flakiness notes:
+/// <https://github.com/moka-rs/moka/issues/591>.
+#[test]
+fn eviction_converges_under_concurrent_key_reuse() {
+    const MAX_CAPACITY: u64 = 10 * 1024 * 1024;
+    const VALUE_SIZE: usize = 64 * 1024;
+    const WRITERS_PER_GROUP: usize = 10;
+    const INSERTS_PER_WRITER: u64 = 1_000;
+    const REUSED_KEY_POOL: u64 = 500;
+    const DRAIN_ROUNDS: usize = 64;
+
+    let cache: Cache<u64, Vec<u8>> = Cache::builder()
+        .max_capacity(MAX_CAPACITY)
+        .weigher(|_k, v: &Vec<u8>| v.len() as u32)
+        .eviction_policy(EvictionPolicy::lru())
+        .build();
+
+    let barrier = Arc::new(Barrier::new(WRITERS_PER_GROUP * 2));
+    let mut handles = Vec::with_capacity(WRITERS_PER_GROUP * 2);
+
+    // Group A: cycle through a small pool of reused keys. Each cycle an
+    // entry is (re-)inserted, potentially while a prior-generation
+    // `WriteOp` is still in the channel — this is the race.
+    for _ in 0..WRITERS_PER_GROUP {
+        let cache = cache.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            for i in 0..INSERTS_PER_WRITER {
+                let key = i % REUSED_KEY_POOL;
+                cache.insert(key, vec![0u8; VALUE_SIZE]);
+            }
+        }));
+    }
+
+    // Group B: fresh, never-repeated keys. These supply eviction pressure
+    // so the reused keys are forced out of the cache between reinsertions.
+    for writer_id in 0..WRITERS_PER_GROUP {
+        let cache = cache.clone();
+        let barrier = Arc::clone(&barrier);
+        let base = (writer_id as u64 + 1) * 1_000_000_000;
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            for i in 0..INSERTS_PER_WRITER {
+                cache.insert(base + i, vec![0u8; VALUE_SIZE]);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("writer thread panicked");
+    }
+
+    // Drain: let housekeeping catch up. Pre-fix this loop made no progress
+    // once a zombie reached the LRU front; post-fix convergence is immediate.
+    for _ in 0..DRAIN_ROUNDS {
+        cache.run_pending_tasks();
+    }
+
+    let ws = cache.weighted_size();
+    let ec = cache.entry_count();
+    let max_entries = MAX_CAPACITY / VALUE_SIZE as u64;
+
+    assert!(
+        ws <= MAX_CAPACITY,
+        "eviction stalled: weighted_size {:.1} MiB > max_capacity {:.1} MiB \
+         after {} rounds of run_pending_tasks()",
+        ws as f64 / (1024.0 * 1024.0),
+        MAX_CAPACITY as f64 / (1024.0 * 1024.0),
+        DRAIN_ROUNDS,
+    );
+    assert!(
+        ec <= max_entries,
+        "eviction stalled: entry_count {ec} > {max_entries} (the number of \
+         {VALUE_SIZE}-byte entries that fit in {MAX_CAPACITY} bytes) after \
+         {DRAIN_ROUNDS} rounds of run_pending_tasks()",
+    );
+}


### PR DESCRIPTION
A stale `WriteOp::Upsert` drained for an already-evicted entry pushed an orphan deque node that the LRU eviction loop could not reclaim, stalling eviction indefinitely and letting `weighted_size` grow without bound.

Add an `is_retired` flag to `EntryInfo`, set inside the post-CAS callback of `cht::remove_entry_if_and` at every removal site so the retirement linearises with the bucket unlink. Buffered-op consumers (`handle_upsert`, `apply_reads`'s Hit handler, TinyLFU inline victim scan) check `is_alive()` before mutating policy state. Includes regression tests for both sync and future variants.

Fixes #590.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moka-rs/moka/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entry lifecycle management to prevent stale operations on removed cache entries.

* **Bug Fixes**
  * Fixed concurrent eviction stalls by ensuring cache policies skip retired entries during operation processing.

* **Tests**
  * Added regression tests validating eviction convergence under concurrent key reuse patterns in both sync and async caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->