### PR TITLE
Works around the ThreadSanitizer false positive reported in #600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,12 @@
 
 ### Changed
 
-- Replaced the standalone `fence(Acquire)` in the internal `MiniArc`'s drop path
-  with an `Acquire` load of the reference count, following the same approach as
-  `std::sync::Arc` under ThreadSanitizer and `triomphe::Arc`. The two forms are
-  semantically equivalent, but ThreadSanitizer does not model standalone fences
-  and reported a false-positive data race on every final drop of a shared
-  `MiniArc`. Downstream projects can now run ThreadSanitizer on code using Moka
-  without hitting this false positive. (Reported in [#600][gh-issue-0600])
+- Worked around a ThreadSanitizer false positive ([#602][gh-pull-0602]):
+    - Replaced the standalone `fence(Acquire)` in the internal `MiniArc`'s drop
+      path with an `Acquire` load of the reference count, so that downstream
+      projects can now run ThreadSanitizer on code using Moka without hitting
+      this false positive.
+    - `std::sync::Arc` has a similar workaround.
 
 ## Version 0.12.15
 
@@ -1156,7 +1155,6 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-xuehaonan27]: https://github.com/xuehaonan27
 [gh-zonyitoo]: https://github.com/zonyitoo
 
-[gh-issue-0600]: https://github.com/moka-rs/moka/issues/600/
 [gh-issue-0590]: https://github.com/moka-rs/moka/issues/590/
 [gh-issue-0580]: https://github.com/moka-rs/moka/issues/580/
 [gh-issue-0575]: https://github.com/moka-rs/moka/issues/575/
@@ -1187,6 +1185,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0602]: https://github.com/moka-rs/moka/pull/602/
 [gh-pull-0592]: https://github.com/moka-rs/moka/pull/592/
 [gh-pull-0586]: https://github.com/moka-rs/moka/pull/586/
 [gh-pull-0584]: https://github.com/moka-rs/moka/pull/584/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
       usable capacity to shrink by one entry per occurrence. Fixed by the same
       change.
 
+### Changed
+
+- Replaced the standalone `fence(Acquire)` in the internal `MiniArc`'s drop path
+  with an `Acquire` load of the reference count, following the same approach as
+  `std::sync::Arc` under ThreadSanitizer and `triomphe::Arc`. The two forms are
+  semantically equivalent, but ThreadSanitizer does not model standalone fences
+  and reported a false-positive data race on every final drop of a shared
+  `MiniArc`. Downstream projects can now run ThreadSanitizer on code using Moka
+  without hitting this false positive. (Reported in [#600][gh-issue-0600])
+
 ## Version 0.12.15
 
 ### Fixed
@@ -1146,6 +1156,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-xuehaonan27]: https://github.com/xuehaonan27
 [gh-zonyitoo]: https://github.com/zonyitoo
 
+[gh-issue-0600]: https://github.com/moka-rs/moka/issues/600/
 [gh-issue-0590]: https://github.com/moka-rs/moka/issues/590/
 [gh-issue-0580]: https://github.com/moka-rs/moka/issues/580/
 [gh-issue-0575]: https://github.com/moka-rs/moka/issues/575/

--- a/src/common/concurrent/arc.rs
+++ b/src/common/concurrent/arc.rs
@@ -141,7 +141,15 @@ impl<T: ?Sized> Drop for MiniArc<T> {
         use std::sync::atomic::Ordering::{Acquire, Release};
 
         if self.data().ref_count.fetch_sub(1, Release) == 1 {
-            atomic::fence(Acquire);
+            // A standalone `atomic::fence(Acquire)` would also be correct here,
+            // but ThreadSanitizer does not model standalone fences and would
+            // report the deallocation below as a data race against other
+            // threads' `fetch_sub` calls (a false positive; see issue #600).
+            // Use an `Acquire` load of the reference count instead, like
+            // `std::sync::Arc` does when compiled with
+            // `cfg(sanitize = "thread")` and like `triomphe::Arc` does
+            // unconditionally.
+            self.data().ref_count.load(Acquire);
             unsafe {
                 drop(Box::from_raw(self.ptr.as_ptr()));
             }
@@ -325,6 +333,40 @@ mod loom_tests {
 
             // Now that `y` is dropped too,
             // the object should have been dropped.
+            assert_eq!(num_drops.load(Relaxed), 1);
+        });
+    }
+
+    /// Two threads drop their clones concurrently, so either of them can
+    /// perform the final decrement of the reference count. Verifies that the
+    /// object is dropped exactly once no matter which thread wins the race.
+    /// (The `test_drop` test above joins the other thread before the final
+    /// drop, so it does not exercise a racing final decrement.)
+    #[test]
+    fn test_concurrent_drop() {
+        use loom::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+        struct DetectDrop(loom::sync::Arc<AtomicUsize>);
+
+        impl Drop for DetectDrop {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Relaxed);
+            }
+        }
+
+        loom::model(move || {
+            let num_drops = loom::sync::Arc::new(AtomicUsize::new(0));
+
+            let x = MiniArc::new(DetectDrop(loom::sync::Arc::clone(&num_drops)));
+            let y = x.clone();
+
+            let t1 = loom::thread::spawn(move || drop(x));
+            let t2 = loom::thread::spawn(move || drop(y));
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            // The object should have been dropped exactly once.
             assert_eq!(num_drops.load(Relaxed), 1);
         });
     }


### PR DESCRIPTION
## What

Replaces the standalone `atomic::fence(Acquire)` in `MiniArc::drop` with an `Acquire` load of the reference count. The two forms are semantically equivalent under the C++/Rust memory model; this is the same approach `std::sync::Arc` takes when compiled with `cfg(sanitize = "thread")` ([source](https://github.com/rust-lang/rust/blob/1.97.1/library/alloc/src/sync.rs#L61-L76)) and `triomphe::Arc` takes unconditionally. (`cfg(sanitize = "thread")` itself is unstable, and Moka's MSRV is 1.71.1, so the load form is used unconditionally.)

Also adds a loom model test (`test_concurrent_drop`) where two threads drop their clones concurrently, so either thread can perform the final decrement. The existing `test_drop` joins the other thread before the final drop, so it did not exercise a racing final decrement.

## Why

LLVM ThreadSanitizer does not model standalone memory fences. With the fence form, every final drop of a shared `MiniArc` is reported as a data race between the winning thread's deallocation and the other threads' `fetch_sub` calls — the exact signature reported in #600. With this change, downstream projects can run TSan on code using Moka without hitting the false positive.

See #600 for the full investigation, including why the report is a false positive and why the 0.12.8 → 0.12.9 bisect result is explained by the `triomphe::Arc` → `MiniArc` fence/load difference rather than a real regression.

## Verification

- [x] `RUSTFLAGS='--cfg moka_loom' cargo test --release --lib --features 'future, sync' common::concurrent::arc::loom_tests` — 2 passed (including the new `test_concurrent_drop`; loom models fences precisely, so it verifies the drop synchronization for both the old and new form)
- [x] `cargo test -F sync --lib common::concurrent::arc` — 3 passed
- [x] The [#600](https://github.com/moka-rs/moka/issues/600) repro (16 tasks × 20k iterations, constant eviction, invalidation on) built against this branch with `-Zsanitizer=thread`: **zero warnings, clean completion**.
  - The same repro against the unmodified code reports the `#600` race within seconds.
  - (During the `#600` investigation, the equivalent one-line change was also verified on x86_64 with heavier loads — 32 tasks × 100k iterations — with zero warnings.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent cleanup behavior to prevent false-positive data-race reports from ThreadSanitizer.
  * Ensured objects are deallocated exactly once when final references are released concurrently.
  * Added coverage for concurrent final-reference cleanup scenarios.

* **Documentation**
  * Added a changelog entry describing the concurrency fix and related issue reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->