### PR TITLE
Fix stale Inserted/ReplacedWith outcome from compute APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 > AI chatbot at DeepWiki in a natural language:
 > <https://deepwiki.com/moka-rs/moka>
 
+## Version Next
+
+### Fixed
+
+- Fixed a TOCTOU race in the `and_compute_with`, `and_try_compute_with`,
+  `and_try_compute_if_nobody_else`, and `and_upsert_with` methods where
+  `CompResult::Inserted` / `CompResult::ReplacedWith` and
+  `Entry::is_old_value_replaced()` could report the wrong outcome when a
+  concurrent `insert`, `invalidate`, or eviction raced against the closure.
+  The result is now derived from the actual outcome of the underlying lock-free
+  hash-table operation rather than from the snapshot taken before the closure
+  ran. Affects `sync::Cache`, `sync::SegmentedCache`, and `future::Cache`.
+
 ## Version 0.12.15
 
 ### Fixed

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -478,7 +478,7 @@ where
         key: Arc<K>,
         hash: u64,
         value: V,
-    ) -> (WriteOp<K, V>, Instant) {
+    ) -> (WriteOp<K, V>, Instant, bool) {
         self.retry_interrupted_ops().await;
 
         let weight = self.inner.weigh(&key, &value);
@@ -537,13 +537,19 @@ where
         );
 
         match (op1, op2) {
-            (Some((_cnt, ins_op)), None) => self.do_post_insert_steps(ts, &key, ins_op),
+            (Some((_cnt, ins_op)), None) => {
+                let (op, ts) = self.do_post_insert_steps(ts, &key, ins_op);
+                (op, ts, false)
+            }
             (Some((cnt1, ins_op)), Some((cnt2, ..))) if cnt1 > cnt2 => {
-                self.do_post_insert_steps(ts, &key, ins_op)
+                let (op, ts) = self.do_post_insert_steps(ts, &key, ins_op);
+                (op, ts, false)
             }
             (_, Some((_cnt, old_entry, upd_op))) => {
-                self.do_post_update_steps(ts, key, old_entry, upd_op, &self.interrupted_op_ch_snd)
-                    .await
+                let (op, ts) = self
+                    .do_post_update_steps(ts, key, old_entry, upd_op, &self.interrupted_op_ch_snd)
+                    .await;
+                (op, ts, true)
             }
             (None, None) => unreachable!(),
         }
@@ -2854,7 +2860,7 @@ mod tests {
         }
 
         async fn insert(cache: &BaseCache<Key, Value>, key: Key, hash: u64, value: Value) {
-            let (op, _now) = cache.do_insert_with_hash(Arc::new(key), hash, value).await;
+            let (op, _now, _replaced) = cache.do_insert_with_hash(Arc::new(key), hash, value).await;
             cache.write_op_ch.send(op).expect("Failed to send");
         }
 

--- a/src/future/cache.rs
+++ b/src/future/cache.rs
@@ -1807,12 +1807,12 @@ where
         }
     }
 
-    pub(crate) async fn insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) {
+    pub(crate) async fn insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) -> bool {
         if self.base.is_map_disabled() {
-            return;
+            return false;
         }
 
-        let (op, ts) = self.base.do_insert_with_hash(key, hash, value).await;
+        let (op, ts, replaced) = self.base.do_insert_with_hash(key, hash, value).await;
         let mut cancel_guard = CancelGuard::new(&self.base.interrupted_op_ch_snd, ts);
         cancel_guard.set_op(op.clone());
 
@@ -1841,6 +1841,7 @@ where
         .await
         .expect("Failed to schedule write op for insert");
         cancel_guard.clear();
+        replaced
     }
 
     pub(crate) async fn compute_with_hash_and_fun<F, Fut>(

--- a/src/future/value_initializer.rs
+++ b/src/future/value_initializer.rs
@@ -328,7 +328,6 @@ where
         } else {
             None
         };
-        let entry_existed = maybe_entry.is_some();
 
         // Evaluate the `f` closure and get a future. Catching panic is safe here as
         // we will not evaluate the closure again.
@@ -372,11 +371,11 @@ where
                 }
             }
             Ok(Op::Put(value)) => {
-                cache
+                let replaced = cache
                     .insert_with_hash(Arc::clone(&c_key), c_hash, value.clone())
                     .await;
                 waiter_guard.set_waiter_value(WaiterValue::ReadyNone);
-                if entry_existed {
+                if replaced {
                     crossbeam_epoch::pin().flush();
                     let entry = Entry::new(Some(c_key), value, true, true);
                     Ok(CompResult::ReplacedWith(entry))
@@ -474,7 +473,6 @@ where
         } else {
             None
         };
-        let entry_existed = maybe_entry.is_some();
 
         // Evaluate the `f` closure and get a future. Catching panic is safe here as
         // we will not evaluate the closure again.
@@ -517,11 +515,11 @@ where
                 }
             }
             Ok(Op::Put(value)) => {
-                cache
+                let replaced = cache
                     .insert_with_hash(Arc::clone(&c_key), c_hash, value.clone())
                     .await;
                 waiter_guard.set_waiter_value(WaiterValue::ReadyNone);
-                if entry_existed {
+                if replaced {
                     crossbeam_epoch::pin().flush();
                     let entry = Entry::new(Some(c_key), value, true, true);
                     Ok(CompResult::ReplacedWith(entry))

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -484,7 +484,7 @@ where
         key: Arc<K>,
         hash: u64,
         value: V,
-    ) -> (WriteOp<K, V>, Instant) {
+    ) -> (WriteOp<K, V>, Instant, bool) {
         let weight = self.inner.weigh(&key, &value);
         let op_cnt1 = Rc::new(AtomicU8::new(0));
         let op_cnt2 = Rc::clone(&op_cnt1);
@@ -537,12 +537,17 @@ where
         );
 
         match (op1, op2) {
-            (Some((_cnt, ins_op)), None) => self.do_post_insert_steps(ts, &key, ins_op),
+            (Some((_cnt, ins_op)), None) => {
+                let (op, ts) = self.do_post_insert_steps(ts, &key, ins_op);
+                (op, ts, false)
+            }
             (Some((cnt1, ins_op)), Some((cnt2, ..))) if cnt1 > cnt2 => {
-                self.do_post_insert_steps(ts, &key, ins_op)
+                let (op, ts) = self.do_post_insert_steps(ts, &key, ins_op);
+                (op, ts, false)
             }
             (_, Some((_cnt, old_info, upd_op))) => {
-                self.do_post_update_steps(ts, key, old_info, upd_op)
+                let (op, ts) = self.do_post_update_steps(ts, key, old_info, upd_op);
+                (op, ts, true)
             }
             (None, None) => unreachable!(),
         }
@@ -2625,7 +2630,7 @@ mod tests {
         }
 
         fn insert(cache: &BaseCache<Key, Value>, key: Key, hash: u64, value: Value) {
-            let (op, _now) = cache.do_insert_with_hash(Arc::new(key), hash, value);
+            let (op, _now, _replaced) = cache.do_insert_with_hash(Arc::new(key), hash, value);
             cache.write_op_ch.send(op).expect("Failed to send");
         }
 

--- a/src/sync/cache.rs
+++ b/src/sync/cache.rs
@@ -1030,7 +1030,9 @@ where
             self.base
                 .get_with_hash_without_recording(&*key, hash, replace_if.as_mut())
         };
-        let insert = |v| self.insert_with_hash(key.clone(), hash, v);
+        let insert = |v| {
+            self.insert_with_hash(key.clone(), hash, v);
+        };
 
         let k = if need_key {
             Some(Arc::clone(&key))
@@ -1251,7 +1253,9 @@ where
             self.base
                 .get_with_hash_without_recording(&*key, hash, ignore_if)
         };
-        let insert = |v| self.insert_with_hash(key.clone(), hash, v);
+        let insert = |v| {
+            self.insert_with_hash(key.clone(), hash, v);
+        };
 
         let k = if need_key {
             Some(Arc::clone(&key))
@@ -1443,7 +1447,9 @@ where
             self.base
                 .get_with_hash_without_recording(&*key, hash, ignore_if)
         };
-        let insert = |v| self.insert_with_hash(key.clone(), hash, v);
+        let insert = |v| {
+            self.insert_with_hash(key.clone(), hash, v);
+        };
 
         let k = if need_key {
             Some(Arc::clone(&key))
@@ -1479,12 +1485,12 @@ where
         self.insert_with_hash(key, hash, value);
     }
 
-    pub(crate) fn insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) {
+    pub(crate) fn insert_with_hash(&self, key: Arc<K>, hash: u64, value: V) -> bool {
         if self.base.is_map_disabled() {
-            return;
+            return false;
         }
 
-        let (op, now) = self.base.do_insert_with_hash(key, hash, value);
+        let (op, now, replaced) = self.base.do_insert_with_hash(key, hash, value);
         let hk = self.base.housekeeper.as_ref();
         Self::schedule_write_op(
             self.base.inner.as_ref(),
@@ -1494,6 +1500,7 @@ where
             hk,
         )
         .expect("Failed to insert");
+        replaced
     }
 
     pub(crate) fn compute_with_hash_and_fun<F>(

--- a/src/sync/value_initializer.rs
+++ b/src/sync/value_initializer.rs
@@ -234,7 +234,6 @@ where
         } else {
             None
         };
-        let entry_existed = maybe_entry.is_some();
 
         // Evaluate the `f` closure. Catching panic is safe here as we will not
         // evaluate the closure again.
@@ -275,8 +274,8 @@ where
                 }
             }
             Op::Put(value) => {
-                cache.insert_with_hash(Arc::clone(&c_key), c_hash, value.clone());
-                if entry_existed {
+                let replaced = cache.insert_with_hash(Arc::clone(&c_key), c_hash, value.clone());
+                if replaced {
                     crossbeam_epoch::pin().flush();
                     let entry = Entry::new(Some(c_key), value, true, true);
                     Ok(CompResult::ReplacedWith(entry))

--- a/tests/and_compute_with_outcome_future.rs
+++ b/tests/and_compute_with_outcome_future.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "future")]
+
+//! Regression tests for a TOCTOU race in `and_compute_with` (future).
+//!
+//! Before the fix, `try_compute` decided between [`compute::CompResult::Inserted`]
+//! and [`compute::CompResult::ReplacedWith`] using the entry snapshot taken
+//! _before_ the user closure ran. A concurrent `insert` or `invalidate` from
+//! another task could land between that snapshot and the actual CAS into the
+//! lock-free hash table, leaving the returned `CompResult` (and
+//! `Entry::is_old_value_replaced`) stale.
+
+use std::sync::Arc;
+
+use moka::future::Cache;
+use moka::ops::compute;
+use tokio::sync::Barrier;
+
+/// Closure observes `Some`, helper task invalidates concurrently, CAS sees no
+/// entry — outcome must be `Inserted`, not `ReplacedWith`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observed_some_racing_invalidate_yields_inserted() {
+    let cache: Cache<String, u64> = Cache::builder().max_capacity(100).build();
+    let key = "k".to_string();
+
+    cache.insert(key.clone(), 0).await;
+
+    let before = Arc::new(Barrier::new(2));
+    let after = Arc::new(Barrier::new(2));
+
+    let cache_b = cache.clone();
+    let key_b = key.clone();
+    let before_b = Arc::clone(&before);
+    let after_b = Arc::clone(&after);
+
+    let helper = tokio::spawn(async move {
+        before_b.wait().await;
+        cache_b.invalidate(&key_b).await;
+        after_b.wait().await;
+    });
+
+    let before_a = Arc::clone(&before);
+    let after_a = Arc::clone(&after);
+
+    let result = cache
+        .entry_by_ref(&key)
+        .and_compute_with(|entry| {
+            let before_a = Arc::clone(&before_a);
+            let after_a = Arc::clone(&after_a);
+            async move {
+                assert!(entry.is_some(), "closure should observe seeded entry");
+                before_a.wait().await;
+                after_a.wait().await;
+                compute::Op::Put(2)
+            }
+        })
+        .await;
+
+    helper.await.unwrap();
+
+    match result {
+        compute::CompResult::Inserted(entry) => {
+            assert!(
+                !entry.is_old_value_replaced(),
+                "Inserted entry must not report old-value-replaced"
+            );
+            assert_eq!(*entry.value(), 2);
+        }
+        other => panic!(
+            "expected CompResult::Inserted after racing invalidate, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}
+
+/// Closure observes `None`, helper task inserts concurrently, CAS sees an
+/// existing entry — outcome must be `ReplacedWith`, not `Inserted`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observed_none_racing_insert_yields_replaced_with() {
+    let cache: Cache<String, u64> = Cache::builder().max_capacity(100).build();
+    let key = "k".to_string();
+
+    let before = Arc::new(Barrier::new(2));
+    let after = Arc::new(Barrier::new(2));
+
+    let cache_b = cache.clone();
+    let key_b = key.clone();
+    let before_b = Arc::clone(&before);
+    let after_b = Arc::clone(&after);
+
+    let helper = tokio::spawn(async move {
+        before_b.wait().await;
+        cache_b.insert(key_b, 1).await;
+        after_b.wait().await;
+    });
+
+    let before_a = Arc::clone(&before);
+    let after_a = Arc::clone(&after);
+
+    let result = cache
+        .entry_by_ref(&key)
+        .and_compute_with(|entry| {
+            let before_a = Arc::clone(&before_a);
+            let after_a = Arc::clone(&after_a);
+            async move {
+                assert!(entry.is_none(), "closure should observe an empty cache");
+                before_a.wait().await;
+                after_a.wait().await;
+                compute::Op::Put(2)
+            }
+        })
+        .await;
+
+    helper.await.unwrap();
+
+    match result {
+        compute::CompResult::ReplacedWith(entry) => {
+            assert!(
+                entry.is_old_value_replaced(),
+                "ReplacedWith entry must report old-value-replaced"
+            );
+            assert_eq!(*entry.value(), 2);
+        }
+        other => panic!(
+            "expected CompResult::ReplacedWith after racing insert, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}

--- a/tests/and_compute_with_outcome_sync.rs
+++ b/tests/and_compute_with_outcome_sync.rs
@@ -1,0 +1,123 @@
+#![cfg(feature = "sync")]
+
+//! Regression tests for a TOCTOU race in `and_compute_with` (sync).
+//!
+//! Before the fix, `try_compute` decided between [`compute::CompResult::Inserted`]
+//! and [`compute::CompResult::ReplacedWith`] using the entry snapshot taken
+//! _before_ the user closure ran. A concurrent `insert` or `invalidate` from
+//! another thread could land between that snapshot and the actual CAS into the
+//! lock-free hash table, leaving the returned `CompResult` (and
+//! `Entry::is_old_value_replaced`) stale.
+//!
+//! These tests force that race by gating the closure on a pair of barriers:
+//! the closure wakes a helper thread, waits for it to mutate the cache directly,
+//! then resumes and lets `try_compute` perform the CAS against the post-mutation
+//! state.
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use moka::ops::compute;
+use moka::sync::Cache;
+
+/// Closure observes `Some`, helper thread invalidates concurrently, CAS sees no
+/// entry — outcome must be `Inserted`, not `ReplacedWith`.
+#[test]
+fn observed_some_racing_invalidate_yields_inserted() {
+    let cache: Cache<String, u64> = Cache::builder().max_capacity(100).build();
+    let key = "k".to_string();
+
+    // Seed so the closure observes `Some`.
+    cache.insert(key.clone(), 0);
+
+    let before = Arc::new(Barrier::new(2));
+    let after = Arc::new(Barrier::new(2));
+
+    let cache_b = cache.clone();
+    let key_b = key.clone();
+    let before_b = Arc::clone(&before);
+    let after_b = Arc::clone(&after);
+
+    let helper = thread::spawn(move || {
+        before_b.wait();
+        // Synchronously remove the entry from the lock-free hash table.
+        cache_b.invalidate(&key_b);
+        after_b.wait();
+    });
+
+    let before_a = Arc::clone(&before);
+    let after_a = Arc::clone(&after);
+
+    let result = cache.entry_by_ref(&key).and_compute_with(|entry| {
+        // The closure must observe the seeded entry.
+        assert!(entry.is_some(), "closure should observe seeded entry");
+        before_a.wait();
+        after_a.wait();
+        compute::Op::Put(2)
+    });
+
+    helper.join().unwrap();
+
+    match result {
+        compute::CompResult::Inserted(entry) => {
+            assert!(
+                !entry.is_old_value_replaced(),
+                "Inserted entry must not report old-value-replaced"
+            );
+            assert_eq!(*entry.value(), 2);
+        }
+        other => panic!(
+            "expected CompResult::Inserted after racing invalidate, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}
+
+/// Closure observes `None`, helper thread inserts concurrently, CAS sees an
+/// existing entry — outcome must be `ReplacedWith`, not `Inserted`.
+#[test]
+fn observed_none_racing_insert_yields_replaced_with() {
+    let cache: Cache<String, u64> = Cache::builder().max_capacity(100).build();
+    let key = "k".to_string();
+
+    let before = Arc::new(Barrier::new(2));
+    let after = Arc::new(Barrier::new(2));
+
+    let cache_b = cache.clone();
+    let key_b = key.clone();
+    let before_b = Arc::clone(&before);
+    let after_b = Arc::clone(&after);
+
+    let helper = thread::spawn(move || {
+        before_b.wait();
+        // Synchronously install an entry into the lock-free hash table.
+        cache_b.insert(key_b, 1);
+        after_b.wait();
+    });
+
+    let before_a = Arc::clone(&before);
+    let after_a = Arc::clone(&after);
+
+    let result = cache.entry_by_ref(&key).and_compute_with(|entry| {
+        assert!(entry.is_none(), "closure should observe an empty cache");
+        before_a.wait();
+        after_a.wait();
+        compute::Op::Put(2)
+    });
+
+    helper.join().unwrap();
+
+    match result {
+        compute::CompResult::ReplacedWith(entry) => {
+            assert!(
+                entry.is_old_value_replaced(),
+                "ReplacedWith entry must report old-value-replaced"
+            );
+            assert_eq!(*entry.value(), 2);
+        }
+        other => panic!(
+            "expected CompResult::ReplacedWith after racing insert, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}


### PR DESCRIPTION
The compute APIs (and_compute_with, and_try_compute_with, and_try_compute_if_nobody_else, and_upsert_with) decided between CompResult::Inserted and CompResult::ReplacedWith — and set Entry::is_old_value_replaced — using the entry snapshot taken before the user closure ran. A concurrent insert, invalidate, or eviction could land between that snapshot and the actual CAS into the lock-free hash table, so the reported outcome could disagree with what actually happened.

The truth is now read from the underlying insert_with_or_modify path and surfaced through insert_with_hash, replacing the pre-closure snapshot. Affects sync::Cache, sync::SegmentedCache, and future::Cache.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moka-rs/moka/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a race condition in cache operations where the reported outcome could diverge from the actual operation result under concurrent access.

* **Tests**
  * Added regression tests for concurrent cache operations to prevent recurrence of race condition issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->