### PR TITLE
Fix CI failures on the MSRV, nightly, and Kani jobs

### DIFF
--- a/.ci_extras/pin-crate-vers-kani.sh
+++ b/.ci_extras/pin-crate-vers-kani.sh
@@ -2,7 +2,33 @@
 
 set -eux
 
+# Kani's bundled Cargo is nightly-2024-08-07 (v1.82.0-nightly), which predates
+# the stabilization of the 2024 edition (Rust 1.85) and therefore cannot parse
+# the manifests of edition-2024 crates. cargo-kani runs `cargo metadata
+# --filter-platform <host>`, so any edition-2024 crate that resolves onto the
+# host platform makes it fail with "feature `edition2024` is required". Downgrade
+# / pin the offenders to their newest edition-2021 releases. Kani only verifies
+# the library, so these dev/build dependencies are never actually compiled here.
+
+# `reqwest` v0.12's dependency tree pulls in many edition-2024 crates (`zeroize`
+# v1.9, the `rand` v0.10 stack, `idna_adapter`, ...). v0.11 uses an older,
+# edition-2021 tree.
+cargo remove --dev reqwest
+cargo add --dev reqwest@0.11.11 --no-default-features --features rustls-tls
+
 # Pin some dependencies to specific versions for the nightly toolchain
 # used by Kani verifier.
 cargo update -p async-lock --precise 3.4.1
 cargo update -p uuid --precise 1.20.0
+# `trybuild` v1.0.106+ requires the edition-2024 `toml` v1.x stack (which in turn
+# forces `indexmap` >= 2.13), and v1.0.118 additionally bumped its own crate to
+# edition 2024. Pin to v1.0.105 — the newest release using the edition-2021
+# `toml` v0.8 stack. This must run before the `indexmap` pin below, otherwise
+# `toml` v1.x keeps `indexmap` locked to >= 2.13. (`trybuild` is
+# `cfg(trybuild)`-gated and never built here.)
+cargo update -p trybuild --precise 1.0.105
+# `url` v2.5.4+ switched to `idna` v1 / `idna_adapter` (edition 2024). Pin to
+# v2.5.2, which still uses the edition-2021 `idna` v0.5.
+cargo update -p url --precise 2.5.2
+# `indexmap` v2.13.0+ is edition 2024. Pin to the last edition-2021 release.
+cargo update -p indexmap --precise 2.11.4

--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -13,10 +13,16 @@ cargo update -p tokio --precise 1.47.1
 cargo update -p tokio-rustls --precise 0.24.1
 cargo update -p tokio-util --precise 0.7.16
 cargo update -p mio --precise 1.0.4
-# `toml` v1.1.1+ (pulled in by `trybuild` via `toml = "^1"`) requires
-# `indexmap` v2.13.0+, which in turn requires Rust 1.82+. Pin `toml` to v1.1.0,
-# the newest release that still accepts `indexmap` v2.11.4.
-cargo update -p toml --precise 1.1.0
+# `trybuild` v1.0.106+ requires `toml = "^0.9"`, and v1.0.118 additionally bumped
+# its own crate to edition 2024. Both pull in edition-2024 manifests (the `toml`
+# 1.x stack, `serde_spanned` 1.x, `toml_parser`, `toml_writer`, ...) that Cargo
+# 1.71.1 cannot even parse ("this version of Cargo is older than the `2024`
+# edition"). Pin `trybuild` to v1.0.105 — the newest release that still requires
+# `toml = "^0.8"`, whose entire dependency subtree remains on edition 2021.
+# `trybuild` is only built under `--cfg trybuild` (which this job does not set),
+# so pinning it to an older release has no effect on the tests we actually run.
+cargo update -p trybuild --precise 1.0.105
+# `indexmap` v2.13.0+ requires Rust 1.82+. Pin to the last 1.71.1-compatible release.
 cargo update -p indexmap --precise 2.11.4
 cargo update -p parking_lot --precise 0.12.4
 cargo update -p parking_lot_core --precise 0.9.11

--- a/.ci_extras/pin-crate-vers-msrv.sh
+++ b/.ci_extras/pin-crate-vers-msrv.sh
@@ -13,6 +13,10 @@ cargo update -p tokio --precise 1.47.1
 cargo update -p tokio-rustls --precise 0.24.1
 cargo update -p tokio-util --precise 0.7.16
 cargo update -p mio --precise 1.0.4
+# `toml` v1.1.1+ (pulled in by `trybuild` via `toml = "^1"`) requires
+# `indexmap` v2.13.0+, which in turn requires Rust 1.82+. Pin `toml` to v1.1.0,
+# the newest release that still accepts `indexmap` v2.11.4.
+cargo update -p toml --precise 1.1.0
 cargo update -p indexmap --precise 2.11.4
 cargo update -p parking_lot --precise 0.12.4
 cargo update -p parking_lot_core --precise 0.9.11

--- a/.ci_extras/pin-crate-vers-nightly.sh
+++ b/.ci_extras/pin-crate-vers-nightly.sh
@@ -10,3 +10,11 @@ cargo add --dev reqwest@0.11.11 --no-default-features --features rustls-tls
 # cargo update -p <crate> --precise <version>
 # https://github.com/tkaitchuck/aHash/issues/200
 cargo update -p ahash --precise 0.8.7
+
+# `-Z minimal-versions` selects `rustix` v0.38.0, whose build script enables the
+# `rustc_attrs` cfg and then uses the reserved `rustc_layout_scalar_valid_range_*`
+# attributes, which the current nightly rejects ("attributes starting with
+# `rustc` are reserved for use by the `rustc` compiler"). v0.38.44 only enables
+# those attributes behind the opt-in `rustix_use_experimental_features` cfg, so
+# it builds on nightly.
+cargo update -p rustix --precise 0.38.44


### PR DESCRIPTION
Fixes the scheduled-CI failures caused by dependency drift. Moka commits no `Cargo.lock`, so CI resolves to the newest dependencies on every run, and several transitive crates have moved to the 2024 edition (which requires Rust 1.85). Toolchains older than 1.85 cannot even *parse* an edition-2024 manifest, which breaks the jobs below before any compilation happens.

- **MSRV (`test (1.71.1)`)**: `trybuild` now resolves to v1.0.118, which is itself edition 2024 and also pulls the edition-2024 `toml` v1.x stack (`toml`, `serde_spanned`, `toml_datetime`, `toml_parser`, `toml_writer`). Cargo 1.71.1 cannot parse them. Pin `trybuild` to **v1.0.105** — the newest release that still requires `toml = "^0.8"`, whose entire dependency subtree stays on edition 2021. `trybuild` is only built under `--cfg trybuild`, which this job does not set, so the older pin has no effect on the tests we actually run. (This replaces the earlier `toml 1.1.0` pin, which was ineffective because `toml` v1.x is itself edition 2024.)
- **nightly (`test (nightly)`)**: `-Z minimal-versions` selects `rustix` v0.38.0, whose build script enables the `rustc_attrs` cfg and uses reserved `rustc_*` attributes that current nightly rejects. Pin `rustix` to **v0.38.44**, which gates those attributes behind an opt-in cfg.
- **Kani (`run-kani`)**: Kani 0.54.0 bundles nightly-2024-08-07 (Cargo 1.82) and runs `cargo metadata --filter-platform <host>`, which fails on the edition-2024 crates pulled onto the host by `reqwest` v0.12 (`zeroize` v1.9, the `rand` v0.10 stack, `idna_adapter`) and by the `trybuild` / `toml` v1.x stack. Downgrade `reqwest` to **v0.11.11** and pin **`trybuild` v1.0.105**, **`url` v2.5.2**, and **`indexmap` v2.11.4** (`trybuild` must be pinned before `indexmap`, since `toml` v1.x forces `indexmap` >= 2.13).

Verified locally against the actual toolchains (`1.71.1` and `nightly-2024-08-07`): the MSRV `cargo test --features sync` compiles, and Kani's `cargo metadata --filter-platform` succeeds — both with zero edition-2024 crates on the host platform.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moka-rs/moka/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI dependency pinning for MSRV by enforcing a `trybuild` version that remains compatible with older Rust toolchains.
  * Improved CI dependency pinning for nightly builds by precisely selecting a `rustix` version that avoids toolchain rejection issues.
  * Improved CI dependency handling for Kani by adjusting `reqwest` to TLS rustls-only and adding additional compatible version constraints, with clearer inline explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
