### PR TITLE
Raises the minimum version of `crossbeam-epoch` from 0.9.18 to 0.9.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@
       projects can now run ThreadSanitizer on code using Moka without hitting
       this false positive.
     - `std::sync::Arc` has a similar workaround.
+- Raised the minimum version of the `crossbeam-epoch` crate from `v0.9.18` to
+  `v0.9.20` to avoid the following advisory ([#603][gh-pull-0603]):
+    - [RUSTSEC-2026-0204] crossbeam-epoch: invalid pointer dereference in
+      `fmt::Pointer` for `Atomic` and `Shared`
+    - Moka is _not_ affected by this advisory because it never formats these
+      pointer types. However, raising the minimum version prevents downstream
+      lockfiles from resolving to an affected `crossbeam-epoch` version via
+      Moka.
 
 ## Version 0.12.15
 
@@ -1113,6 +1121,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [ghsa-qc84-gqf4-9926]: https://github.com/advisories/GHSA-qc84-gqf4-9926
 [gh-rust-issue-62958]: https://github.com/rust-lang/rust/issues/62958
 
+[RUSTSEC-2026-0204]: https://rustsec.org/advisories/RUSTSEC-2026-0204.html
 [RUSTSEC-2025-0052]: https://rustsec.org/advisories/RUSTSEC-2025-0052.html
 [RUSTSEC-2025-0024]: https://rustsec.org/advisories/RUSTSEC-2025-0024.html
 [RUSTSEC-2024-0436]: https://rustsec.org/advisories/RUSTSEC-2024-0436.html
@@ -1185,6 +1194,7 @@ The minimum supported Rust version (MSRV) is now 1.51.0 (Mar 25, 2021).
 [gh-issue-0034]: https://github.com/moka-rs/moka/issues/34/
 [gh-issue-0031]: https://github.com/moka-rs/moka/issues/31/
 
+[gh-pull-0603]: https://github.com/moka-rs/moka/pull/603/
 [gh-pull-0602]: https://github.com/moka-rs/moka/pull/602/
 [gh-pull-0592]: https://github.com/moka-rs/moka/pull/592/
 [gh-pull-0586]: https://github.com/moka-rs/moka/pull/586/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ unstable-debug-counters = ["future"]
 
 [dependencies]
 crossbeam-channel = "0.5.15"
-crossbeam-epoch = "0.9.18"
+crossbeam-epoch = "0.9.20"
 crossbeam-utils = "0.8.21"
 equivalent = "1.0"
 parking_lot = "0.12"


### PR DESCRIPTION
## Why

`crossbeam-epoch` 0.9.0 through 0.9.19 are affected by [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204.html): the `fmt::Pointer` implementations for `Atomic` and `Shared` dereference the underlying pointer without a null check (fixed upstream in [crossbeam#1276](https://github.com/crossbeam-rs/crossbeam/pull/1276), released in 0.9.20).

Moka itself is **not** affected — it never formats these pointer types — but with the current `0.9.18` floor, downstream lockfiles can resolve to an affected version through Moka, and `cargo audit` / `cargo deny` will flag it. Raising the floor removes that possibility.

No MSRV impact: `crossbeam-epoch` 0.9.20 requires Rust 1.61, below Moka's MSRV of 1.71.1.

## Verification

- `cargo build -F sync,future` — resolves to `crossbeam-epoch v0.9.20`, builds clean
- `cargo update -p crossbeam-epoch --precise 0.9.19` — now rejected by the resolver (the floor is effective)
- `cargo test -F sync --lib cht::` — 23 passed (the `cht` module is the main `crossbeam-epoch` user)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled `crossbeam-epoch` component to address a reported security advisory.

* **Documentation**
  * Added changelog details and references for the security-related update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->