### PR TITLE
Add deterministic tests for #590

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,31 @@
 > If you have any questions about Moka's APIs or internal design, you can ask the
 > AI chatbot at DeepWiki in a natural language:
 > <https://deepwiki.com/moka-rs/moka>
+>
+> Of course, you can also refer to the [documentation][moka-docs], or ask the human
+> maintainers questions on the [Moka GitHub repository][gh-repo], but asking the
+> chatbot is often faster and more convenient.
 
 ## Version 0.12.16
 
 ### Fixed
 
 - Fixed a bug where cache eviction could stall permanently when the cache was
-  configured with the **non-default** LRU eviction policy
-  (`EvictionPolicy::lru()`): a race between applying a stale write recording
-  and removing the entry from the internal concurrent hash table could leave an
-  orphaned ("zombie") node at the front of the LRU queue. Once present, no
-  entry was ever evicted again and the cache grew unboundedly past
-  `max_capacity`. This bug was introduced in v0.12.0 and affected
-  `sync::Cache`, `sync::SegmentedCache` and `future::Cache`
+  configured with the **non-default** LRU eviction policy (`EvictionPolicy::lru()`)
+  by a race between insert and remove operations on the same key
   ([#592][gh-pull-0592] by [@kim-jhyeon][gh-kim-jhyeon], reported in
   [#590][gh-issue-0590]):
+    - This bug was introduced in v0.12.0 and affected `sync::Cache`,
+      `sync::SegmentedCache` and `future::Cache`.
+    - A race between applying a write recording for an entry and concurrently
+      removing that entry from the internal concurrent hash table could leave an
+      orphaned node at the front of the LRU queue. Once present, no entry was ever
+      evicted again and the cache grew unboundedly past `max_capacity`.
     - The same race also affected the default TinyLFU eviction policy, but with
       a milder symptom: each occurrence permanently leaked one phantom entry
       slot, causing `entry_count` and `weighted_size` to over-report and the
       usable capacity to shrink by one entry per occurrence. Fixed by the same
       change.
-
 
 ## Version 0.12.15
 
@@ -1086,6 +1090,9 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 
 
 <!-- Links -->
+
+[moka-docs]: https://docs.rs/moka/
+[gh-repo]: https://github.com/moka-rs/moka/
 
 [caffeine-git]: https://github.com/ben-manes/caffeine
 [mini-moka-crate]: https://crates.io/crates/mini-moka

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 > AI chatbot at DeepWiki in a natural language:
 > <https://deepwiki.com/moka-rs/moka>
 
+## Version 0.12.16
+
+### Fixed
+
+- Fixed a bug where cache eviction could stall permanently when the cache was
+  configured with the **non-default** LRU eviction policy
+  (`EvictionPolicy::lru()`): a race between applying a stale write recording
+  and removing the entry from the internal concurrent hash table could leave an
+  orphaned ("zombie") node at the front of the LRU queue. Once present, no
+  entry was ever evicted again and the cache grew unboundedly past
+  `max_capacity`. This bug was introduced in v0.12.0 and affected
+  `sync::Cache`, `sync::SegmentedCache` and `future::Cache`
+  ([#592][gh-pull-0592] by [@kim-jhyeon][gh-kim-jhyeon], reported in
+  [#590][gh-issue-0590]):
+    - The same race also affected the default TinyLFU eviction policy, but with
+      a milder symptom: each occurrence permanently leaked one phantom entry
+      slot, causing `entry_count` and `weighted_size` to over-report and the
+      usable capacity to shrink by one entry per occurrence. Fixed by the same
+      change.
+
+
 ## Version 0.12.15
 
 ### Fixed
@@ -1095,6 +1116,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-JoJoDeveloping]: https://github.com/JoJoDeveloping
 [gh-jiangzhe]: https://github.com/jiangzhe
 [gh-karankurbur]: https://github.com/karankurbur
+[gh-kim-jhyeon]: https://github.com/kim-jhyeon
 [gh-koushiro]: https://github.com/koushiro
 [gh-LMJW]: https://github.com/LMJW
 [gh-messense]: https://github.com/messense
@@ -1117,6 +1139,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-xuehaonan27]: https://github.com/xuehaonan27
 [gh-zonyitoo]: https://github.com/zonyitoo
 
+[gh-issue-0590]: https://github.com/moka-rs/moka/issues/590/
 [gh-issue-0580]: https://github.com/moka-rs/moka/issues/580/
 [gh-issue-0575]: https://github.com/moka-rs/moka/issues/575/
 [gh-issue-0565]: https://github.com/moka-rs/moka/issues/565/
@@ -1146,6 +1169,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0592]: https://github.com/moka-rs/moka/pull/592/
 [gh-pull-0586]: https://github.com/moka-rs/moka/pull/586/
 [gh-pull-0584]: https://github.com/moka-rs/moka/pull/584/
 [gh-pull-0582]: https://github.com/moka-rs/moka/pull/582/

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -3695,8 +3695,50 @@ mod tests {
     // Reproduction tests for issue #590
     // (zombie LRU deque node -> permanent eviction stall -> unbounded growth)
     //
-    // See moka-memo/moka-internals/02-housekeeper.md section 6a for the race
-    // narrative.  These drive `future::BaseCache` internals directly so the
+    // Two facts enable the race:
+    //
+    // 1. A write is NOT atomic with its policy recording.  A writer first
+    //    mutates the hash table (in `do_insert_with_hash`, which only
+    //    *returns* the `WriteOp`) and then, as a separate step, sends that
+    //    op to `write_op_ch` (`schedule_write_op` in the caller).  A writer
+    //    preempted between the two steps makes the channel order differ
+    //    from the hash-table order: ops later in the channel can describe
+    //    *earlier* hash-table states (a "stale" op).
+    //
+    // 2. The update path (`new_value_entry_from`) clones the existing
+    //    `MiniArc<EntryInfo>`, so an updated `ValueEntry` shares its
+    //    `EntryInfo` with the entry it replaces, while the insert path
+    //    creates a fresh `EntryInfo`.
+    //
+    // With writers racing the housekeeper on one key K:
+    //
+    //   t0 insert(K, v1) -> fresh EntryInfo_A; WriteOp A1 queued.
+    //   t1 housekeeper drains A1 -> `handle_admit` pushes LRU node N_A and
+    //        sets is_admitted(EntryInfo_A) = true.
+    //   t2 Writer-B: update(K, v2) -> the new hash-table entry shares
+    //        EntryInfo_A; Writer-B is preempted BEFORE sending WriteOp A2
+    //        (fact 1), so A2 is not in the channel yet.
+    //   t3 Writer-C: remove(K) -> `remove_entry` deletes K from the hash
+    //        table and `WriteOp::Remove` is sent; the housekeeper drains it
+    //        -> `handle_remove` sets is_admitted(EntryInfo_A) = false and
+    //        unlinks N_A.  Writer-B now resumes and sends the stale A2.
+    //   t4 housekeeper drains the stale A2 -> `handle_upsert` sees
+    //        is_admitted == false and calls `handle_admit`, pushing a
+    //        BRAND-NEW deque node backed by the defunct EntryInfo_A even
+    //        though the hash table has no K.  This node is the "zombie".
+    //   t5 insert(K, v3) -> fresh EntryInfo_B, live node N_B.
+    //
+    // The deque now holds two nodes for K: the zombie (-> EntryInfo_A) and
+    // the live N_B (-> EntryInfo_B); the hash table only knows EntryInfo_B.
+    // When the zombie reaches the LRU front, `evict_lru_entries` calls
+    // `remove_if(K, |v| v.last_accessed() == ts)` with EntryInfo_A's
+    // timestamp, which never matches EntryInfo_B's, and
+    // `skip_updated_entry_ao` moves the *hash entry's* node (N_B) to the
+    // back -- it can never unlink the zombie.  Eviction makes no progress
+    // past the zombie, so under the LRU policy the cache grows unboundedly
+    // past max_capacity and never recovers.
+    //
+    // These tests drive `future::BaseCache` internals directly so the
     // interleaving is deterministic (no threads, no sleeps).
     // =====================================================================
     mod gh590 {
@@ -3813,10 +3855,13 @@ mod tests {
 
             // t3: flip is_admitted(EntryInfo_A) -> false while A2 is still queued.
             //
-            // NOTE / DEVIATION from doc 6a: the doc uses *capacity eviction* to do
-            // this.  But the held update A2 leaves N_A dirty (entry_gen != policy_gen)
-            // and `evict_lru_entries` SKIPS dirty nodes, so capacity eviction cannot
-            // remove K here (see `future_lru_capacity_eviction_skips_dirty_node_diag`).
+            // NOTE: why an explicit remove and not *capacity eviction*?  In the
+            // wild, capacity eviction can also de-admit K (via a TOCTOU on the
+            // dirty check), but not in a deterministic single-threaded schedule:
+            // the held update A2 leaves N_A dirty (entry_gen != policy_gen) and
+            // `evict_lru_entries` SKIPS dirty nodes, so capacity eviction cannot
+            // remove K here (see the
+            // `future_lru_capacity_eviction_skips_dirty_node_diag` test below).
             // An explicit remove reaches `handle_remove`, which sets is_admitted=false
             // with NO dirty check -- reaching the exact same precondition the race
             // produces: a stale queued Upsert for a de-admitted EntryInfo.
@@ -3881,8 +3926,8 @@ mod tests {
 
         // -----------------------------------------------------------------
         // CONTROL: identical shape but A2 is drained in the CORRECT order
-        // (before the remove), so no stale replay occurs.  Must PASS today,
-        // proving the harness itself is sound.
+        // (before the remove), so no stale replay occurs.  Must PASS even
+        // with issue #590 unfixed, proving the harness itself is sound.
         // -----------------------------------------------------------------
         #[tokio::test]
         async fn future_lru_zombie_stall_control() {
@@ -3925,9 +3970,11 @@ mod tests {
         }
 
         // -----------------------------------------------------------------
-        // DIAGNOSTIC: documents the deviation from doc 6a t3.  A held update
-        // makes K's node dirty, and capacity eviction (`evict_lru_entries`)
-        // skips dirty nodes, so it does NOT evict K.  This must PASS today.
+        // DIAGNOSTIC: documents why step t3 of the narrative above uses an
+        // explicit remove rather than capacity eviction.  A held update makes
+        // K's node dirty, and capacity eviction (`evict_lru_entries`) skips
+        // dirty nodes, so it does NOT evict K.  This must PASS even with
+        // issue #590 unfixed.
         // -----------------------------------------------------------------
         #[tokio::test]
         async fn future_lru_capacity_eviction_skips_dirty_node_diag() {
@@ -3942,8 +3989,9 @@ mod tests {
             let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100).await;
             let (_adm, dirty_after_update, _eg) = probe(&a2);
 
-            // t3 (doc): push over capacity with 4 other keys, then run maintenance.
-            // The doc claims K is evicted here; observe that it is not.
+            // t3 (attempted via capacity eviction): push over capacity with 4
+            // other keys, then run maintenance.  If capacity eviction could
+            // de-admit K, it would be evicted here; observe that it is not.
             for nk in 1u32..=4 {
                 insert(&cache, nk, nk).await;
             }
@@ -3964,7 +4012,7 @@ mod tests {
             );
             assert!(
                 still_present,
-                "DEVIATION from doc 6a t3: capacity eviction skips the dirty node, so K survives"
+                "capacity eviction skips the dirty node, so K survives (t3 cannot happen this way)"
             );
             assert!(
                 adm_after,

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -1922,15 +1922,28 @@ where
         timer_wheel: &mut TimerWheel<K>,
         counters: &mut EvictionCounters,
     ) {
-        // Precondition: admission only applies to Alive, not-yet-admitted
-        // entries. Violations indicate a caller failed to guard with
-        // `is_alive()` / `!is_admitted()`. Admitting a retired entry would
-        // produce an orphan deque node unreachable from the CHT, stalling
-        // eviction indefinitely (moka-rs/moka#590).
-        debug_assert!(
-            entry.entry_info().is_alive(),
-            "handle_admit called on non-Alive entry",
-        );
+        // The caller checked `is_alive()` before calling us, but a concurrent
+        // `remove`/`invalidate` on a user thread may have retired the entry in
+        // the meantime; retirement is lock-free and does not take the
+        // maintenance locks. Skip the admission in that case: admitting a
+        // retired entry would produce an orphan deque node unreachable from
+        // the CHT (moka-rs/moka#590). The thread that retired the entry has
+        // already recorded a `WriteOp::Remove`, and since this entry is not
+        // admitted, that op will not touch the deques, leaving no dangling
+        // policy state.
+        //
+        // Note this re-check is best-effort, not a guarantee: because we hold
+        // no lock, the entry can still be retired between this check and the
+        // `set_admitted(true)` below. That residual race is benign and
+        // self-healing: the same queued `WriteOp::Remove` will observe
+        // `is_admitted() == true`, unlink the node, and reverse the entry
+        // count/weight updates. A *permanent* orphan (the #590 zombie) cannot
+        // form here, because the only retirement paths that run outside the
+        // maintenance locks are user `remove`/`invalidate`, and both always
+        // enqueue that `WriteOp::Remove`.
+        if !entry.entry_info().is_alive() {
+            return;
+        }
         debug_assert!(
             !entry.is_admitted(),
             "handle_admit called on already-admitted entry",

--- a/src/future/base_cache.rs
+++ b/src/future/base_cache.rs
@@ -3690,4 +3690,358 @@ mod tests {
 
         assert_expiry!(cache, key, hash, mock, 4);
     }
+
+    // =====================================================================
+    // Reproduction tests for issue #590
+    // (zombie LRU deque node -> permanent eviction stall -> unbounded growth)
+    //
+    // See moka-memo/moka-internals/02-housekeeper.md section 6a for the race
+    // narrative.  These drive `future::BaseCache` internals directly so the
+    // interleaving is deterministic (no threads, no sleeps).
+    // =====================================================================
+    mod gh590 {
+        use super::super::BaseCache;
+        use crate::common::concurrent::WriteOp;
+        use crate::{
+            common::{time::Clock, HousekeeperConfig},
+            policy::{EvictionPolicy, ExpirationPolicy},
+        };
+        use std::collections::hash_map::RandomState;
+        use std::sync::Arc;
+
+        const MAX: u64 = 4;
+
+        async fn new_lru_cache() -> BaseCache<u32, u32> {
+            let mut cache = BaseCache::<u32, u32>::new(
+                None,
+                Some(MAX),
+                None,
+                RandomState::default(),
+                None,
+                EvictionPolicy::lru(),
+                None,
+                ExpirationPolicy::default(),
+                HousekeeperConfig::default(),
+                false,
+                Clock::default(),
+            );
+            // Disable the housekeeper auto-run so this test controls every
+            // maintenance run explicitly.
+            cache.reconfigure_for_testing().await;
+            cache
+        }
+
+        async fn new_tinylfu_cache() -> BaseCache<u32, u32> {
+            let mut cache = BaseCache::<u32, u32>::new(
+                None,
+                Some(MAX),
+                None,
+                RandomState::default(),
+                None,
+                EvictionPolicy::tiny_lfu(),
+                None,
+                ExpirationPolicy::default(),
+                HousekeeperConfig::default(),
+                false,
+                Clock::default(),
+            );
+            cache.reconfigure_for_testing().await;
+            cache
+        }
+
+        /// Insert (or update) a key and queue its `WriteOp` on the write channel,
+        /// WITHOUT running maintenance.
+        async fn insert(cache: &BaseCache<u32, u32>, k: u32, v: u32) {
+            let hash = cache.hash(&k);
+            let (op, _now) = cache.do_insert_with_hash(Arc::new(k), hash, v).await;
+            cache.write_op_ch.send(op).expect("send upsert");
+        }
+
+        /// Run one maintenance pass (drains the write channel, then evicts).
+        async fn run(cache: &BaseCache<u32, u32>) {
+            cache.inner.do_run_pending_tasks(None, 1, 10).await;
+        }
+
+        /// Read the shared `EntryInfo` state carried by an (Upsert) `WriteOp`.
+        /// Returns (is_admitted, is_dirty, entry_gen).  (`policy_gen` has no
+        /// public getter; `is_dirty` already reflects entry_gen != policy_gen.)
+        fn probe(op: &WriteOp<u32, u32>) -> (bool, bool, u16) {
+            match op {
+                WriteOp::Upsert { value_entry, .. } => {
+                    let ei = value_entry.entry_info();
+                    (ei.is_admitted(), ei.is_dirty(), ei.entry_gen())
+                }
+                _ => panic!("expected an Upsert WriteOp"),
+            }
+        }
+
+        /// Explicitly remove `k` from the hash table and queue the resulting
+        /// `WriteOp::Remove` (mirrors `future::Cache::invalidate`'s op building).
+        fn queue_remove(cache: &BaseCache<u32, u32>, k: u32, hash: u64) {
+            let kv = cache.remove_entry(&k, hash).expect("remove_entry");
+            let entry_gen = kv.entry.entry_info().incr_entry_gen();
+            cache
+                .write_op_ch
+                .send(WriteOp::Remove {
+                    kv_entry: kv,
+                    entry_gen,
+                })
+                .expect("send remove");
+        }
+
+        // -----------------------------------------------------------------
+        // PRIMARY REPRO: at 7006d8c this test FAILS with the stall assertion.
+        // -----------------------------------------------------------------
+        #[tokio::test]
+        async fn future_lru_zombie_stall_repro() {
+            let cache = new_lru_cache().await;
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            // t0/t1: insert K and let the housekeeper admit it (EntryInfo_A, an
+            // LRU node N_A pushed, is_admitted(EntryInfo_A) = true).
+            insert(&cache, k, 1).await;
+            run(&cache).await;
+            assert!(cache.contains_key_with_hash(&k, hash_k));
+            assert_eq!(cache.entry_count(), 1);
+
+            // t2: UPDATE K.  Update path shares EntryInfo_A and bumps entry_gen, so
+            // the queued WriteOp (A2) points at EntryInfo_A.  HOLD A2 (do not send).
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100).await;
+            let (adm, dirty, eg) = probe(&a2);
+            eprintln!("[t2] held A2: is_admitted={adm} is_dirty={dirty} entry_gen={eg}");
+
+            // t3: flip is_admitted(EntryInfo_A) -> false while A2 is still queued.
+            //
+            // NOTE / DEVIATION from doc 6a: the doc uses *capacity eviction* to do
+            // this.  But the held update A2 leaves N_A dirty (entry_gen != policy_gen)
+            // and `evict_lru_entries` SKIPS dirty nodes, so capacity eviction cannot
+            // remove K here (see `future_lru_capacity_eviction_skips_dirty_node_diag`).
+            // An explicit remove reaches `handle_remove`, which sets is_admitted=false
+            // with NO dirty check -- reaching the exact same precondition the race
+            // produces: a stale queued Upsert for a de-admitted EntryInfo.
+            queue_remove(&cache, k, hash_k);
+            run(&cache).await;
+            assert!(
+                !cache.contains_key_with_hash(&k, hash_k),
+                "K must be gone from the hash table after remove"
+            );
+            let (adm, dirty, eg) = probe(&a2);
+            eprintln!(
+                "[t3] after remove drained: is_admitted={adm} is_dirty={dirty} \
+                 entry_gen={eg} entry_count={}",
+                cache.entry_count()
+            );
+            assert!(!adm, "EntryInfo_A must be de-admitted");
+
+            // t4: drain the STALE A2.  handle_upsert sees is_admitted(EntryInfo_A)
+            // == false and calls handle_admit, pushing a BRAND-NEW zombie node for
+            // the defunct EntryInfo_A even though the hash table has no K.
+            cache.write_op_ch.send(a2).expect("send stale A2");
+            run(&cache).await;
+            eprintln!(
+                "[t4] after stale A2 drained: entry_count={} contains(K)={}",
+                cache.entry_count(),
+                cache.contains_key_with_hash(&k, hash_k)
+            );
+
+            // t5: re-insert K -> fresh EntryInfo_B, live node N_B.  Now the hash
+            // table has K again, so `skip_updated_entry_ao` will move N_B (the live
+            // node) to the back and can never reach the zombie N_A2.
+            insert(&cache, k, 2).await;
+            run(&cache).await;
+
+            // Insert many new keys, one maintenance run each.  Each admit inflates
+            // the entry counter; eviction peeks the zombie stuck at the LRU front,
+            // fails remove_if, skips a *different* node, and evicts nothing.
+            for nk in 100u32..150 {
+                insert(&cache, nk, nk).await;
+                run(&cache).await;
+            }
+
+            // Extra maintenance runs with NO pending writes.  A healthy cache
+            // converges to <= MAX; the stalled cache does not shrink at all.
+            let before = cache.entry_count();
+            for _ in 0..20 {
+                run(&cache).await;
+            }
+            let after = cache.entry_count();
+            eprintln!("[final] entry_count before extra drains={before}, after={after}, MAX={MAX}");
+
+            assert_eq!(
+                before, after,
+                "no writes occurred, so the count must be stable across drains"
+            );
+            assert!(
+                after <= MAX,
+                "STALL (issue #590): entry_count={after} stays above max_capacity={MAX}; \
+                 the zombie LRU node blocks all further eviction and the cache grows unboundedly"
+            );
+        }
+
+        // -----------------------------------------------------------------
+        // CONTROL: identical shape but A2 is drained in the CORRECT order
+        // (before the remove), so no stale replay occurs.  Must PASS today,
+        // proving the harness itself is sound.
+        // -----------------------------------------------------------------
+        #[tokio::test]
+        async fn future_lru_zombie_stall_control() {
+            let cache = new_lru_cache().await;
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            insert(&cache, k, 1).await;
+            run(&cache).await;
+
+            // t2: update K, but SEND A2 immediately and drain it as a normal update
+            // (is_admitted stays true, policy_gen catches up -> node not dirty).
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100).await;
+            cache.write_op_ch.send(a2).expect("send A2");
+            run(&cache).await;
+
+            // Now remove K normally (no stale op left behind).
+            queue_remove(&cache, k, hash_k);
+            run(&cache).await;
+            assert!(!cache.contains_key_with_hash(&k, hash_k));
+
+            // Re-insert K and fill with many keys.
+            insert(&cache, k, 2).await;
+            run(&cache).await;
+            for nk in 100u32..150 {
+                insert(&cache, nk, nk).await;
+                run(&cache).await;
+            }
+
+            let before = cache.entry_count();
+            for _ in 0..20 {
+                run(&cache).await;
+            }
+            let after = cache.entry_count();
+            eprintln!("[control final] before={before} after={after} MAX={MAX}");
+            assert!(
+                after <= MAX,
+                "control must converge but entry_count={after} > max_capacity={MAX}"
+            );
+        }
+
+        // -----------------------------------------------------------------
+        // DIAGNOSTIC: documents the deviation from doc 6a t3.  A held update
+        // makes K's node dirty, and capacity eviction (`evict_lru_entries`)
+        // skips dirty nodes, so it does NOT evict K.  This must PASS today.
+        // -----------------------------------------------------------------
+        #[tokio::test]
+        async fn future_lru_capacity_eviction_skips_dirty_node_diag() {
+            let cache = new_lru_cache().await;
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            insert(&cache, k, 1).await;
+            run(&cache).await;
+
+            // t2: update K, HOLD A2 -> node becomes dirty.
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100).await;
+            let (_adm, dirty_after_update, _eg) = probe(&a2);
+
+            // t3 (doc): push over capacity with 4 other keys, then run maintenance.
+            // The doc claims K is evicted here; observe that it is not.
+            for nk in 1u32..=4 {
+                insert(&cache, nk, nk).await;
+            }
+            run(&cache).await;
+
+            let still_present = cache.contains_key_with_hash(&k, hash_k);
+            let (adm_after, dirty_after, eg_after) = probe(&a2);
+            eprintln!(
+                "[cap-diag] dirty_after_update={dirty_after_update} K_present={still_present} \
+                 K_is_admitted={adm_after} dirty={dirty_after} entry_gen={eg_after} \
+                 entry_count={}",
+                cache.entry_count()
+            );
+
+            assert!(
+                dirty_after_update,
+                "a held update must leave the node dirty (entry_gen != policy_gen)"
+            );
+            assert!(
+                still_present,
+                "DEVIATION from doc 6a t3: capacity eviction skips the dirty node, so K survives"
+            );
+            assert!(
+                adm_after,
+                "K remains admitted because capacity eviction never removed it"
+            );
+        }
+
+        // -----------------------------------------------------------------
+        // TinyLFU (default policy) variant.  The zombie still forms: at t4 the
+        // stale A2 is replayed and, because the cache is under capacity right
+        // after the remove, handle_upsert takes the `has_enough_capacity`
+        // branch and calls handle_admit WITHOUT consulting the sketch -- so the
+        // zombie is policy-independent (no sketch warming needed).
+        //
+        // Under TinyLFU the symptom differs from LRU: not unbounded growth but a
+        // permanent phantom slot.  The entry counter counts the zombie, but the
+        // hash table never holds it, so `entry_count()` over-reports the number
+        // of live entries forever.  This test asserts the counter equals the
+        // actual number of reachable keys; at 7006d8c it FAILS (off by the
+        // zombie).
+        // -----------------------------------------------------------------
+        #[tokio::test]
+        async fn future_tinylfu_zombie_phantom_slot_repro() {
+            let cache = new_tinylfu_cache().await;
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            // t0/t1
+            insert(&cache, k, 1).await;
+            run(&cache).await;
+            assert!(cache.contains_key_with_hash(&k, hash_k));
+
+            // t2: update K, HOLD the stale A2.
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100).await;
+            let (_adm, dirty, _eg) = probe(&a2);
+            assert!(dirty, "held update marks the node dirty");
+
+            // t3: remove K -> de-admit EntryInfo_A while A2 waits.
+            queue_remove(&cache, k, hash_k);
+            run(&cache).await;
+            assert!(!cache.contains_key_with_hash(&k, hash_k));
+            let (adm, _d, _e) = probe(&a2);
+            assert!(!adm, "EntryInfo_A must be de-admitted");
+
+            // t4: replay stale A2 -> zombie node for the defunct EntryInfo_A.
+            cache.write_op_ch.send(a2).expect("send stale A2");
+            run(&cache).await;
+
+            // t5: re-insert K -> live EntryInfo_B, and add a few more keys.
+            insert(&cache, k, 2).await;
+            run(&cache).await;
+            for nk in 100u32..120 {
+                insert(&cache, nk, nk).await;
+                run(&cache).await;
+            }
+            for _ in 0..10 {
+                run(&cache).await;
+            }
+
+            // Count keys the hash table actually still holds.
+            let mut live = 0u64;
+            if cache.contains_key_with_hash(&k, hash_k) {
+                live += 1;
+            }
+            for nk in 100u32..120 {
+                if cache.contains_key_with_hash(&nk, cache.hash(&nk)) {
+                    live += 1;
+                }
+            }
+            let count = cache.entry_count();
+            eprintln!("[tinylfu] entry_count={count} actual_live_keys={live} MAX={MAX}");
+
+            assert_eq!(
+                count, live,
+                "TinyLFU zombie (issue #590): entry_count={count} over-reports the \
+                 {live} live keys -- a phantom slot is leaked permanently"
+            );
+        }
+    }
 }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -3458,7 +3458,9 @@ mod tests {
     }
 
     // =====================================================================
-    // Reproduction tests for issue #590 (sync mirror of the future tests).
+    // Reproduction tests for issue #590 (sync mirror of the future tests;
+    // see the race narrative in the `gh590` test module of
+    // `src/future/base_cache.rs`).
     // The issue was reported for `future::Cache`; these verify whether the
     // same structural race reproduces in `sync::Cache` (it does).
     // =====================================================================
@@ -3648,7 +3650,7 @@ mod tests {
             );
             assert!(
                 still_present,
-                "DEVIATION from doc 6a t3: capacity eviction skips the dirty node, K survives"
+                "capacity eviction skips the dirty node, K survives (t3 cannot happen this way)"
             );
             assert!(adm_after, "K remains admitted because it was never evicted");
         }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -3456,4 +3456,201 @@ mod tests {
 
         assert_expiry!(cache, key, hash, mock, 4);
     }
+
+    // =====================================================================
+    // Reproduction tests for issue #590 (sync mirror of the future tests).
+    // The issue was reported for `future::Cache`; these verify whether the
+    // same structural race reproduces in `sync::Cache` (it does).
+    // =====================================================================
+    mod gh590 {
+        use super::super::BaseCache;
+        use crate::common::concurrent::WriteOp;
+        use crate::{
+            common::{time::Clock, HousekeeperConfig},
+            policy::{EvictionPolicy, ExpirationPolicy},
+        };
+        use std::collections::hash_map::RandomState;
+        use std::sync::Arc;
+
+        const MAX: u64 = 4;
+
+        fn new_lru_cache() -> BaseCache<u32, u32> {
+            let mut cache = BaseCache::<u32, u32>::new(
+                None,
+                Some(MAX),
+                None,
+                RandomState::default(),
+                None,
+                EvictionPolicy::lru(),
+                None,
+                ExpirationPolicy::default(),
+                HousekeeperConfig::default(),
+                false,
+                Clock::default(),
+            );
+            cache.reconfigure_for_testing();
+            cache
+        }
+
+        fn insert(cache: &BaseCache<u32, u32>, k: u32, v: u32) {
+            let hash = cache.hash(&k);
+            let (op, _now) = cache.do_insert_with_hash(Arc::new(k), hash, v);
+            cache.write_op_ch.send(op).expect("send upsert");
+        }
+
+        fn run(cache: &BaseCache<u32, u32>) {
+            cache.inner.do_run_pending_tasks(None, 1, 10);
+        }
+
+        fn probe(op: &WriteOp<u32, u32>) -> (bool, bool, u16) {
+            match op {
+                WriteOp::Upsert { value_entry, .. } => {
+                    let ei = value_entry.entry_info();
+                    (ei.is_admitted(), ei.is_dirty(), ei.entry_gen())
+                }
+                _ => panic!("expected an Upsert WriteOp"),
+            }
+        }
+
+        fn queue_remove(cache: &BaseCache<u32, u32>, k: u32, hash: u64) {
+            let kv = cache.remove_entry(&k, hash).expect("remove_entry");
+            let entry_gen = kv.entry.entry_info().incr_entry_gen();
+            cache
+                .write_op_ch
+                .send(WriteOp::Remove {
+                    kv_entry: kv,
+                    entry_gen,
+                })
+                .expect("send remove");
+        }
+
+        // PRIMARY REPRO: at 7006d8c this test FAILS with the stall assertion.
+        #[test]
+        fn sync_lru_zombie_stall_repro() {
+            let cache = new_lru_cache();
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            insert(&cache, k, 1);
+            run(&cache);
+            assert!(cache.contains_key_with_hash(&k, hash_k));
+            assert_eq!(cache.entry_count(), 1);
+
+            // t2: update K, HOLD the stale WriteOp (A2).
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100);
+            let (adm, dirty, eg) = probe(&a2);
+            eprintln!("[t2] held A2: is_admitted={adm} is_dirty={dirty} entry_gen={eg}");
+
+            // t3: flip is_admitted -> false via an explicit remove while A2 waits.
+            queue_remove(&cache, k, hash_k);
+            run(&cache);
+            assert!(!cache.contains_key_with_hash(&k, hash_k));
+            let (adm, _dirty, _eg) = probe(&a2);
+            assert!(!adm, "EntryInfo_A must be de-admitted");
+
+            // t4: drain the STALE A2 -> zombie node for the defunct EntryInfo_A.
+            cache.write_op_ch.send(a2).expect("send stale A2");
+            run(&cache);
+            eprintln!(
+                "[t4] entry_count={} contains(K)={}",
+                cache.entry_count(),
+                cache.contains_key_with_hash(&k, hash_k)
+            );
+
+            // t5: re-insert K -> live node, so skip_updated_entry_ao can never
+            // reach the zombie.
+            insert(&cache, k, 2);
+            run(&cache);
+
+            for nk in 100u32..150 {
+                insert(&cache, nk, nk);
+                run(&cache);
+            }
+
+            let before = cache.entry_count();
+            for _ in 0..20 {
+                run(&cache);
+            }
+            let after = cache.entry_count();
+            eprintln!("[final] before={before} after={after} MAX={MAX}");
+
+            assert_eq!(before, after, "count must be stable across no-op drains");
+            assert!(
+                after <= MAX,
+                "STALL (issue #590, sync): entry_count={after} stays above max_capacity={MAX}"
+            );
+        }
+
+        // CONTROL: correct ordering, must PASS.
+        #[test]
+        fn sync_lru_zombie_stall_control() {
+            let cache = new_lru_cache();
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            insert(&cache, k, 1);
+            run(&cache);
+
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100);
+            cache.write_op_ch.send(a2).expect("send A2");
+            run(&cache);
+
+            queue_remove(&cache, k, hash_k);
+            run(&cache);
+            assert!(!cache.contains_key_with_hash(&k, hash_k));
+
+            insert(&cache, k, 2);
+            run(&cache);
+            for nk in 100u32..150 {
+                insert(&cache, nk, nk);
+                run(&cache);
+            }
+            let before = cache.entry_count();
+            for _ in 0..20 {
+                run(&cache);
+            }
+            let after = cache.entry_count();
+            eprintln!("[control final] before={before} after={after} MAX={MAX}");
+            assert!(
+                after <= MAX,
+                "control must converge but entry_count={after} > {MAX}"
+            );
+        }
+
+        // DIAGNOSTIC: capacity eviction skips the dirty node; must PASS.
+        #[test]
+        fn sync_lru_capacity_eviction_skips_dirty_node_diag() {
+            let cache = new_lru_cache();
+            let k: u32 = 0;
+            let hash_k = cache.hash(&k);
+
+            insert(&cache, k, 1);
+            run(&cache);
+
+            let (a2, _now) = cache.do_insert_with_hash(Arc::new(k), hash_k, 100);
+            let (_adm, dirty_after_update, _eg) = probe(&a2);
+
+            for nk in 1u32..=4 {
+                insert(&cache, nk, nk);
+            }
+            run(&cache);
+
+            let still_present = cache.contains_key_with_hash(&k, hash_k);
+            let (adm_after, _d, _e) = probe(&a2);
+            eprintln!(
+                "[cap-diag] dirty_after_update={dirty_after_update} K_present={still_present} \
+                 K_is_admitted={adm_after} entry_count={}",
+                cache.entry_count()
+            );
+            assert!(
+                dirty_after_update,
+                "a held update must leave the node dirty"
+            );
+            assert!(
+                still_present,
+                "DEVIATION from doc 6a t3: capacity eviction skips the dirty node, K survives"
+            );
+            assert!(adm_after, "K remains admitted because it was never evicted");
+        }
+    }
 }

--- a/src/sync/base_cache.rs
+++ b/src/sync/base_cache.rs
@@ -1763,15 +1763,28 @@ where
         timer_wheel: &mut TimerWheel<K>,
         counters: &mut EvictionCounters,
     ) {
-        // Precondition: admission only applies to Alive, not-yet-admitted
-        // entries. Violations indicate a caller failed to guard with
-        // `is_alive()` / `!is_admitted()`. Admitting a retired entry would
-        // produce an orphan deque node unreachable from the CHT, stalling
-        // eviction indefinitely (moka-rs/moka#590).
-        debug_assert!(
-            entry.entry_info().is_alive(),
-            "handle_admit called on non-Alive entry",
-        );
+        // The caller checked `is_alive()` before calling us, but a concurrent
+        // `remove`/`invalidate` on a user thread may have retired the entry in
+        // the meantime; retirement is lock-free and does not take the
+        // maintenance locks. Skip the admission in that case: admitting a
+        // retired entry would produce an orphan deque node unreachable from
+        // the CHT (moka-rs/moka#590). The thread that retired the entry has
+        // already recorded a `WriteOp::Remove`, and since this entry is not
+        // admitted, that op will not touch the deques, leaving no dangling
+        // policy state.
+        //
+        // Note this re-check is best-effort, not a guarantee: because we hold
+        // no lock, the entry can still be retired between this check and the
+        // `set_admitted(true)` below. That residual race is benign and
+        // self-healing: the same queued `WriteOp::Remove` will observe
+        // `is_admitted() == true`, unlink the node, and reverse the entry
+        // count/weight updates. A *permanent* orphan (the #590 zombie) cannot
+        // form here, because the only retirement paths that run outside the
+        // maintenance locks are user `remove`/`invalidate`, and both always
+        // enqueue that `WriteOp::Remove`.
+        if !entry.entry_info().is_alive() {
+            return;
+        }
         debug_assert!(
             !entry.is_admitted(),
             "handle_admit called on already-admitted entry",


### PR DESCRIPTION
This Pull Request (PR) follows up on #592 (issue #590) by doing the following:

1. Change the `debug_assert!` (added by #592) in `handle_admit` to a graceful skip to avoid a panic in debug builds.
2. Add some deterministic regression tests.

## 1. Change the `debug_assert!` in `handle_admit` to a graceful skip to avoid a panic in debug builds

The `debug_assert!` added in #592 asserted that `handle_admit` is never called on a retired (non-alive) entry, but that precondition is not enforceable: a concurrent `remove`/`invalidate` on a user thread can retire the entry lock-free between the caller's `is_alive()` check and the `handle_admit` call. 

The `sync::Cache` doctest hit this window on the first post-merge MSRV CI run and the assertion killed the housekeeping thread ([failed job](https://github.com/moka-rs/moka/actions/runs/29195312132/job/86657128977)).

```console
thread '<unnamed>' panicked at 'handle_admit called on non-Alive entry', /home/runner/work/moka/moka/src/sync/base_cache.rs:1771:9
```

<details>
    <summary>Full log</summary>

```console
---- src/sync/cache.rs - sync::cache::Cache (line 65) stdout ----
Test executable failed (exit status: 101).

stderr:
thread '<unnamed>' panicked at 'handle_admit called on non-Alive entry', /home/runner/work/moka/moka/src/sync/base_cache.rs:1771:9
stack backtrace:
   0:     0x5566407dbea1 - std::backtrace_rs::backtrace::libunwind::trace::h782cc21a5acaf6cb
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x5566407dbea1 - std::backtrace_rs::backtrace::trace_unsynchronized::hc579eb24ab204515
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x5566407dbea1 - std::sys_common::backtrace::_print_fmt::h7223525cfdbacda2
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x5566407dbea1 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hbd7d55b7108d2ab8
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x5566407f8d7f - core::fmt::rt::Argument::fmt::hb4f4a02b9bd9dd49
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/fmt/rt.rs:138:9
   5:     0x5566407f8d7f - core::fmt::write::h6d54cd7c9e155ec5
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/fmt/mod.rs:1094:21
   6:     0x5566407da0b1 - std::io::Write::write_fmt::h6a453a71c692f63b
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/io/mod.rs:1713:15
   7:     0x5566407dbcb5 - std::sys_common::backtrace::_print::h1cbaa8b42678f928
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:47:5
   8:     0x5566407dbcb5 - std::sys_common::backtrace::print::h4ddf81241a51b337
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:34:9
   9:     0x5566407dd157 - std::panicking::default_hook::{{closure}}::hff91f1f484ade5cd
  10:     0x5566407dcf44 - std::panicking::default_hook::h21f14afd59f7aef9
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:288:9
  11:     0x5566407dd60c - std::panicking::rust_panic_with_hook::h45f66047b14c555c
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:705:13
  12:     0x5566407dd4c1 - std::panicking::begin_panic_handler::{{closure}}::h49d1a88ef0908eb4
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:595:13
  13:     0x5566407dc2d6 - std::sys_common::backtrace::__rust_end_short_backtrace::hccebf9e57f8cc425
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:151:18
  14:     0x5566407dd252 - rust_begin_unwind
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:593:5
  15:     0x556640707fc3 - core::panicking::panic_fmt::h54ec9d0e3180a83d
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:67:14
  16:     0x55664074c240 - moka::sync::base_cache::Inner<K,V,S>::handle_admit::h56201d388683242d
  17:     0x55664074c94d - moka::sync::base_cache::Inner<K,V,S>::handle_upsert::hddf0441a49503f2c
  18:     0x55664074c139 - moka::sync::base_cache::Inner<K,V,S>::apply_writes::h328ad03741922156
  19:     0x556640750867 - moka::sync::base_cache::Inner<K,V,S>::do_run_pending_tasks::h09cb36aaf64a2970
  20:     0x55664070c306 - <moka::sync::base_cache::Inner<K,V,S> as moka::common::concurrent::housekeeper::InnerSync>::run_pending_tasks::h911aa34bc0fd7011
  21:     0x55664075bebf - moka::common::concurrent::housekeeper::Housekeeper::do_run_pending_tasks::h9ee8156030da656a
  22:     0x55664075bf67 - moka::common::concurrent::housekeeper::Housekeeper::try_run_pending_tasks::hb9d28617b4f0e2a3
  23:     0x5566407578cd - moka::sync::base_cache::BaseCache<K,V,S>::apply_reads_writes_if_needed::h2732d6f588dde285
  24:     0x55664075a85a - moka::sync::cache::Cache<K,V,S>::schedule_write_op::h6fee8adf9325d280
  25:     0x55664075b0ed - moka::sync::cache::Cache<K,V,S>::invalidate_with_hash::h945320fe105aa668
  26:     0x55664075a16b - moka::sync::cache::Cache<K,V,S>::invalidate::h2b1640761cdf7b04
  27:     0x55664077e39b - rust_out::main::_doctest_main_src_sync_cache_rs_65_0::{{closure}}::{{closure}}::h288b0cf61903a772
  28:     0x5566407205e6 - std::sys_common::backtrace::__rust_begin_short_backtrace::h7850e8f17b844fb7
  29:     0x556640721f9c - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::hfb6c6b0a481d3114
  30:     0x55664070c2c0 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h051ddabb24bce06b
  31:     0x55664072212c - std::panicking::try::do_call::h185ab1725f288704
  32:     0x55664077e40b - __rust_try
  33:     0x5566407220c5 - std::panicking::try::h792c1d429ca4e4b7
  34:     0x556640721dfd - std::thread::Builder::spawn_unchecked_::{{closure}}::h3254a2ff07b24b65
  35:     0x5566407243d6 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h5e4757d4947981ad
  36:     0x5566407dfa65 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::he3e5dbdfabe0b668
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1985:9
  37:     0x5566407dfa65 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h246f7c7964633611
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1985:9
  38:     0x5566407dfa65 - std::sys::unix::thread::Thread::new::thread_start::hadf9e3501ff0df23
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/thread.rs:108:17
  39:     0x7f089b69caa4 - <unknown>
  40:     0x7f089b729c6c - <unknown>
  41:                0x0 - <unknown>
thread 'main' panicked at 'Failed: Any { .. }', src/sync/cache.rs:45:43
stack backtrace:
   0:     0x5566407dbea1 - std::backtrace_rs::backtrace::libunwind::trace::h782cc21a5acaf6cb
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x5566407dbea1 - std::backtrace_rs::backtrace::trace_unsynchronized::hc579eb24ab204515
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x5566407dbea1 - std::sys_common::backtrace::_print_fmt::h7223525cfdbacda2
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x5566407dbea1 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hbd7d55b7108d2ab8
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x5566407f8d7f - core::fmt::rt::Argument::fmt::hb4f4a02b9bd9dd49
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/fmt/rt.rs:138:9
   5:     0x5566407f8d7f - core::fmt::write::h6d54cd7c9e155ec5
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/fmt/mod.rs:1094:21
   6:     0x5566407da0b1 - std::io::Write::write_fmt::h6a453a71c692f63b
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/io/mod.rs:1713:15
   7:     0x5566407dbcb5 - std::sys_common::backtrace::_print::h1cbaa8b42678f928
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:47:5
   8:     0x5566407dbcb5 - std::sys_common::backtrace::print::h4ddf81241a51b337
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:34:9
   9:     0x5566407dd157 - std::panicking::default_hook::{{closure}}::hff91f1f484ade5cd
  10:     0x5566407dcf44 - std::panicking::default_hook::h21f14afd59f7aef9
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:288:9
  11:     0x5566407dd60c - std::panicking::rust_panic_with_hook::h45f66047b14c555c
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:705:13
  12:     0x5566407dd507 - std::panicking::begin_panic_handler::{{closure}}::h49d1a88ef0908eb4
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:597:13
  13:     0x5566407dc2d6 - std::sys_common::backtrace::__rust_end_short_backtrace::hccebf9e57f8cc425
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys_common/backtrace.rs:151:18
  14:     0x5566407dd252 - rust_begin_unwind
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:593:5
  15:     0x556640707fc3 - core::panicking::panic_fmt::h54ec9d0e3180a83d
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:67:14
  16:     0x556640708493 - core::result::unwrap_failed::h1cd730365d65235f
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/result.rs:1651:5
  17:     0x5566407337c2 - core::result::Result<T,E>::expect::hedbd4b19aeb2439f
  18:     0x55664077e3e0 - rust_out::main::_doctest_main_src_sync_cache_rs_65_0::{{closure}}::h6023c63c49dd36c9
  19:     0x55664072b1b5 - core::iter::traits::iterator::Iterator::for_each::call::{{closure}}::hdba06ec01c3db3ca
  20:     0x55664072a38b - core::iter::traits::iterator::Iterator::fold::h1810446f06b8ad08
  21:     0x55664072af9c - core::iter::traits::iterator::Iterator::for_each::haedec16e77e83b39
  22:     0x55664077da57 - rust_out::main::_doctest_main_src_sync_cache_rs_65_0::hd4c8bcf5a9da3c2a
  23:     0x55664077d966 - rust_out::main::h9d98ab4a1af73092
  24:     0x556640724533 - core::ops::function::FnOnce::call_once::hc3bad73dc4da76eb
  25:     0x5566407205f6 - std::sys_common::backtrace::__rust_begin_short_backtrace::habfe68203686c77c
  26:     0x556640720679 - std::rt::lang_start::{{closure}}::h17c790a605fc6e1e
  27:     0x5566407d7725 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h802b0fdd426a12ca
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:284:13
  28:     0x5566407d7725 - std::panicking::try::do_call::h2a2f25050efa0cf8
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  29:     0x5566407d7725 - std::panicking::try::h9ca7f841c0f0e3dd
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  30:     0x5566407d7725 - std::panic::catch_unwind::h92d42a62587f8121
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  31:     0x5566407d7725 - std::rt::lang_start_internal::{{closure}}::hf1926c7a173d562c
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/rt.rs:148:48
  32:     0x5566407d7725 - std::panicking::try::do_call::haac70d88f0cce898
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:500:40
  33:     0x5566407d7725 - std::panicking::try::h5c20719e1031e74b
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:464:19
  34:     0x5566407d7725 - std::panic::catch_unwind::h9b15b36860d5fe4a
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panic.rs:142:14
  35:     0x5566407d7725 - std::rt::lang_start_internal::hf502095b101390bb
                               at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/rt.rs:148:20
  36:     0x556640720657 - std::rt::lang_start::h37b20cb649569472
  37:     0x55664077e445 - main
  38:     0x7f089b62a1ca - <unknown>
  39:     0x7f089b62a28b - __libc_start_main
  40:     0x556640708795 - _start
  41:                0x0 - <unknown>

failures:
    src/sync/cache.rs - sync::cache::Cache (line 65)
```

</details>

- In debug builds the assertion panics and kills the housekeeping thread.
- In release builds the assert compiles away and the retired entry is silently admitted.
  - If its `WriteOp::Remove` is still queued, the phantom slot lingers until that op is drained.
  - If the `WriteOp::Remove` has already been drained — the interleaving the repro tests force — the phantom slot is permanent (the #590 zombie).

The assertion is replaced with a graceful skip, mirroring how the TinyLFU victim scan already treats non-alive entries. The re-check is best-effort (no lock is held, so the entry can still be retired between the re-check and `set_admitted(true)`), but both outcomes are self-healing:

(Analysis by Claude Fable 5 (an LLM) — reviewed and verified by me.)

> - The retiring thread has already recorded a `WriteOp::Remove`, which either finds the entry not admitted and leaves the deques alone, or finds it admitted and unlinks the node, reversing the entry-count/weight updates.
> - A permanent orphan cannot form because every lock-free retirement path enqueues that `WriteOp::Remove`. The reasoning is documented in a code comment at the skip site.
> - In particular, the #590 zombie cannot recur: it required admitting an entry whose `WriteOp::Remove` had already been drained, but a drained `WriteOp::Remove` means the retirement completed before `handle_admit` ran, so the `is_alive()` re-check is guaranteed to observe it and skip. The residual race can only admit an entry whose `WriteOp::Remove` is still queued — the self-healing case above.

## 2. Deterministic regression tests

Used an LLM (Claude) to generate the white-box tests in the `base_cache.rs` test modules that force the exact interleaving behind the eviction stall — no threads, sleeps, or stress: the tests hold the `WriteOp` returned by `do_insert_with_hash`, de-admit the entry via the `WriteOp::Remove` path, and then replay the stale op.

Here are the descriptions of the tests (generated by Claude; the repro tests themselves were verified to fail on the pre-#592 code):

> - `future_lru_zombie_stall_repro` / `sync_lru_zombie_stall_repro` — fail on the pre-#592 code with the cache stuck above `max_capacity` forever; pass with the fix.
> - `future_tinylfu_zombie_phantom_slot_repro` — pins the TinyLFU variant of the bug: a permanently leaked phantom slot that makes `entry_count` / `weighted_size` over-report.
> - Control tests (stale op drained in the normal order → cache converges) prove the harness is sound, and diagnostic tests document why the naive single-threaded schedule cannot trigger the bug (the `is_dirty` gate in `evict_lru_entries`), which is why the in-the-wild trigger is a `is_dirty` TOCTOU under concurrency.

All 7 tests pass on current `main` with this branch applied; the three repro tests were verified to fail on the pre-#592 code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare race condition that could stall LRU eviction and let the cache exceed its configured capacity.
  * Prevented stale entries from causing TinyLFU accounting leaks.
  * Improved cache behavior during concurrent updates and removals.

* **Documentation**
  * Added Version 0.12.16 release notes and completed related documentation reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->